### PR TITLE
chore : write RoleReconciler test codes

### DIFF
--- a/src/test/java/io/ten1010/coaster/groupcontroller/controller/role/RoleReconcilerTest.java
+++ b/src/test/java/io/ten1010/coaster/groupcontroller/controller/role/RoleReconcilerTest.java
@@ -4,9 +4,7 @@ import io.kubernetes.client.extended.controller.reconciler.Request;
 import io.kubernetes.client.informer.cache.Indexer;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.RbacAuthorizationV1Api;
-import io.kubernetes.client.openapi.models.V1Namespace;
-import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import io.kubernetes.client.openapi.models.V1Role;
+import io.kubernetes.client.openapi.models.*;
 import io.ten1010.coaster.groupcontroller.core.KeyUtil;
 import io.ten1010.coaster.groupcontroller.model.V1ResourceGroup;
 import io.ten1010.coaster.groupcontroller.model.V1ResourceGroupSpec;
@@ -74,4 +72,183 @@ class RoleReconcilerTest {
         Mockito.verifyNoMoreInteractions(this.rbacAuthorizationV1Api);
     }
 
+    @Test
+    void given_role_has_empty_rules_then_should_update_the_role() {
+        V1ResourceGroup group1 = new V1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        meta1.setUid("group1-uid");
+        group1.setMetadata(meta1);
+        V1ResourceGroupSpec spec1 = new V1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+        V1Namespace ns1 = new V1Namespace();
+        V1ObjectMeta nsMeta1 = new V1ObjectMeta();
+        nsMeta1.setName("ns1");
+        ns1.setMetadata(nsMeta1);
+        List<V1PolicyRule> rule1 = List.of(new V1PolicyRuleBuilder().withApiGroups()
+                .withResources()
+                .withVerbs()
+                .build());
+        V1RoleBuilder builder = new V1RoleBuilder();
+        V1Role role1 = builder.withNewMetadata()
+                .withNamespace("ns1")
+                .withName("resource-group-controller.ten1010.io:group1")
+                .withOwnerReferences()
+                .endMetadata()
+                .withRules(rule1)
+                .build();
+
+        Mockito.doReturn(group1).when(this.groupIndexer).getByKey("group1");
+        Mockito.doReturn(ns1).when(this.namespaceIndexer).getByKey("ns1");
+        Mockito.doReturn(role1).when(this.roleIndexer).getByKey(KeyUtil.buildKey("ns1", "resource-group-controller.ten1010.io:group1"));
+
+        RoleReconciler roleReconciler = new RoleReconciler(this.namespaceIndexer, this.groupIndexer, this.roleNameUtil, this.roleIndexer, this.rbacAuthorizationV1Api);
+        roleReconciler.reconcile(new Request("ns1", "resource-group-controller.ten1010.io:group1"));
+        try {
+            Mockito.verify(this.rbacAuthorizationV1Api).replaceNamespacedRole(
+                    Mockito.eq("resource-group-controller.ten1010.io:group1"),
+                    Mockito.eq("ns1"),
+                    Mockito.argThat(role -> {
+                        if (!role.getMetadata().getNamespace().equals("ns1")) {
+                            return false;
+                        }
+                        V1PolicyRule coreApiRule = new V1PolicyRuleBuilder().withApiGroups("")
+                                .withResources("pods", "services", "configmaps", "secrets", "persistentvolumeclaims", "serviceaccounts", "limitranges", "events")
+                                .withVerbs("*")
+                                .build();
+                        V1PolicyRule eventApiRule = new V1PolicyRuleBuilder().withApiGroups("events.k8s.io")
+                                .withResources("events")
+                                .withVerbs("*")
+                                .build();
+                        V1PolicyRule batchApiRule = new V1PolicyRuleBuilder().withApiGroups("batch")
+                                .withResources("jobs", "cronjobs")
+                                .withVerbs("*")
+                                .build();
+                        V1PolicyRule appsApiRule = new V1PolicyRuleBuilder().withApiGroups("apps")
+                                .withResources("deployments", "statefulsets")
+                                .withVerbs("*")
+                                .build();
+                        V1PolicyRule autoscalingApiRule = new V1PolicyRuleBuilder().withApiGroups("autoscaling")
+                                .withResources("horizontalpodautoscalers")
+                                .withVerbs("*")
+                                .build();
+                        V1PolicyRule poddisrubptionbudgetApiRule = new V1PolicyRuleBuilder().withApiGroups("policy")
+                                .withResources("poddisruptionbudgets")
+                                .withVerbs("*")
+                                .build();
+                        List<V1PolicyRule> rules = List.of(coreApiRule, eventApiRule, batchApiRule, appsApiRule, autoscalingApiRule, poddisrubptionbudgetApiRule);
+                        if (!role.getRules().equals(rules)) {
+                            return false;
+                        }
+                        return role.getMetadata().getName().equals("resource-group-controller.ten1010.io:group1");
+                    }),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null)
+            );
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+        Mockito.verifyNoMoreInteractions(this.rbacAuthorizationV1Api);
+    }
+
+    @Test
+    void given_role_has_group_which_not_exists_then_delete_the_role() {
+        V1Namespace ns1 = new V1Namespace();
+        V1ObjectMeta nsMeta1 = new V1ObjectMeta();
+        nsMeta1.setName("ns1");
+        ns1.setMetadata(nsMeta1);
+
+        List<V1PolicyRule> rule1 = List.of(new V1PolicyRuleBuilder().withApiGroups()
+                .withResources()
+                .withVerbs()
+                .build());
+        V1RoleBuilder builder = new V1RoleBuilder();
+        V1Role role1 = builder.withNewMetadata()
+                .withNamespace("ns1")
+                .withName("resource-group-controller.ten1010.io:group1")
+                .withOwnerReferences()
+                .endMetadata()
+                .withRules(rule1)
+                .build();
+
+        Mockito.doReturn(null).when(this.groupIndexer).getByKey("group1");
+        Mockito.doReturn(ns1).when(this.namespaceIndexer).getByKey("ns1");
+        Mockito.doReturn(role1).when(this.roleIndexer).getByKey(KeyUtil.buildKey("ns1", "resource-group-controller.ten1010.io:group1"));
+        RoleReconciler roleReconciler = new RoleReconciler(this.namespaceIndexer, this.groupIndexer, this.roleNameUtil, this.roleIndexer, this.rbacAuthorizationV1Api);
+        roleReconciler.reconcile(new Request("ns1", "resource-group-controller.ten1010.io:group1"));
+        try {
+            Mockito.verify(this.rbacAuthorizationV1Api).deleteNamespacedRole(
+                    Mockito.eq("resource-group-controller.ten1010.io:group1"), // name
+                    Mockito.eq("ns1"), // namespace
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null) // body
+            );
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+        Mockito.verifyNoMoreInteractions(this.rbacAuthorizationV1Api);
+    }
+
+    @Test
+    void given_role_has_namespace_which_group_does_not_have_then_delete_the_role() {
+        V1ResourceGroup group1 = new V1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        meta1.setUid("group1-uid");
+        group1.setMetadata(meta1);
+        V1ResourceGroupSpec spec1 = new V1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1Namespace ns1 = new V1Namespace();
+        V1ObjectMeta nsMeta1 = new V1ObjectMeta();
+        nsMeta1.setName("ns1");
+        ns1.setMetadata(nsMeta1);
+        V1Namespace ns2 = new V1Namespace();
+        V1ObjectMeta nsMeta2 = new V1ObjectMeta();
+        nsMeta1.setName("ns2");
+        ns1.setMetadata(nsMeta2);
+
+        List<V1PolicyRule> rule1 = List.of(new V1PolicyRuleBuilder().withApiGroups()
+                .withResources()
+                .withVerbs()
+                .build());
+        V1RoleBuilder builder = new V1RoleBuilder();
+        V1Role role1 = builder.withNewMetadata()
+                .withNamespace("ns2")
+                .withName("resource-group-controller.ten1010.io:group1")
+                .withOwnerReferences()
+                .endMetadata()
+                .withRules(rule1)
+                .build();
+
+        Mockito.doReturn(group1).when(this.groupIndexer).getByKey("group1");
+        Mockito.doReturn(ns1).when(this.namespaceIndexer).getByKey("ns1");
+        Mockito.doReturn(ns2).when(this.namespaceIndexer).getByKey("ns2");
+        Mockito.doReturn(role1).when(this.roleIndexer).getByKey(KeyUtil.buildKey("ns2", "resource-group-controller.ten1010.io:group1"));
+        RoleReconciler roleReconciler = new RoleReconciler(this.namespaceIndexer, this.groupIndexer, this.roleNameUtil, this.roleIndexer, this.rbacAuthorizationV1Api);
+        roleReconciler.reconcile(new Request("ns2", "resource-group-controller.ten1010.io:group1"));
+        try {
+            Mockito.verify(this.rbacAuthorizationV1Api).deleteNamespacedRole(
+                    Mockito.eq("resource-group-controller.ten1010.io:group1"), // name
+                    Mockito.eq("ns2"),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null)
+            );
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+        Mockito.verifyNoMoreInteractions(this.rbacAuthorizationV1Api);
+    }
 }


### PR DESCRIPTION
## Motivation
RoleReconciler의 reconcile()에 대한 update, delete작업 검증을 위한 테스트코드를 작성하였습니다.



## Key Changes
- `given_role_has_empty_rules_then_should_update_the_role()`
  - 주어진 Role에 rule이 명시되지 않은 경우, 해당 Role을 업데이트 하는 케이스
- `given_role_has_group_which_not_exist_then_delete_the_role()`
  - 주어진 Role이 존재하지 않는 group명을 지닌 경우, 해당 Role을 삭제 하는 케이스
- `given_role_has_namespace_which_group_does_not_have_then_del()`
  - 주어진 Role의 namespace가 group의 namespace와 다른 경우, 해당 Role을 삭제 하는 케이스



## To Reviewers
[RoleReconciler의 reconcile() 코드 참조](https://github.com/ten1010-io/resource-group-controller/blob/main/src/main/java/io/ten1010/coaster/groupcontroller/controller/role/RoleReconciler.java)
- update (RoleReconciler클래스 170라인)
```Java
...
updateRole(role, RULES);
```

- delete (RoleReconciler클래스 150\~153, 157\~160라인)
```Java
if (group == null) {
    deleteRoleIfExist(request.getNamespace(), request.getName());
    return new Result(false);
}
  ...
if (!namespacesInGroup.contains(request.getNamespace())) {
    deleteRoleIfExist(request.getNamespace(), request.getName());
    return new Result(false);
}
```

- ten1010-io(upstream)의 1.0.x 브랜치를 기반으로 변경하였습니다.