### PR TITLE
chore: allow the controller to be deployed on the control plane

### DIFF
--- a/kubernetes/controller/templates/deployment.yaml
+++ b/kubernetes/controller/templates/deployment.yaml
@@ -12,6 +12,10 @@ spec:
       labels:
         app: resource-group-controller
     spec:
+      tolerations:
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
       serviceAccountName: resource-group-controller
       automountServiceAccountToken: true
       containers:


### PR DESCRIPTION
## Motivation
- resource group controller가 control plane에 뜰 수 있도록 toleration을 추가하였습니다.


## Key Changes
- kubernetes/controller/template/deployment.yaml
  control-plane의 taint에 해당하는 toleration 추가
