### PR TITLE
chore: prefer to deploy the controller on the control plane above all

### DIFF
--- a/kubernetes/controller/templates/deployment.yaml
+++ b/kubernetes/controller/templates/deployment.yaml
@@ -12,6 +12,14 @@ spec:
       labels:
         app: resource-group-controller
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       tolerations:
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"


### PR DESCRIPTION
## Motivation
- resource group controller가 control plane에 우선적으로 배포될 수 있도록 변경하였습니다.


## Key Changes
- kubernetes/controller/templates/deployment.yaml
  - control plane의 label에 대한 preferred node affinity를 추가하였습니다.


## To Reviewers
- 1개의 control plane, 2개의 워커노드로 구성된 클러스터 E2E테스트 환경에서 아래의 사항을 확인하였습니다.
  - resource-group-controller 파드가 control plane에 우선적으로 배포 됨.

  