### PR TITLE
feat: selective pod scheduling

### DIFF
--- a/kubernetes/controller/kustomization.yaml
+++ b/kubernetes/controller/kustomization.yaml
@@ -6,6 +6,7 @@ configMapGenerator:
       - SPRING_PROFILES_ACTIVE=production
       - LOGGING_LEVEL_IO_TEN1010_COASTER_GROUPCONTROLLER=info
       - SERVER_SSL_KEY_STORE=/etc/resource-group-controller/tls/tls.p12
+      - APP_SCHEDULING_GROUP_NODE_ONLY=true
 secretGenerator:
   - name: resource-group-controller-envs
     literals:

--- a/src/main/java/io/ten1010/coaster/groupcontroller/configuration/ControllerConfiguration.java
+++ b/src/main/java/io/ten1010/coaster/groupcontroller/configuration/ControllerConfiguration.java
@@ -8,6 +8,7 @@ import io.kubernetes.client.extended.event.legacy.LegacyEventBroadcaster;
 import io.kubernetes.client.informer.SharedInformerFactory;
 import io.kubernetes.client.informer.cache.Indexer;
 import io.kubernetes.client.openapi.models.V1EventSource;
+import io.ten1010.coaster.groupcontroller.configuration.property.SchedulingProperties;
 import io.ten1010.coaster.groupcontroller.controller.Reconciliation;
 import io.ten1010.coaster.groupcontroller.controller.SharedInformerFactoryFactory;
 import io.ten1010.coaster.groupcontroller.core.K8sApis;
@@ -49,11 +50,11 @@ public class ControllerConfiguration {
     }
 
     @Bean
-    public Reconciliation reconciliation(SharedInformerFactory sharedInformerFactory) {
+    public Reconciliation reconciliation(SharedInformerFactory sharedInformerFactory, SchedulingProperties schedulingProperties) {
         Indexer<V1Beta1ResourceGroup> groupIndexer = sharedInformerFactory
                 .getExistingSharedIndexInformer(V1Beta1ResourceGroup.class)
                 .getIndexer();
-        return new Reconciliation(groupIndexer);
+        return new Reconciliation(groupIndexer, schedulingProperties);
     }
 
     @Bean(initMethod = "startRecording", destroyMethod = "shutdown")

--- a/src/main/java/io/ten1010/coaster/groupcontroller/configuration/KubernetesConfiguration.java
+++ b/src/main/java/io/ten1010/coaster/groupcontroller/configuration/KubernetesConfiguration.java
@@ -3,9 +3,8 @@ package io.ten1010.coaster.groupcontroller.configuration;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.util.ClientBuilder;
 import io.kubernetes.client.util.KubeConfig;
+import io.ten1010.coaster.groupcontroller.configuration.property.KubernetesClientProperties;
 import io.ten1010.coaster.groupcontroller.core.K8sApis;
-import lombok.*;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,21 +14,8 @@ import java.io.FileReader;
 import java.io.IOException;
 
 @Configuration
-@EnableConfigurationProperties({KubernetesConfiguration.KubernetesClientProperties.class})
+@EnableConfigurationProperties({KubernetesClientProperties.class})
 public class KubernetesConfiguration {
-
-    @ConfigurationProperties(prefix = "app.kubernetes.client")
-    @NoArgsConstructor
-    @Getter
-    @Setter
-    @EqualsAndHashCode
-    @ToString
-    public static class KubernetesClientProperties {
-
-        private boolean verifySsl = true;
-        private String kubeconfigPath = "$HOME/.kube/config";
-
-    }
 
     @Profile("in-cluster-kubeconfig")
     @Bean

--- a/src/main/java/io/ten1010/coaster/groupcontroller/configuration/property/KubernetesClientProperties.java
+++ b/src/main/java/io/ten1010/coaster/groupcontroller/configuration/property/KubernetesClientProperties.java
@@ -1,0 +1,20 @@
+package io.ten1010.coaster.groupcontroller.configuration.property;
+
+import lombok.*;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration("kubernetesClientConfig")
+@ConfigurationProperties(prefix = "app.kubernetes.client")
+@NoArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
+
+public class KubernetesClientProperties {
+
+    private boolean verifySsl = true;
+    private String kubeconfigPath = "$HOME/.kube/config";
+
+}

--- a/src/main/java/io/ten1010/coaster/groupcontroller/configuration/property/SchedulingProperties.java
+++ b/src/main/java/io/ten1010/coaster/groupcontroller/configuration/property/SchedulingProperties.java
@@ -1,0 +1,23 @@
+package io.ten1010.coaster.groupcontroller.configuration.property;
+
+import lombok.*;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "app")
+@NoArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
+public class SchedulingProperties {
+
+    private boolean schedulingGroupNodeOnly = true;
+
+    public SchedulingProperties(@DefaultValue("true") boolean schedulingGroupNodeOnly) {
+        this.schedulingGroupNodeOnly = schedulingGroupNodeOnly;
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,4 +13,5 @@ spring.profiles.active=production
 logging.level.io.ten1010.coaster.groupcontroller=info
 ### Kubernetes client
 app.kubernetes.client.verify-ssl=true
+app.scheduling-group-node-only=true
 #app.kubernetes.client.kubeconfig-path=

--- a/src/test/java/io/ten1010/coaster/groupcontroller/controller/cluster/node/NodeReconcilerTest.java
+++ b/src/test/java/io/ten1010/coaster/groupcontroller/controller/cluster/node/NodeReconcilerTest.java
@@ -95,7 +95,6 @@ class NodeReconcilerTest {
         }
     }
 
-
     @Test
     void should_do_nothing_the_given_labels_and_taints_of_node_are_equal_with_resource_groups() {
         V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();

--- a/src/test/java/io/ten1010/coaster/groupcontroller/controller/workload/daemonset/DaemonSetReconcilerTest.java
+++ b/src/test/java/io/ten1010/coaster/groupcontroller/controller/workload/daemonset/DaemonSetReconcilerTest.java
@@ -5,12 +5,13 @@ import io.kubernetes.client.informer.cache.Indexer;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.models.*;
+import io.ten1010.coaster.groupcontroller.configuration.property.SchedulingProperties;
 import io.ten1010.coaster.groupcontroller.controller.Reconciliation;
 import io.ten1010.coaster.groupcontroller.core.IndexNames;
 import io.ten1010.coaster.groupcontroller.core.KeyUtil;
 import io.ten1010.coaster.groupcontroller.core.Taints;
-import io.ten1010.coaster.groupcontroller.model.V1Beta1K8sObjectReference;
 import io.ten1010.coaster.groupcontroller.model.V1Beta1DaemonSet;
+import io.ten1010.coaster.groupcontroller.model.V1Beta1K8sObjectReference;
 import io.ten1010.coaster.groupcontroller.model.V1Beta1ResourceGroup;
 import io.ten1010.coaster.groupcontroller.model.V1Beta1ResourceGroupSpec;
 import org.junit.jupiter.api.Assertions;
@@ -30,11 +31,13 @@ class DaemonSetReconcilerTest {
     Reconciliation reconciliation;
     Indexer<V1DaemonSet> daemonSetIndexer;
     AppsV1Api appsV1Api;
+    SchedulingProperties schedulingProperties;
 
     @BeforeEach
     void setUp() {
         this.groupIndexer = Mockito.mock(Indexer.class);
-        this.reconciliation = new Reconciliation(this.groupIndexer);
+        this.schedulingProperties = Mockito.mock(SchedulingProperties.class);
+        this.reconciliation = new Reconciliation(this.groupIndexer, this.schedulingProperties);
         this.daemonSetIndexer = Mockito.mock(Indexer.class);
         this.appsV1Api = Mockito.mock(AppsV1Api.class);
     }

--- a/src/test/java/io/ten1010/coaster/groupcontroller/controller/workload/pod/PodReconcilerTest.java
+++ b/src/test/java/io/ten1010/coaster/groupcontroller/controller/workload/pod/PodReconcilerTest.java
@@ -5,6 +5,7 @@ import io.kubernetes.client.informer.cache.Indexer;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.*;
+import io.ten1010.coaster.groupcontroller.configuration.property.SchedulingProperties;
 import io.ten1010.coaster.groupcontroller.controller.Reconciliation;
 import io.ten1010.coaster.groupcontroller.core.IndexNames;
 import io.ten1010.coaster.groupcontroller.core.KeyUtil;
@@ -26,11 +27,13 @@ class PodReconcilerTest {
     Reconciliation reconciliation;
     Indexer<V1Pod> podIndexer;
     CoreV1Api coreV1Api;
+    SchedulingProperties schedulingProperties;
 
     @BeforeEach
     void setUp() {
         this.groupIndexer = Mockito.mock(Indexer.class);
-        this.reconciliation = new Reconciliation(this.groupIndexer);
+        this.schedulingProperties = Mockito.mock(SchedulingProperties.class);
+        this.reconciliation = new Reconciliation(this.groupIndexer, this.schedulingProperties);
         this.podIndexer = Mockito.mock(Indexer.class);
         this.coreV1Api = Mockito.mock(CoreV1Api.class);
     }
@@ -67,6 +70,7 @@ class PodReconcilerTest {
         podSpec1.setAffinity(affinity1);
         pod1.setSpec(podSpec1);
 
+        Mockito.doReturn(true).when(this.schedulingProperties).isSchedulingGroupNodeOnly();
         Mockito.doReturn(List.of(group1))
                 .when(this.groupIndexer)
                 .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
@@ -95,7 +99,6 @@ class PodReconcilerTest {
         V1ObjectMeta meta1 = new V1ObjectMeta();
         meta1.setName("group1");
         group1.setMetadata(meta1);
-
         V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
         spec1.setNamespaces(List.of("ns1"));
         group1.setSpec(spec1);
@@ -126,6 +129,7 @@ class PodReconcilerTest {
         podSpec1.setAffinity(affinity1);
         pod1.setSpec(podSpec1);
 
+        Mockito.doReturn(true).when(this.schedulingProperties).isSchedulingGroupNodeOnly();
         Mockito.doReturn(List.of(group1))
                 .when(this.groupIndexer)
                 .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
@@ -148,6 +152,7 @@ class PodReconcilerTest {
         V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
         spec1.setNamespaces(List.of("ns1"));
         group1.setSpec(spec1);
+
         V1Pod pod1 = new V1Pod();
         V1ObjectMeta podMeta1 = new V1ObjectMeta();
         podMeta1.setNamespace("ns1");
@@ -158,10 +163,7 @@ class PodReconcilerTest {
                 .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
                 .withValue("group2")
                 .withOperator("Equal");
-        podSpec1.setTolerations(List.of(
-                tolerationBuilder.withEffect("NoSchedule").build(),
-                tolerationBuilder.withEffect("NoExecute").build()
-        ));
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
         V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
                 new V1NodeAffinityBuilder().withRequiredDuringSchedulingIgnoredDuringExecution(
                         new V1NodeSelectorBuilder().withNodeSelectorTerms(
@@ -177,6 +179,10 @@ class PodReconcilerTest {
         podSpec1.setAffinity(affinity1);
         pod1.setSpec(podSpec1);
 
+        Mockito.doReturn(true).when(this.schedulingProperties).isSchedulingGroupNodeOnly();
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
         Mockito.doReturn(pod1).when(this.podIndexer).getByKey(KeyUtil.buildKey("ns1", "pod1"));
         PodReconciler podReconciler = new PodReconciler(this.podIndexer, this.reconciliation, this.coreV1Api);
         podReconciler.reconcile(new Request("ns1", "pod1"));
@@ -205,6 +211,7 @@ class PodReconcilerTest {
         V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
         spec1.setNamespaces(List.of("ns1"));
         group1.setSpec(spec1);
+
         V1Pod pod1 = new V1Pod();
         V1ObjectMeta podMeta1 = new V1ObjectMeta();
         podMeta1.setNamespace("ns1");
@@ -217,12 +224,13 @@ class PodReconcilerTest {
                 .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
                 .withValue("group1")
                 .withOperator("Equal");
-        podSpec1.setTolerations(List.of(
-                tolerationBuilder.withEffect("NoSchedule").build(),
-                tolerationBuilder.withEffect("NoExecute").build()
-        ));
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
         pod1.setSpec(podSpec1);
 
+        Mockito.doReturn(true).when(this.schedulingProperties).isSchedulingGroupNodeOnly();
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
         Mockito.doReturn(pod1).when(this.podIndexer).getByKey(KeyUtil.buildKey("ns1", "pod1"));
         PodReconciler podReconciler = new PodReconciler(this.podIndexer, this.reconciliation, this.coreV1Api);
         podReconciler.reconcile(new Request("ns1", "pod1"));
@@ -333,7 +341,6 @@ class PodReconcilerTest {
                 ).build()
         ).build();
         V1PodSpec podSpec1 = new V1PodSpec();
-
         podSpec1.setAffinity(affinity1);
         V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
                 .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
@@ -341,6 +348,7 @@ class PodReconcilerTest {
                 .withOperator("Equal");
         podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
         pod1.setSpec(podSpec1);
+        Mockito.doReturn(true).when(this.schedulingProperties).isSchedulingGroupNodeOnly();
         Mockito.doReturn(List.of(group1))
                 .when(this.groupIndexer)
                 .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
@@ -407,6 +415,7 @@ class PodReconcilerTest {
                 .withOperator("Equal");
         podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
         pod1.setSpec(podSpec1);
+        Mockito.doReturn(true).when(this.schedulingProperties).isSchedulingGroupNodeOnly();
         Mockito.doReturn(List.of(group1))
                 .when(this.groupIndexer)
                 .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
@@ -519,6 +528,7 @@ class PodReconcilerTest {
         podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
         pod1.setSpec(podSpec1);
 
+        Mockito.doReturn(true).when(this.schedulingProperties).isSchedulingGroupNodeOnly();
         Mockito.doReturn(List.of(group1))
                 .when(this.groupIndexer)
                 .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
@@ -544,6 +554,7 @@ class PodReconcilerTest {
         podSpec1.setTolerations(new ArrayList<>());
         pod1.setSpec(podSpec1);
 
+        Mockito.doReturn(true).when(this.schedulingProperties).isSchedulingGroupNodeOnly();
         Mockito.doReturn(new ArrayList<>())
                 .when(this.groupIndexer)
                 .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
@@ -557,5 +568,376 @@ class PodReconcilerTest {
         }
     }
 
-}
+    @Test
+    void given_pod_has_preferred_node_affinity_in_exclusive_mode_then_should_delete_pod() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
 
+        V1Pod pod1 = new V1Pod();
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        pod1.setMetadata(podMeta1);
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withPreferredDuringSchedulingIgnoredDuringExecution(
+                        new V1PreferredSchedulingTermBuilder()
+                                .withWeight(1)
+                                .withPreference(new V1NodeSelectorTermBuilder()
+                                        .withMatchExpressions(
+                                                new V1NodeSelectorRequirementBuilder()
+                                                        .withKey(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                        .withOperator("In")
+                                                        .withValues("group1").build()
+                                        ).build()
+                                ).build()
+                ).build()
+        ).build();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        podSpec1.setAffinity(affinity1);
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
+        pod1.setSpec(podSpec1);
+
+        Mockito.doReturn(true).when(this.schedulingProperties).isSchedulingGroupNodeOnly();
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(pod1).when(this.podIndexer).getByKey(KeyUtil.buildKey("ns1", "pod1"));
+        PodReconciler podReconciler = new PodReconciler(this.podIndexer, this.reconciliation, this.coreV1Api);
+        podReconciler.reconcile(new Request("ns1", "pod1"));
+        try {
+            Mockito.verify(this.coreV1Api).deleteNamespacedPod(
+                    Mockito.eq("pod1"),
+                    Mockito.eq("ns1"),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+        Mockito.verifyNoMoreInteractions(this.coreV1Api);
+    }
+
+    @Test
+    void given_pod_has_a_preferred_node_affinity_in_non_exclusive_mode_then_do_nothing() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1Pod pod1 = new V1Pod();
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        pod1.setMetadata(podMeta1);
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withPreferredDuringSchedulingIgnoredDuringExecution(
+                        new V1PreferredSchedulingTermBuilder()
+                                .withWeight(1)
+                                .withPreference(new V1NodeSelectorTermBuilder()
+                                        .withMatchExpressions(
+                                                new V1NodeSelectorRequirementBuilder()
+                                                        .withKey(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                        .withOperator("In")
+                                                        .withValues("group1").build()
+                                        ).build()
+                                ).build()
+                ).build()
+        ).build();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        podSpec1.setAffinity(affinity1);
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
+        pod1.setSpec(podSpec1);
+
+        Mockito.doReturn(false).when(this.schedulingProperties).isSchedulingGroupNodeOnly();
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(pod1).when(this.podIndexer).getByKey(KeyUtil.buildKey("ns1", "pod1"));
+        PodReconciler podReconciler = new PodReconciler(this.podIndexer, this.reconciliation, this.coreV1Api);
+        podReconciler.reconcile(new Request("ns1", "pod1"));
+        try {
+            Mockito.verifyNoInteractions(this.coreV1Api);
+        } catch (Exception e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_pod_has_preferred_node_affinities_in_non_exclusive_mode_then_do_nothing() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+        V1Pod pod1 = new V1Pod();
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        pod1.setMetadata(podMeta1);
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withPreferredDuringSchedulingIgnoredDuringExecution(
+                        new V1PreferredSchedulingTermBuilder()
+                                .withWeight(1)
+                                .withPreference(new V1NodeSelectorTermBuilder()
+                                        .withMatchExpressions(
+                                                new V1NodeSelectorRequirementBuilder()
+                                                        .withKey("kubernetes.io/hostname")
+                                                        .withOperator("In")
+                                                        .withValues("cpu1")
+                                                        .build(),
+                                                new V1NodeSelectorRequirementBuilder()
+                                                        .withKey(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                        .withOperator("In")
+                                                        .withValues("group1")
+                                                        .build()
+                                        ).build()
+                                ).build(),
+                        new V1PreferredSchedulingTermBuilder()
+                                .withWeight(1)
+                                .withPreference(new V1NodeSelectorTermBuilder()
+                                        .withMatchExpressions(
+                                                new V1NodeSelectorRequirementBuilder()
+                                                        .withKey("kubernetes.io/hostname")
+                                                        .withOperator("In")
+                                                        .withValues("cpu2")
+                                                        .build(),
+                                                new V1NodeSelectorRequirementBuilder()
+                                                        .withKey(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                        .withOperator("In")
+                                                        .withValues("group1")
+                                                        .build()
+                                        ).build()
+                                ).build()
+                ).build()
+        ).build();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        podSpec1.setAffinity(affinity1);
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
+        pod1.setSpec(podSpec1);
+
+        Mockito.doReturn(false).when(this.schedulingProperties).isSchedulingGroupNodeOnly();
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(pod1).when(this.podIndexer).getByKey(KeyUtil.buildKey("ns1", "pod1"));
+        PodReconciler podReconciler = new PodReconciler(this.podIndexer, this.reconciliation, this.coreV1Api);
+        podReconciler.reconcile(new Request("ns1", "pod1"));
+        try {
+            Mockito.verifyNoInteractions(this.coreV1Api);
+        } catch (Exception e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_pod_has_preferred_node_affinities_only_one_for_group_in_non_exclusive_mode_then_should_delete_pod() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+        V1Pod pod1 = new V1Pod();
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        pod1.setMetadata(podMeta1);
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withPreferredDuringSchedulingIgnoredDuringExecution(
+                        new V1PreferredSchedulingTermBuilder()
+                                .withWeight(1)
+                                .withPreference(new V1NodeSelectorTermBuilder()
+                                        .withMatchExpressions(
+                                                new V1NodeSelectorRequirementBuilder()
+                                                        .withKey("kubernetes.io/hostname")
+                                                        .withOperator("In")
+                                                        .withValues("cpu1")
+                                                        .build(),
+                                                new V1NodeSelectorRequirementBuilder()
+                                                        .withKey(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                        .withOperator("In")
+                                                        .withValues("group1")
+                                                        .build()
+                                        ).build()
+                                ).build(),
+                        new V1PreferredSchedulingTermBuilder()
+                                .withWeight(1)
+                                .withPreference(new V1NodeSelectorTermBuilder()
+                                        .withMatchExpressions(
+                                                new V1NodeSelectorRequirementBuilder()
+                                                        .withKey("kubernetes.io/hostname")
+                                                        .withOperator("In")
+                                                        .withValues("cpu2")
+                                                        .build()
+                                        ).build()
+                                ).build()
+                ).build()
+        ).build();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        podSpec1.setAffinity(affinity1);
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
+        pod1.setSpec(podSpec1);
+
+        Mockito.doReturn(false).when(this.schedulingProperties).isSchedulingGroupNodeOnly();
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(pod1).when(this.podIndexer).getByKey(KeyUtil.buildKey("ns1", "pod1"));
+        PodReconciler podReconciler = new PodReconciler(this.podIndexer, this.reconciliation, this.coreV1Api);
+        podReconciler.reconcile(new Request("ns1", "pod1"));
+        try {
+            Mockito.verify(this.coreV1Api).deleteNamespacedPod(
+                    Mockito.eq("pod1"),
+                    Mockito.eq("ns1"),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+        Mockito.verifyNoMoreInteractions(this.coreV1Api);
+    }
+
+    @Test
+    void given_pod_has_required_node_affinity_in_exclusive_mode_then_do_nothing() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1Pod pod1 = new V1Pod();
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        pod1.setMetadata(podMeta1);
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withRequiredDuringSchedulingIgnoredDuringExecution(
+                        new V1NodeSelectorBuilder().withNodeSelectorTerms(
+                                new V1NodeSelectorTermBuilder().withMatchExpressions(
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                .withOperator("In")
+                                                .withValues("group1").build()
+                                ).build()
+                        ).build()
+                ).build()
+        ).build();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        podSpec1.setAffinity(affinity1);
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
+        pod1.setSpec(podSpec1);
+
+        Mockito.doReturn(true).when(this.schedulingProperties).isSchedulingGroupNodeOnly();
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(pod1).when(this.podIndexer).getByKey(KeyUtil.buildKey("ns1", "pod1"));
+        PodReconciler podReconciler = new PodReconciler(this.podIndexer, this.reconciliation, this.coreV1Api);
+        podReconciler.reconcile(new Request("ns1", "pod1"));
+        try {
+            Mockito.verifyNoInteractions(this.coreV1Api);
+        } catch (Exception e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_pod_has_required_node_affinity_in_non_exclusive_mode_then_should_delete_pod() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1Pod pod1 = new V1Pod();
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        pod1.setMetadata(podMeta1);
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withRequiredDuringSchedulingIgnoredDuringExecution(
+                        new V1NodeSelectorBuilder().withNodeSelectorTerms(
+                                new V1NodeSelectorTermBuilder().withMatchExpressions(
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                .withOperator("In")
+                                                .withValues("group1").build()
+                                ).build()
+                        ).build()
+                ).build()
+        ).build();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        podSpec1.setAffinity(affinity1);
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
+        pod1.setSpec(podSpec1);
+
+        Mockito.doReturn(false).when(this.schedulingProperties).isSchedulingGroupNodeOnly();
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(pod1).when(this.podIndexer).getByKey(KeyUtil.buildKey("ns1", "pod1"));
+        PodReconciler podReconciler = new PodReconciler(this.podIndexer, this.reconciliation, this.coreV1Api);
+        podReconciler.reconcile(new Request("ns1", "pod1"));
+        try {
+            Mockito.verify(this.coreV1Api).deleteNamespacedPod(
+                    Mockito.eq("pod1"),
+                    Mockito.eq("ns1"),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+        Mockito.verifyNoMoreInteractions(this.coreV1Api);
+    }
+
+}

--- a/src/test/java/io/ten1010/coaster/groupcontroller/mutating/AdmissionReviewServiceTest.java
+++ b/src/test/java/io/ten1010/coaster/groupcontroller/mutating/AdmissionReviewServiceTest.java
@@ -9,6 +9,7 @@ import io.kubernetes.client.informer.cache.Indexer;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.ten1010.coaster.groupcontroller.configuration.property.SchedulingProperties;
 import io.ten1010.coaster.groupcontroller.controller.Reconciliation;
 import io.ten1010.coaster.groupcontroller.core.IndexNames;
 import io.ten1010.coaster.groupcontroller.model.V1Beta1ResourceGroup;
@@ -27,11 +28,13 @@ class AdmissionReviewServiceTest {
 
     Indexer<V1Beta1ResourceGroup> groupIndexer;
     Reconciliation reconciliation;
+    SchedulingProperties schedulingProperties;
 
     @BeforeEach
     void setUp() {
         this.groupIndexer = Mockito.mock(Indexer.class);
-        this.reconciliation = new Reconciliation(this.groupIndexer);
+        this.schedulingProperties = Mockito.mock(SchedulingProperties.class);
+        this.reconciliation = new Reconciliation(this.groupIndexer, this.schedulingProperties);
     }
 
     @Test


### PR DESCRIPTION
## Motivation
- configuration property에 따라 scheduling mode를 달리 할 수 있도록 하였습니다.
- ConfigMap에 pod scheduling을 위한 값을 추가하였습니다. 
  - 기본값을 true로 하여 exclusive pod scheduling되도록 하였습니다.
- Configuration Property 관리를 위한 디렉터리 및 클래스를 추가하였습니다.
- Preferred Node Affinity 생성을 위한 weight 상수를 추가하였습니다.
- Reconciliation에서 nodeAffinity reconcile 기능을 추가하였습니다.
- NodeAffinity에 따른 pod scheduling 검증을 위한 테스트코드를 추가하였습니다.


## Key Changes
- kustomization.yaml
  - APP_SCHEDULING_GROUP_NODE_ONLY property 추가

- ControllerConfiguration.java
  - Reconciliation에 SchedulingProperties 주입

- KubernetesConfiguration.java
  - 기존의 KubernetesClientProperties 삭제 및 configuration/property 디렉터리로 이동

- configuration/property
  - KubernetesClientProperties, SchedulingProperties 클래스 추가

- Reconciliation.java
  - SchedulingProperties 필드 추가 및 주입
  - NodeAffinity reconcile 메소드 구현
  - scheduling properties에 따른 node affinity 로직 분기
  - PreferredSchedulingTerm을 위한 WEIGHT 상수 추가
 
- resource/application.properties
  - app.scheduling-group-node-only 프로퍼티 추가

- NodeReconcilerTest.java
  - 불필요한 개행 제거

- PodReconcilerTest.java
  - SchedulingProperties 필드 추가
  - 기존 테스트 케이스에 대해 Affinity 검증로직 추가
  - Affinity reconcilation에 대한 테스트케이스 추가
    - given_pod_has_proper_node_affinity_then_do_nothing()
      - 주어진 파드가 적절한 affinity를 지닌 경우, reconcile이 일어나지 않음을 검증하는 케이스 
    - given_pod_has_no_tolerations_and_affinity_when_groups_not_exist_then_do_nothing()
      - 주어진 파드가 affinity와 toleration이 없는 경우, 해당 파드를 삭제하는 케이스
    - given_pod_has_preferred_node_affinity_in_exclusive_mode_then_should_delete_pod()
      - exclusive mode에서 주어진 파드가 preferred affinity를 지닌 경우, 해당 파드를 삭제하는 케이스
    - given_pod_has_preferred_node_affinity_in_non_exclusive_mode_then_do_nothing()
      - non-exclusive mode에서 주어진 파드가 preferred affinity를 지닌 경우, reconcile이 일어나지 않음을 검증하는 케이스
    - given_pod_has_required_node_affinity_in_exclusive_mode_then_do_nothing()
      - exclusive mode에서 주어진 파드가 required affinity를 지닌 경우, reconcile이 일어나지 않음을 검증하는 케이스
    - given_pod_has_required_node_affinity_in_non_exclusive_mode_then_should_delete_pod()
        - non-exclusive mode에서 주어진 파드가 required affinity를 지닌 경우, 해당 파드를 삭제하는 케이스

## To Reviewers
- 1개의 control plane, 2개의 워커노드로 구성된 클러스터 E2E테스트 환경에서 아래의 사항을 확인하였습니다.
  - Configuration Property에 따라 pod scheduling이 달리 됨을 확인하였습니다.
    - 기본적으로 exclusive mode로 pod scheduling이 일어나며, 파드에 required node affinity가 추가됨
    - APP_SCHEDULING_GROUP_NODE_ONLY가 false라면 non-exclusive mode로 파드에 preferred node affinity가 추가됨

## Concerns
- Reconciliation클래스 내부에서 SchedulingProperties를 참조하는 방식과 구조에 대해 고민하였습니다. 현재 reconcileAffinity()가 private static으로 선언되어 직접 참조할 수 없기에, 공개되어있는 reconcileUncontrolledAffinity() 내부에서 SchedulingProperties를 참조하여 reconcileAffinity()를 호출하도록 하였습니다.

