### PR TITLE
chore/maintenance

### DIFF
--- a/src/main/java/io/ten1010/coaster/groupcontroller/controller/pod/PodReconciler.java
+++ b/src/main/java/io/ten1010/coaster/groupcontroller/controller/pod/PodReconciler.java
@@ -41,6 +41,12 @@ public class PodReconciler implements Reconciler {
         this.eventRecorder = eventRecorder;
     }
 
+    /**
+     * Reconcile given pod based on {@link Request} to ensure that pods are running with correct tolerations based on Resource Group which pods belong.
+     * If reconciled tolerations of pods differ from Resource Group tolerations, then delete the pod through {@link CoreV1Api}.
+     * @param request the reconcile request, triggered by watch events
+     * @return
+     */
     @Override
     public Result reconcile(Request request) {
         return this.template.execute(() -> {

--- a/src/main/java/io/ten1010/coaster/groupcontroller/model/V1ResourceGroup.java
+++ b/src/main/java/io/ten1010/coaster/groupcontroller/model/V1ResourceGroup.java
@@ -98,13 +98,22 @@ public class V1ResourceGroup implements KubernetesObject {
 
     @Override
     public String toString() {
-        return "V1ResourceGroup{" +
-                "apiVersion='" + this.apiVersion + '\'' +
-                ", kind='" + this.kind + '\'' +
-                ", metadata=" + this.metadata +
-                ", spec=" + this.spec +
-                ", status=" + this.status +
-                '}';
+        StringBuilder sb = new StringBuilder();
+        sb.append("class V1ResourceGroup {\n");
+        sb.append("    apiVersion: '").append(toIndentedString(this.apiVersion)).append("\'\n");
+        sb.append("    kind: '").append(toIndentedString(this.kind)).append("\'\n");
+        sb.append("    metadata: ").append(toIndentedString(this.metadata)).append("\n");
+        sb.append("    spec: ").append(toIndentedString(this.spec)).append("\n");
+        sb.append("    status: ").append(toIndentedString(this.status)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private String toIndentedString(java.lang.Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
     }
 
 }

--- a/src/main/java/io/ten1010/coaster/groupcontroller/model/V1ResourceGroupList.java
+++ b/src/main/java/io/ten1010/coaster/groupcontroller/model/V1ResourceGroupList.java
@@ -80,12 +80,21 @@ public class V1ResourceGroupList implements KubernetesListObject {
 
     @Override
     public String toString() {
-        return "V1ResourceGroupList{" +
-                "apiVersion='" + this.apiVersion + '\'' +
-                ", kind='" + this.kind + '\'' +
-                ", metadata=" + this.metadata +
-                ", items=" + this.items +
-                '}';
+        StringBuilder sb = new StringBuilder();
+        sb.append("class V1ResourceGroupList {\n");
+        sb.append("    apiVersion: ").append(toIndentedString(this.apiVersion)).append("\'\n");
+        sb.append("    kind: ").append(toIndentedString(this.kind)).append("\'\n");
+        sb.append("    metadata: ").append(toIndentedString(this.metadata)).append("\n");
+        sb.append("    items: ").append(toIndentedString(this.items)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private String toIndentedString(java.lang.Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
     }
 
 }

--- a/src/main/java/io/ten1010/coaster/groupcontroller/model/V1ResourceGroupSpec.java
+++ b/src/main/java/io/ten1010/coaster/groupcontroller/model/V1ResourceGroupSpec.java
@@ -74,12 +74,22 @@ public class V1ResourceGroupSpec {
 
     @Override
     public String toString() {
-        return "V1ResourceGroupSpec{" +
-                "nodes=" + this.nodes +
-                ", namespaces=" + this.namespaces +
-                ", exceptions=" + this.exceptions +
-                ", subjects=" + this.subjects +
-                '}';
+        StringBuilder sb = new StringBuilder();
+        sb.append("class V1ResourceGroupSpec {\n");
+        sb.append("    nodes: " + this.nodes + "\n");
+        sb.append("    nodes: ").append(toIndentedString(this.nodes)).append("\n");
+        sb.append("    namespaces: ").append(toIndentedString(this.namespaces)).append("\n");
+        sb.append("    exceptions: ").append(toIndentedString(this.exceptions)).append("\n");
+        sb.append("    subjects: ").append(toIndentedString(this.subjects)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private String toIndentedString(java.lang.Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
     }
 
 }

--- a/src/test/java/io/ten1010/coaster/groupcontroller/controller/pod/PodReconcilerTest.java
+++ b/src/test/java/io/ten1010/coaster/groupcontroller/controller/pod/PodReconcilerTest.java
@@ -51,7 +51,7 @@ class PodReconcilerTest {
         podMeta1.setName("pod1");
         pod1.setMetadata(podMeta1);
         V1PodSpec podSpec1 = new V1PodSpec();
-        podSpec1.setTolerations(new ArrayList<>());
+        podSpec1.setTolerations(new ArrayList<>()); // empty tolerations
         pod1.setSpec(podSpec1);
 
         try {
@@ -78,5 +78,30 @@ class PodReconcilerTest {
         Mockito.verifyNoMoreInteractions(this.coreV1Api);
     }
 
+    @Test
+    void pod_replace() {
+
+
+
+        try {
+            Mockito.verify(this.coreV1Api).replaceNamespacedPod(
+                    Mockito.eq("pod1"),
+                    Mockito.eq("ns1"),
+                    Mockito.argThat(pod -> {
+                        String podName = pod.getMetadata().getName();
+                        if(!podName.equals("pod1")) {
+                            return false;
+                        }
+                        return true;
+                    }),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null)
+            );
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
 }
 


### PR DESCRIPTION
## Motivation
- NodeReconciler 클래스의 각 메소드에 해당하는 comment를 작성하였습니다.
- NodeReconcilerTest에서 label과 taint가 동일한 경우, api interaction이 없어야 함을 검증하는 테스트코드를 작성하였습니다.
- Custom Resource(ResourceGroup) 클래스의 toString에 대해 Kubernetes에서 사용한 출력 컨벤션을 적용하여 동일하게 작성하였습니다.