### PR TITLE
fix: mutating webhook should operate when updating

### DIFF
--- a/kubernetes/controller/templates/mutating-webhook-configuration.yaml
+++ b/kubernetes/controller/templates/mutating-webhook-configuration.yaml
@@ -20,17 +20,17 @@ webhooks:
     rules:
       - apiGroups:   [""]
         apiVersions: ["v1"]
-        operations:  ["CREATE"]
+        operations:  [ "CREATE", "UPDATE" ]
         resources:   ["pods", "replicationcontrollers"]
         scope: "*"
       - apiGroups: [ "batch" ]
         apiVersions: [ "v1" ]
-        operations: [ "CREATE" ]
+        operations: [ "CREATE", "UPDATE" ]
         resources: [ "cronjobs", "jobs" ]
         scope: "*"
       - apiGroups: [ "apps" ]
         apiVersions: [ "v1" ]
-        operations: [ "CREATE" ]
+        operations: [ "CREATE", "UPDATE" ]
         resources: [ "daemonsets", "deployments", "replicasets", "statefulsets" ]
         scope: "*"
     sideEffects: None


### PR DESCRIPTION
## Motivation

리소스가 업데이트될 때 mutating webhook 을 거치지 않음

## Key Changes

- mutating-webhook-configuration.yaml 의 operations 에 UPDATE 추가