### PR TITLE
feat: allow groups to have the same namespace

### DIFF
--- a/src/main/java/io/ten1010/coaster/groupcontroller/controller/GroupResolver.java
+++ b/src/main/java/io/ten1010/coaster/groupcontroller/controller/GroupResolver.java
@@ -35,35 +35,14 @@ public class GroupResolver {
         return Pair.with(daemonSetRefOpt.isPresent(), daemonSetRefOpt.orElse(null));
     }
 
-    public static class NamespaceConflictException extends Exception {
-
-        private String namespace;
-        private List<V1ResourceGroup> groups;
-
-        public NamespaceConflictException(String namespace, List<V1ResourceGroup> groups) {
-            this.namespace = namespace;
-            this.groups = groups;
-        }
-
-        public String getNamespace() {
-            return this.namespace;
-        }
-
-        public List<V1ResourceGroup> getGroups() {
-            return this.groups;
-        }
-
-    }
-
     private Indexer<V1ResourceGroup> groupIndexer;
 
     public GroupResolver(Indexer<V1ResourceGroup> groupIndexer) {
         this.groupIndexer = groupIndexer;
     }
 
-    public List<V1ResourceGroup> resolve(V1Pod pod) throws NamespaceConflictException {
-        List<V1ResourceGroup> groupsContainingNamespace = resolve(ReconcilerUtil.getNamespace(pod)).stream()
-                .collect(Collectors.toList());
+    public List<V1ResourceGroup> resolve(V1Pod pod) {
+        List<V1ResourceGroup> groupsContainingNamespace = resolve(ReconcilerUtil.getNamespace(pod));
         Pair<Boolean, V1OwnerReference> result = isDaemonSetPod(pod);
         if (!result.getValue0()) {
             return groupsContainingNamespace;
@@ -77,9 +56,8 @@ public class GroupResolver {
                 .collect(Collectors.toList());
     }
 
-    public List<V1ResourceGroup> resolve(V1DaemonSet daemonSet) throws NamespaceConflictException {
-        List<V1ResourceGroup> groupsContainingNamespace = resolve(ReconcilerUtil.getNamespace(daemonSet)).stream()
-                .collect(Collectors.toList());
+    public List<V1ResourceGroup> resolve(V1DaemonSet daemonSet) {
+        List<V1ResourceGroup> groupsContainingNamespace = resolve(ReconcilerUtil.getNamespace(daemonSet));
         List<V1ResourceGroup> groupsContainingDaemonSet = this.groupIndexer.byIndex(
                 IndexNameConstants.BY_DAEMON_SET_KEY_TO_GROUP_OBJECT,
                 KeyUtil.buildKey(ReconcilerUtil.getNamespace(daemonSet), ReconcilerUtil.getName(daemonSet)));
@@ -89,15 +67,10 @@ public class GroupResolver {
                 .collect(Collectors.toList());
     }
 
-    private Optional<V1ResourceGroup> resolve(String namespace) throws NamespaceConflictException {
-        List<V1ResourceGroup> groupsContainingNamespace = this.groupIndexer.byIndex(
+    private List<V1ResourceGroup> resolve(String namespace) {
+        return this.groupIndexer.byIndex(
                 IndexNameConstants.BY_NAMESPACE_NAME_TO_GROUP_OBJECT,
                 namespace);
-        if (groupsContainingNamespace.size() > 1) {
-            throw new NamespaceConflictException(namespace, groupsContainingNamespace);
-        }
-
-        return groupsContainingNamespace.size() == 1 ? Optional.of(groupsContainingNamespace.get(0)) : Optional.empty();
     }
 
 }

--- a/src/main/java/io/ten1010/coaster/groupcontroller/controller/ReconcilerUtil.java
+++ b/src/main/java/io/ten1010/coaster/groupcontroller/controller/ReconcilerUtil.java
@@ -1,23 +1,15 @@
 package io.ten1010.coaster.groupcontroller.controller;
 
 import io.kubernetes.client.common.KubernetesObject;
-import io.kubernetes.client.extended.event.EventType;
-import io.kubernetes.client.extended.event.legacy.EventRecorder;
-import io.kubernetes.client.openapi.models.V1Pod;
-import io.kubernetes.client.openapi.models.V1Toleration;
-import io.kubernetes.client.openapi.models.V1TolerationBuilder;
-import io.ten1010.coaster.groupcontroller.core.EventConstants;
+import io.kubernetes.client.openapi.models.*;
 import io.ten1010.coaster.groupcontroller.core.LabelConstants;
 import io.ten1010.coaster.groupcontroller.core.TaintConstants;
 import io.ten1010.coaster.groupcontroller.model.V1ResourceGroup;
-import org.springframework.lang.Nullable;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
 public class ReconcilerUtil {
-
-    private static final String MSG_NAMESPACE_BELONGS_TO_MULTIPLE_GROUPS = "Namespace [%s] belongs to multiple groups";
 
     public static String getName(KubernetesObject object) {
         Objects.requireNonNull(object.getMetadata());
@@ -37,10 +29,10 @@ public class ReconcilerUtil {
         return tolerations == null ? new ArrayList<>() : tolerations;
     }
 
-    public static Map<String, String> getNodeSelector(V1Pod pod) {
+    public static V1Affinity getAffinity(V1Pod pod) {
         Objects.requireNonNull(pod.getSpec());
-        Map<String, String> selector = pod.getSpec().getNodeSelector();
-        return selector == null ? new HashMap<>() : selector;
+        V1Affinity affinity = pod.getSpec().getAffinity();
+        return affinity == null ? new V1AffinityBuilder().build() : affinity;
     }
 
     public static boolean isResourceGroupExclusiveToleration(V1Toleration toleration) {
@@ -49,6 +41,14 @@ public class ReconcilerUtil {
         }
 
         return toleration.getKey().equals(TaintConstants.KEY_RESOURCE_GROUP_EXCLUSIVE);
+    }
+
+    public static boolean isResourceGroupExclusiveNodeSelectorRequirement(V1NodeSelectorRequirement requirement) {
+        if (requirement == null || requirement.getKey() == null) {
+            return false;
+        }
+
+        return requirement.getKey().equals(LabelConstants.KEY_RESOURCE_GROUP_EXCLUSIVE);
     }
 
     public static List<V1Toleration> buildResourceGroupExclusiveTolerations(V1ResourceGroup group) {
@@ -72,6 +72,23 @@ public class ReconcilerUtil {
                 .collect(Collectors.toList());
     }
 
+    public static List<V1NodeSelectorRequirement> buildResourceGroupExclusiveNodeSelectorRequirements(Collection<V1ResourceGroup> groups) {
+        V1NodeSelectorRequirementBuilder builder = new V1NodeSelectorRequirementBuilder()
+                .withKey(LabelConstants.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withOperator("In")
+                .withValues(groups.stream()
+                        .map(ReconcilerUtil::getName)
+                        .distinct().collect(Collectors.toList()));
+
+        return List.of(builder.build());
+    }
+
+    public static V1NodeSelectorTerm buildResourceGroupExclusiveRequiredSchedulingTerm(Collection<V1ResourceGroup> groups) {
+        return new V1NodeSelectorTermBuilder()
+                .withMatchExpressions(buildResourceGroupExclusiveNodeSelectorRequirements(groups))
+                .build();
+    }
+
     public static List<V1Toleration> reconcileTolerations(Collection<V1Toleration> tolerations, Collection<V1ResourceGroup> groups) {
         List<V1Toleration> built = tolerations.stream()
                 .filter(e -> !isResourceGroupExclusiveToleration(e))
@@ -81,25 +98,45 @@ public class ReconcilerUtil {
         return built;
     }
 
-    public static Map<String, String> reconcileNodeSelector(Map<String, String> nodeSelectors, @Nullable V1ResourceGroup group) {
-        Map<String, String> built = new HashMap<>(nodeSelectors);
-        built.remove(LabelConstants.KEY_RESOURCE_GROUP_EXCLUSIVE);
-        if (group == null) {
-            return built;
+    public static V1Affinity reconcileAffinity(V1Affinity affinity, Collection<V1ResourceGroup> groups) {
+        if(groups.isEmpty()) {
+            return affinity;
         }
-        built.put(LabelConstants.KEY_RESOURCE_GROUP_EXCLUSIVE, getName(group));
+        V1Affinity built = cloneAndInitializeIfNull(affinity);
+        built.getNodeAffinity()
+                .getRequiredDuringSchedulingIgnoredDuringExecution()
+                .setNodeSelectorTerms(extractResourceGroupNonExclusiveNodeSelectorTerms(built));
+        built.getNodeAffinity().getRequiredDuringSchedulingIgnoredDuringExecution().getNodeSelectorTerms()
+                .add(buildResourceGroupExclusiveRequiredSchedulingTerm(groups));
 
         return built;
     }
 
-    public static void issueWarningEvents(GroupResolver.NamespaceConflictException e, EventRecorder eventRecorder) {
-        for (V1ResourceGroup g : e.getGroups()) {
-            eventRecorder.event(
-                    g,
-                    EventType.Warning,
-                    EventConstants.REASON_NAMESPACE_CONFLICT, MSG_NAMESPACE_BELONGS_TO_MULTIPLE_GROUPS,
-                    e.getNamespace());
+    private static V1Affinity cloneAndInitializeIfNull(V1Affinity affinity) {
+        V1Affinity built = new V1AffinityBuilder(affinity).build();
+        if(built.getNodeAffinity() == null) {
+            built.setNodeAffinity(new V1NodeAffinityBuilder().build());
         }
+        if(built.getNodeAffinity().getRequiredDuringSchedulingIgnoredDuringExecution() == null) {
+            built.getNodeAffinity().setRequiredDuringSchedulingIgnoredDuringExecution(new V1NodeSelectorBuilder().build());
+        }
+        if(built.getNodeAffinity().getRequiredDuringSchedulingIgnoredDuringExecution().getNodeSelectorTerms() == null) {
+            built.getNodeAffinity().getRequiredDuringSchedulingIgnoredDuringExecution().setNodeSelectorTerms(new ArrayList<>());
+        }
+
+        return built;
+    }
+
+    private static List<V1NodeSelectorTerm> extractResourceGroupNonExclusiveNodeSelectorTerms(V1Affinity affinity) {
+        return affinity.getNodeAffinity()
+                .getRequiredDuringSchedulingIgnoredDuringExecution()
+                .getNodeSelectorTerms()
+                .stream()
+                .filter(term -> term.getMatchExpressions() != null)
+                .filter(term -> term.getMatchExpressions()
+                        .stream()
+                        .noneMatch(ReconcilerUtil::isResourceGroupExclusiveNodeSelectorRequirement))
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/io/ten1010/coaster/groupcontroller/controller/daemonset/DaemonSetReconciler.java
+++ b/src/main/java/io/ten1010/coaster/groupcontroller/controller/daemonset/DaemonSetReconciler.java
@@ -68,12 +68,7 @@ public class DaemonSetReconciler implements Reconciler {
                     log.debug("v [{}] founded while reconciling\n{}", daemonSetKey, daemonSet.toString());
 
                     List<V1ResourceGroup> groups;
-                    try {
-                        groups = this.groupResolver.resolve(daemonSet);
-                    } catch (GroupResolver.NamespaceConflictException e) {
-                        ReconcilerUtil.issueWarningEvents(e, this.eventRecorder);
-                        return new Result(true, INVALID_STATE_REQUEUE_DURATION);
-                    }
+                    groups = this.groupResolver.resolve(daemonSet);
 
                     List<V1Toleration> tolerations = getTolerations(daemonSet);
                     List<V1Toleration> reconciledTolerations = ReconcilerUtil.reconcileTolerations(tolerations, groups);

--- a/src/main/java/io/ten1010/coaster/groupcontroller/controller/rolebinding/NamespaceWatch.java
+++ b/src/main/java/io/ten1010/coaster/groupcontroller/controller/rolebinding/NamespaceWatch.java
@@ -23,8 +23,6 @@ public class NamespaceWatch implements ControllerWatch<V1Namespace> {
 
     public static class EventHandler implements ResourceEventHandler<V1Namespace> {
 
-        private static final String MSG_NAMESPACE_BELONGS_TO_MULTIPLE_GROUPS = "Namespace [%s] belongs to multiple groups";
-
         private WorkQueue<Request> queue;
         private Indexer<V1ResourceGroup> groupIndexer;
         private RoleNameUtil roleNameUtil;
@@ -47,18 +45,9 @@ public class NamespaceWatch implements ControllerWatch<V1Namespace> {
             if (groups.size() == 0) {
                 return;
             }
-            if (groups.size() > 1) {
-                for (V1ResourceGroup g : groups) {
-                    this.eventRecorder.event(
-                            g,
-                            EventType.Warning,
-                            EventConstants.REASON_NAMESPACE_CONFLICT, MSG_NAMESPACE_BELONGS_TO_MULTIPLE_GROUPS,
-                            ReconcilerUtil.getName(obj));
-                }
-            }
-            String roleName = this.roleNameUtil.buildRoleBindingName(ReconcilerUtil.getName(groups.get(0)));
-            Request request = new Request(ReconcilerUtil.getName(obj), roleName);
-            this.queue.add(request);
+            groups.stream()
+                    .map(group -> new Request(ReconcilerUtil.getName(obj), this.roleNameUtil.buildRoleName(ReconcilerUtil.getName(group))))
+                    .forEach(this.queue::add);
         }
 
         @Override

--- a/src/main/java/io/ten1010/coaster/groupcontroller/core/EventConstants.java
+++ b/src/main/java/io/ten1010/coaster/groupcontroller/core/EventConstants.java
@@ -2,7 +2,6 @@ package io.ten1010.coaster.groupcontroller.core;
 
 public class EventConstants {
 
-    public static final String REASON_NAMESPACE_CONFLICT = "NamespaceConflict";
     public static final String REASON_NODE_CONFLICT = "NodeConflict";
 
 }

--- a/src/test/java/io/ten1010/coaster/groupcontroller/controller/GroupResolverTest.java
+++ b/src/test/java/io/ten1010/coaster/groupcontroller/controller/GroupResolverTest.java
@@ -49,16 +49,12 @@ class GroupResolverTest {
                 .endMetadata()
                 .build();
 
-        try {
-            Assertions.assertEquals(List.of(group1), groupResolver.resolve(pod1));
-            Assertions.assertEquals(List.of(), groupResolver.resolve(pod2));
-        } catch (GroupResolver.NamespaceConflictException e) {
-            Assertions.fail();
-        }
+        Assertions.assertEquals(List.of(group1), groupResolver.resolve(pod1));
+        Assertions.assertEquals(List.of(), groupResolver.resolve(pod2));
     }
 
     @Test
-    void should_throw_NamespaceConflictException() {
+    void should_return_groups_having_same_namespace() {
         V1ResourceGroup group1 = new V1ResourceGroup();
         V1ObjectMeta meta1 = new V1ObjectMeta();
         meta1.setName("group1");
@@ -90,8 +86,8 @@ class GroupResolverTest {
                 .endMetadata()
                 .build();
 
-        Assertions.assertThrows(GroupResolver.NamespaceConflictException.class, () -> groupResolver.resolve(pod1));
-        Assertions.assertThrows(GroupResolver.NamespaceConflictException.class, () -> groupResolver.resolve(ds1));
+        Assertions.assertEquals(List.of(group1, group2), groupResolver.resolve(pod1));
+        Assertions.assertEquals(List.of(group1, group2), groupResolver.resolve(ds1));
     }
 
     @Test
@@ -132,11 +128,7 @@ class GroupResolverTest {
                 .endMetadata()
                 .build();
 
-        try {
-            Assertions.assertEquals(List.of(group1, group2), groupResolver.resolve(ds1));
-        } catch (GroupResolver.NamespaceConflictException e) {
-            Assertions.fail();
-        }
+        Assertions.assertEquals(List.of(group1, group2), groupResolver.resolve(ds1));
     }
 
 }

--- a/src/test/java/io/ten1010/coaster/groupcontroller/controller/daemonset/DaemonSetReconcilerTest.java
+++ b/src/test/java/io/ten1010/coaster/groupcontroller/controller/daemonset/DaemonSetReconcilerTest.java
@@ -80,11 +80,7 @@ class DaemonSetReconcilerTest {
         dsSpec1.setTemplate(podTemplateSpec);
         ds1.setSpec(dsSpec1);
 
-        try {
-            Mockito.doReturn(List.of(group1, group2)).when(this.groupResolver).resolve(ds1);
-        } catch (GroupResolver.NamespaceConflictException e) {
-            Assertions.fail();
-        }
+        Mockito.doReturn(List.of(group1, group2)).when(this.groupResolver).resolve(ds1);
         Mockito.doReturn(ds1).when(this.daemonSetIndexer).getByKey(KeyUtil.buildKey("ns1", "ds1"));
         DaemonSetReconciler daemonSetReconciler = new DaemonSetReconciler(this.daemonSetIndexer, this.groupResolver, this.appsV1Api, this.eventRecorder);
         daemonSetReconciler.reconcile(new Request("ns1", "ds1"));

--- a/src/test/java/io/ten1010/coaster/groupcontroller/controller/pod/PodReconcilerTest.java
+++ b/src/test/java/io/ten1010/coaster/groupcontroller/controller/pod/PodReconcilerTest.java
@@ -8,6 +8,7 @@ import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.*;
 import io.ten1010.coaster.groupcontroller.controller.GroupResolver;
 import io.ten1010.coaster.groupcontroller.core.KeyUtil;
+import io.ten1010.coaster.groupcontroller.core.LabelConstants;
 import io.ten1010.coaster.groupcontroller.core.TaintConstants;
 import io.ten1010.coaster.groupcontroller.model.V1ResourceGroup;
 import io.ten1010.coaster.groupcontroller.model.V1ResourceGroupSpec;
@@ -51,13 +52,23 @@ class PodReconcilerTest {
         pod1.setMetadata(podMeta1);
         V1PodSpec podSpec1 = new V1PodSpec();
         podSpec1.setTolerations(new ArrayList<>());
+        podSpec1.setTolerations(new ArrayList<>());
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withRequiredDuringSchedulingIgnoredDuringExecution(
+                        new V1NodeSelectorBuilder().withNodeSelectorTerms(
+                                new V1NodeSelectorTermBuilder().withMatchExpressions(
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey(LabelConstants.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                .withOperator("In")
+                                                .withValues("group1").build()
+                                ).build()
+                        ).build()
+                ).build()
+        ).build();
+        podSpec1.setAffinity(affinity1);
         pod1.setSpec(podSpec1);
 
-        try {
-            Mockito.doReturn(List.of(group1)).when(this.groupResolver).resolve(pod1);
-        } catch (GroupResolver.NamespaceConflictException e) {
-            Assertions.fail();
-        }
+        Mockito.doReturn(List.of(group1)).when(this.groupResolver).resolve(pod1);
         Mockito.doReturn(pod1).when(this.podIndexer).getByKey(KeyUtil.buildKey("ns1", "pod1"));
         PodReconciler podReconciler = new PodReconciler(this.podIndexer, this.groupResolver, this.coreV1Api, this.eventRecorder);
         podReconciler.reconcile(new Request("ns1", "pod1"));
@@ -90,7 +101,7 @@ class PodReconcilerTest {
 
         V1Pod pod1 = new V1Pod();
         V1ObjectMeta podMeta1 = new V1ObjectMeta();
-        podMeta1.setName("ns1");
+        podMeta1.setNamespace("ns1");
         podMeta1.setName("pod1");
         pod1.setMetadata(podMeta1);
         V1PodSpec podSpec1 = new V1PodSpec();
@@ -102,18 +113,202 @@ class PodReconcilerTest {
                 tolerationBuilder.withEffect("NoSchedule").build(),
                 tolerationBuilder.withEffect("NoExecute").build()
                 ));
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withRequiredDuringSchedulingIgnoredDuringExecution(
+                        new V1NodeSelectorBuilder().withNodeSelectorTerms(
+                                new V1NodeSelectorTermBuilder().withMatchExpressions(
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey(LabelConstants.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                .withOperator("In")
+                                                .withValues("group1").build()
+                                ).build()
+                        ).build()
+                ).build()
+        ).build();
+        podSpec1.setAffinity(affinity1);
         pod1.setSpec(podSpec1);
 
+        Mockito.doReturn(List.of(group1)).when(this.groupResolver).resolve(pod1);
+        Mockito.doReturn(pod1).when(this.podIndexer).getByKey(KeyUtil.buildKey("ns1", "pod1"));
+        PodReconciler podReconciler = new PodReconciler(this.podIndexer, this.groupResolver, this.coreV1Api, this.eventRecorder);
+        podReconciler.reconcile(new Request("ns1", "pod1"));
         try {
-            Mockito.doReturn(List.of(group1)).when(this.groupResolver).resolve(pod1);
-        } catch (GroupResolver.NamespaceConflictException e) {
+            Mockito.verifyNoInteractions(this.coreV1Api);
+        } catch (Exception e) {
             Assertions.fail();
         }
+    }
+
+    @Test
+    void given_pod_has_tolerations_for_not_existing_group_then_should_delete_pod() {
+        V1ResourceGroup group1 = new V1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1ResourceGroupSpec spec1 = new V1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+        V1Pod pod1 = new V1Pod();
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        pod1.setMetadata(podMeta1);
+        V1PodSpec podSpec1 = new V1PodSpec();
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(TaintConstants.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group2")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(
+                tolerationBuilder.withEffect("NoSchedule").build(),
+                tolerationBuilder.withEffect("NoExecute").build()
+        ));
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withRequiredDuringSchedulingIgnoredDuringExecution(
+                        new V1NodeSelectorBuilder().withNodeSelectorTerms(
+                                new V1NodeSelectorTermBuilder().withMatchExpressions(
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey(LabelConstants.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                .withOperator("In")
+                                                .withValues("group1").build()
+                                ).build()
+                        ).build()
+                ).build()
+        ).build();
+        podSpec1.setAffinity(affinity1);
+        pod1.setSpec(podSpec1);
 
         Mockito.doReturn(pod1).when(this.podIndexer).getByKey(KeyUtil.buildKey("ns1", "pod1"));
         PodReconciler podReconciler = new PodReconciler(this.podIndexer, this.groupResolver, this.coreV1Api, this.eventRecorder);
         podReconciler.reconcile(new Request("ns1", "pod1"));
+        try {
+            Mockito.verify(this.coreV1Api).deleteNamespacedPod(
+                    Mockito.eq("pod1"),
+                    Mockito.eq("ns1"),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+        Mockito.verifyNoMoreInteractions(this.coreV1Api);
+    }
 
+    @Test
+    void given_pod_does_not_have_affinity_for_group_then_should_delete_pod() {
+        V1ResourceGroup group1 = new V1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1ResourceGroupSpec spec1 = new V1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+        V1Pod pod1 = new V1Pod();
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        pod1.setMetadata(podMeta1);
+        V1Affinity affinity1 = new V1Affinity();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        podSpec1.setAffinity(affinity1);
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(TaintConstants.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(
+                tolerationBuilder.withEffect("NoSchedule").build(),
+                tolerationBuilder.withEffect("NoExecute").build()
+        ));
+        pod1.setSpec(podSpec1);
+
+        Mockito.doReturn(pod1).when(this.podIndexer).getByKey(KeyUtil.buildKey("ns1", "pod1"));
+        PodReconciler podReconciler = new PodReconciler(this.podIndexer, this.groupResolver, this.coreV1Api, this.eventRecorder);
+        podReconciler.reconcile(new Request("ns1", "pod1"));
+        try {
+            Mockito.verify(this.coreV1Api).deleteNamespacedPod(
+                    Mockito.eq("pod1"),
+                    Mockito.eq("ns1"),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+        Mockito.verifyNoMoreInteractions(this.coreV1Api);
+    }
+
+    @Test
+    void given_pod_has_proper_node_affinity_then_do_nothing() {
+        V1ResourceGroup group1 = new V1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1ResourceGroupSpec spec1 = new V1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1Pod pod1 = new V1Pod();
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        pod1.setMetadata(podMeta1);
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withRequiredDuringSchedulingIgnoredDuringExecution(
+                        new V1NodeSelectorBuilder().withNodeSelectorTerms(
+                                new V1NodeSelectorTermBuilder().withMatchExpressions(
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey(LabelConstants.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                .withOperator("In")
+                                                .withValues("group1")
+                                                .build()
+                                ).build()
+                        ).build()
+                ).build()
+        ).build();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        podSpec1.setAffinity(affinity1);
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(TaintConstants.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(
+                tolerationBuilder.withEffect("NoSchedule").build(),
+                tolerationBuilder.withEffect("NoExecute").build()
+        ));
+        pod1.setSpec(podSpec1);
+
+        Mockito.doReturn(List.of(group1)).when(this.groupResolver).resolve(pod1);
+        Mockito.doReturn(pod1).when(this.podIndexer).getByKey(KeyUtil.buildKey("ns1", "pod1"));
+        PodReconciler podReconciler = new PodReconciler(this.podIndexer, this.groupResolver, this.coreV1Api, this.eventRecorder);
+        podReconciler.reconcile(new Request("ns1", "pod1"));
+        try {
+            Mockito.verifyNoInteractions(this.coreV1Api);
+        } catch (Exception e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_pod_has_no_tolerations_and_affinity_when_groups_not_exist_then_do_nothing() {
+        V1Pod pod1 = new V1Pod();
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        pod1.setMetadata(podMeta1);
+        V1PodSpec podSpec1 = new V1PodSpec();
+        podSpec1.setTolerations(new ArrayList<>());
+        podSpec1.setTolerations(new ArrayList<>());
+        pod1.setSpec(podSpec1);
+
+        Mockito.doReturn(new ArrayList<>()).when(this.groupResolver).resolve(pod1);
+        Mockito.doReturn(pod1).when(this.podIndexer).getByKey(KeyUtil.buildKey("ns1", "pod1"));
+        PodReconciler podReconciler = new PodReconciler(this.podIndexer, this.groupResolver, this.coreV1Api, this.eventRecorder);
+        podReconciler.reconcile(new Request("ns1", "pod1"));
         try {
             Mockito.verifyNoInteractions(this.coreV1Api);
         } catch (Exception e) {

--- a/src/test/java/io/ten1010/coaster/groupcontroller/mutating/AdmissionReviewServiceTest.java
+++ b/src/test/java/io/ten1010/coaster/groupcontroller/mutating/AdmissionReviewServiceTest.java
@@ -5,9 +5,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import io.kubernetes.client.openapi.models.V1Pod;
-import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.kubernetes.client.openapi.models.*;
 import io.ten1010.coaster.groupcontroller.controller.GroupResolver;
 import io.ten1010.coaster.groupcontroller.model.V1ResourceGroup;
 import io.ten1010.coaster.groupcontroller.model.V1ResourceGroupSpec;
@@ -31,7 +29,7 @@ class AdmissionReviewServiceTest {
     }
 
     @Test
-    void should_patch_nodeSelectors_and_tolerations() {
+    void should_patch_nodeAffinities_and_tolerations() {
         V1ResourceGroup group1 = new V1ResourceGroup();
         V1ObjectMeta meta1 = new V1ObjectMeta();
         meta1.setName("group1");
@@ -49,11 +47,7 @@ class AdmissionReviewServiceTest {
         podSpec1.setTolerations(new ArrayList<>());
         pod1.setSpec(podSpec1);
 
-        try {
-            Mockito.doReturn(List.of(group1)).when(this.groupResolver).resolve(pod1);
-        } catch (GroupResolver.NamespaceConflictException e) {
-            Assertions.fail();
-        }
+        Mockito.doReturn(List.of(group1)).when(this.groupResolver).resolve(pod1);
         AdmissionReviewService admissionReviewService = new AdmissionReviewService(this.groupResolver);
         V1AdmissionReviewRequest request = new V1AdmissionReviewRequest();
         V1AdmissionReviewRequest.Kind kind = new V1AdmissionReviewRequest.Kind();
@@ -82,10 +76,10 @@ class AdmissionReviewServiceTest {
         } catch (JsonProcessingException e) {
             Assertions.fail(e);
         }
-        String nodeSelectorPath = "/spec/nodeSelector";
+        String affinityPath = "/spec/affinity";
         String tolerationsPath = "/spec/tolerations";
         for (ObjectNode e : patchJson) {
-            if ((!e.get("path").textValue().equals(nodeSelectorPath) && !e.get("path").textValue().equals(tolerationsPath))) {
+            if ((!e.get("path").textValue().equals(affinityPath) && !e.get("path").textValue().equals(tolerationsPath))) {
                 Assertions.fail();
             }
         }


### PR DESCRIPTION
## Motivation
- 단일 namespace를 여러 resource group이 추가할 수 있도록 하였습니다.
- 관련된 클래스들의 내부 로직을 변경하고 테스트케이스를 추가/삭제 하였습니다.
- pod 스케쥴링에서 nodeSelector에 대한 로직을 affinity로 변경하였습니다.
  - RequiredDuringSchedulingIgnoredDuringExecution을 통해 exclusive pod scheduling으로 구현하였습니다.
- 변경사항들에 대한 E2E테스트를 진행하였습니다.


## Key Changes
- GroupResolver.class 
  - NamespaceConflictException 클래스 삭제
  - resolve() 내 NamespaceConflictException 로직 제거
  - resolve()의 input 파라미터와 리턴 형식을 ResourceGroup 리스트 형태로 변경


- ReconcilerUtil.class 
  - nodeSelector 관련 메소드 삭제
    - getNodeSelector(), reconcileNodeSelector()
  - NamespaceConflictExcpetion을 위한 issueWarningEvents() 삭제
  - affinity 관련 메소드 구현
    - reconcileAffinity()
    - getAffinity()
    - isResourceGroupExclusiveNodeSelectorRequirement()
    - buildResourceGroupExclusiveNodeSelectorRequirements()
    - buildResourceGroupExclusiveRequiredSchedulingTerm()
    - cloneAndInitializeIfNull()
    - extractResourceGroupNonExclusiveNodeSelectorTerms()

- DaemonSetReconciler.class 
  - GroupResolver의 NamespaceConflictException 로직 제거

- PodReconciler.class 
  - reconcile()의 NamespaceConflictException 로직 제거
  - 파드의 affinity에 대한 reconcile 및 검증 작업 추가


- NamespaceWatch.class 
  - onAdd()의 NamespaceConflictException 로직 제거

  
- EventConstants.class
  - NamespaceConflict레이블 삭제


- AdmissionReviewService.class 
  - GroupResolver의 NamespaceConflictException 로직 제거
  - reconcileNodeSelector()에 input 파라미터를 ResourceGroup 리스트형태로 변경
  - nodeSelector에 대한 reconcile 및 JSON patch 메소드 삭제
  - affinity에 대한 reconcile 로직 구현 및 JSON patch 메소드 정의



- GroupResolverTest.class 
  - GroupResolver의 NamespaceConflictException 로직 제거
  - NamespaceConflictException 테스트케이스를 단일 namespace에 대한 복수 resource group 리턴 검증 테스트 케이스로 변경


- DaemonSetReconcilerTest.class
  - GroupResolver의 NamespaceConflictException 로직 제거


- PodReconcilerTest.class 
  - 기존 테스트케이스의 오탈자 수정
  - GroupResolver의 NamespaceConflictException 로직 제거
  - 기존 테스트케이스에 Node Affinity설정 로직 추가
  - 추가 테스트케이스 작성
    - `given_pod_has_tolerations_for_not_existing_group_then_should_delete_pod()`
      - Pod의 toleration value값(group이름)이 존재하지 않는 경우, 해당 Pod를 삭제하는 케이스
    - `given_pod_does_not_have_affinity_for_group_then_should_delete_pod()`
      - Pod가 해당 NS의 group에 대한 affinity가 없는 경우, 해당 Pod를 삭제하는 케이스
    - `given_pod_has_proper_node_affinity_then_do_nothing()`
      - Pod가 group에 해당하는 적절한 node affinity를 지닌 경우, reconciliation작업이 일어나지 않음을 검증하는 케이스
    - `given_pod_has_no_tolerations_and_affinity_when_groups_not_exist_then_do_nothing()`
      - group이 존재하지 않는 경우, reconciliation작업이 일어나지 않음을 검증하는 케이스



- AdmissionReviewServiceTest.class 
  - GroupResolver의 NamespaceConflictException 로직 제거
  - nodeSelector에 대한 검증 삭제
  - affinity에 대한 검증 추가


## To Reviewers
- 1개의 control plane, 2개의 워커노드로 구성된 클러스터 E2E테스트 환경에서 아래의 사항을 확인하였습니다.
  - 단일 NS에 각 워커노드별로 ResourceGroup이 할당됨
  - 단일 NS의 Resource Group별로 Toleration을 정의하여 파드 deploy 시 적절한 노드의 네임스페이스에 파드가 띄워짐
  - 파드의 네임스페이스에 따라 적절한 toleration과 affinity이 적용됨을 확인함
