### PR TITLE
chore: write workload reconciler test codes

### DIFF
--- a/src/main/java/io/ten1010/coaster/groupcontroller/controller/workload/replicationcontroller/ReplicationControllerReconciler.java
+++ b/src/main/java/io/ten1010/coaster/groupcontroller/controller/workload/replicationcontroller/ReplicationControllerReconciler.java
@@ -97,6 +97,7 @@ public class ReplicationControllerReconciler implements Reconciler {
                 .editTemplate()
                 .editSpec()
                 .withAffinity(affinity)
+                .withTolerations(tolerations)
                 .endSpec()
                 .endTemplate()
                 .endSpec()

--- a/src/test/java/io/ten1010/coaster/groupcontroller/controller/workload/cronjob/CronJobReconcilerTest.java
+++ b/src/test/java/io/ten1010/coaster/groupcontroller/controller/workload/cronjob/CronJobReconcilerTest.java
@@ -1,0 +1,362 @@
+package io.ten1010.coaster.groupcontroller.controller.workload.cronjob;
+
+import io.kubernetes.client.extended.controller.reconciler.Request;
+import io.kubernetes.client.informer.cache.Indexer;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.BatchV1Api;
+import io.kubernetes.client.openapi.models.*;
+import io.ten1010.coaster.groupcontroller.controller.Reconciliation;
+import io.ten1010.coaster.groupcontroller.core.IndexNames;
+import io.ten1010.coaster.groupcontroller.core.KeyUtil;
+import io.ten1010.coaster.groupcontroller.core.Labels;
+import io.ten1010.coaster.groupcontroller.core.Taints;
+import io.ten1010.coaster.groupcontroller.model.V1Beta1ResourceGroup;
+import io.ten1010.coaster.groupcontroller.model.V1Beta1ResourceGroupSpec;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class CronJobReconcilerTest {
+
+    Indexer<V1CronJob> cronJobIndexer;
+    Indexer<V1Beta1ResourceGroup> groupIndexer;
+    Reconciliation reconciliation;
+    BatchV1Api batchV1Api;
+
+    @BeforeEach
+    void setUp() {
+        this.cronJobIndexer = Mockito.mock(Indexer.class);
+        this.groupIndexer = Mockito.mock(Indexer.class);
+        this.reconciliation = new Reconciliation(this.groupIndexer);
+        this.batchV1Api = Mockito.mock(BatchV1Api.class);
+    }
+
+    @Test
+    void given_cronjob_does_not_have_toleration_and_affinity_when_it_belongs_to_the_resource_group_then_should_update_cronjob() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1CronJob cronJob1 = new V1CronJob();
+        V1ObjectMeta cronJobMeta1 = new V1ObjectMeta();
+        cronJobMeta1.setNamespace("ns1");
+        cronJobMeta1.setName("cronjob1");
+        cronJob1.setMetadata(cronJobMeta1);
+        V1CronJobSpec cronJobSpec1 = new V1CronJobSpec();
+        V1JobTemplateSpec jobTemplateSpec1 = new V1JobTemplateSpec();
+        V1ObjectMeta jobMeta1 = new V1ObjectMeta();
+        jobMeta1.setNamespace("ns1");
+        jobMeta1.setName("cj1");
+        jobTemplateSpec1.setMetadata(jobMeta1);
+        V1JobSpec jobSpec1 = new V1JobSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        podTemplateSpec1.setSpec(podSpec1);
+        jobSpec1.setTemplate(podTemplateSpec1);
+        jobTemplateSpec1.setSpec(jobSpec1);
+        cronJobSpec1.setJobTemplate(jobTemplateSpec1);
+        cronJob1.setSpec(cronJobSpec1);
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(cronJob1).when(this.cronJobIndexer).getByKey(KeyUtil.buildKey("ns1", "cronjob1"));
+        CronJobReconciler cronJobReconciler = new CronJobReconciler(this.cronJobIndexer, this.reconciliation, this.batchV1Api);
+        cronJobReconciler.reconcile(new Request("ns1", "cronjob1"));
+        try {
+            Mockito.verify(this.batchV1Api).replaceNamespacedCronJob(
+                    Mockito.eq("cronjob1"),
+                    Mockito.eq("ns1"),
+                    Mockito.argThat(cronJob -> {
+                        List<String> tolerationValues = cronJob.getSpec().getJobTemplate().getSpec()
+                                .getTemplate().getSpec().getTolerations().stream()
+                                .filter(e -> {
+                                    if (e.getKey() == null) {
+                                        return false;
+                                    }
+                                    return e.getKey().equals(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE);
+                                })
+                                .map(V1Toleration::getValue)
+                                .collect(Collectors.toList());
+                        Set<String> valueSet = new HashSet<>(tolerationValues);
+                        if (!valueSet.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        Set<String> affinityValues = cronJob.getSpec().getJobTemplate().getSpec()
+                                .getTemplate().getSpec().getAffinity().getNodeAffinity()
+                                .getRequiredDuringSchedulingIgnoredDuringExecution().getNodeSelectorTerms().stream()
+                                .flatMap(nst -> nst.getMatchExpressions().stream())
+                                .filter(nsr -> nsr.getKey().equals(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE))
+                                .flatMap(nsr -> nsr.getValues().stream())
+                                .collect(Collectors.toSet());
+                        if (!affinityValues.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        return true;
+                    }),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.batchV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_cronjob_does_not_have_toleration_when_it_belongs_to_the_resource_group_then_should_update_cronjob() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1CronJob cronJob1 = new V1CronJob();
+        V1ObjectMeta cronJobMeta1 = new V1ObjectMeta();
+        cronJobMeta1.setNamespace("ns1");
+        cronJobMeta1.setName("cronjob1");
+        cronJob1.setMetadata(cronJobMeta1);
+        V1CronJobSpec cronJobSpec1 = new V1CronJobSpec();
+        V1JobTemplateSpec jobTemplateSpec1 = new V1JobTemplateSpec();
+        V1ObjectMeta jobMeta1 = new V1ObjectMeta();
+        jobMeta1.setNamespace("ns1");
+        jobMeta1.setName("cj1");
+        jobTemplateSpec1.setMetadata(jobMeta1);
+        V1JobSpec jobSpec1 = new V1JobSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withRequiredDuringSchedulingIgnoredDuringExecution(
+                        new V1NodeSelectorBuilder().withNodeSelectorTerms(
+                                new V1NodeSelectorTermBuilder().withMatchExpressions(
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                .withOperator("In")
+                                                .withValues("group1")
+                                                .build()
+                                ).build()
+                        ).build()
+                ).build()
+        ).build();
+        podSpec1.setAffinity(affinity1);
+        podTemplateSpec1.setSpec(podSpec1);
+        jobSpec1.setTemplate(podTemplateSpec1);
+        jobTemplateSpec1.setSpec(jobSpec1);
+        cronJobSpec1.setJobTemplate(jobTemplateSpec1);
+        cronJob1.setSpec(cronJobSpec1);
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(cronJob1).when(this.cronJobIndexer).getByKey(KeyUtil.buildKey("ns1", "cronjob1"));
+        CronJobReconciler cronJobReconciler = new CronJobReconciler(this.cronJobIndexer, this.reconciliation, this.batchV1Api);
+        cronJobReconciler.reconcile(new Request("ns1", "cronjob1"));
+        try {
+            Mockito.verify(this.batchV1Api).replaceNamespacedCronJob(
+                    Mockito.eq("cronjob1"),
+                    Mockito.eq("ns1"),
+                    Mockito.argThat(cronJob -> {
+                        List<String> tolerationValues = cronJob.getSpec().getJobTemplate().getSpec()
+                                .getTemplate().getSpec().getTolerations().stream()
+                                .filter(e -> {
+                                    if (e.getKey() == null) {
+                                        return false;
+                                    }
+                                    return e.getKey().equals(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE);
+                                })
+                                .map(V1Toleration::getValue)
+                                .collect(Collectors.toList());
+                        Set<String> valueSet = new HashSet<>(tolerationValues);
+                        if (!valueSet.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        Set<String> affinityValues = cronJob.getSpec().getJobTemplate().getSpec()
+                                .getTemplate().getSpec().getAffinity().getNodeAffinity()
+                                .getRequiredDuringSchedulingIgnoredDuringExecution().getNodeSelectorTerms().stream()
+                                .flatMap(nst -> nst.getMatchExpressions().stream())
+                                .filter(nsr -> nsr.getKey().equals(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE))
+                                .flatMap(nsr -> nsr.getValues().stream())
+                                .collect(Collectors.toSet());
+                        if (!affinityValues.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        return true;
+                    }),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.batchV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_cronjob_does_not_have_affinity_when_it_belongs_to_the_resource_group_then_should_update_cronjob() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1CronJob cronJob1 = new V1CronJob();
+        V1ObjectMeta cronJobMeta1 = new V1ObjectMeta();
+        cronJobMeta1.setNamespace("ns1");
+        cronJobMeta1.setName("cronjob1");
+        cronJob1.setMetadata(cronJobMeta1);
+        V1CronJobSpec cronJobSpec1 = new V1CronJobSpec();
+        V1JobTemplateSpec jobTemplateSpec1 = new V1JobTemplateSpec();
+        V1ObjectMeta jobMeta1 = new V1ObjectMeta();
+        jobMeta1.setNamespace("ns1");
+        jobMeta1.setName("cj1");
+        jobTemplateSpec1.setMetadata(jobMeta1);
+        V1JobSpec jobSpec1 = new V1JobSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
+        podTemplateSpec1.setSpec(podSpec1);
+        jobSpec1.setTemplate(podTemplateSpec1);
+        jobTemplateSpec1.setSpec(jobSpec1);
+        cronJobSpec1.setJobTemplate(jobTemplateSpec1);
+        cronJob1.setSpec(cronJobSpec1);
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(cronJob1).when(this.cronJobIndexer).getByKey(KeyUtil.buildKey("ns1", "cronjob1"));
+        CronJobReconciler cronJobReconciler = new CronJobReconciler(this.cronJobIndexer, this.reconciliation, this.batchV1Api);
+        cronJobReconciler.reconcile(new Request("ns1", "cronjob1"));
+        try {
+            Mockito.verify(this.batchV1Api).replaceNamespacedCronJob(
+                    Mockito.eq("cronjob1"),
+                    Mockito.eq("ns1"),
+                    Mockito.argThat(cronJob -> {
+                        List<String> tolerationValues = cronJob.getSpec().getJobTemplate().getSpec()
+                                .getTemplate().getSpec().getTolerations().stream()
+                                .filter(e -> {
+                                    if (e.getKey() == null) {
+                                        return false;
+                                    }
+                                    return e.getKey().equals(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE);
+                                })
+                                .map(V1Toleration::getValue)
+                                .collect(Collectors.toList());
+                        Set<String> valueSet = new HashSet<>(tolerationValues);
+                        if (!valueSet.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        Set<String> affinityValues = cronJob.getSpec().getJobTemplate().getSpec()
+                                .getTemplate().getSpec().getAffinity().getNodeAffinity()
+                                .getRequiredDuringSchedulingIgnoredDuringExecution().getNodeSelectorTerms().stream()
+                                .flatMap(nst -> nst.getMatchExpressions().stream())
+                                .filter(nsr -> nsr.getKey().equals(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE))
+                                .flatMap(nsr -> nsr.getValues().stream())
+                                .collect(Collectors.toSet());
+                        if (!affinityValues.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        return true;
+                    }),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.batchV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_cronjob_has_unsupported_controller_then_should_delete_cronjob() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1CronJob cronJob1 = new V1CronJob();
+        V1ObjectMeta cronJobMeta1 = new V1ObjectMeta();
+        cronJobMeta1.setNamespace("ns1");
+        cronJobMeta1.setName("cronjob1");
+        cronJob1.setMetadata(cronJobMeta1);
+        V1CronJobSpec cronJobSpec1 = new V1CronJobSpec();
+        V1JobTemplateSpec jobTemplateSpec1 = new V1JobTemplateSpec();
+        V1ObjectMeta jobMeta1 = new V1ObjectMeta();
+        jobMeta1.setNamespace("ns1");
+        jobMeta1.setName("cj1");
+        jobTemplateSpec1.setMetadata(jobMeta1);
+        V1JobSpec jobSpec1 = new V1JobSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withRequiredDuringSchedulingIgnoredDuringExecution(
+                        new V1NodeSelectorBuilder().withNodeSelectorTerms(
+                                new V1NodeSelectorTermBuilder().withMatchExpressions(
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                .withOperator("In")
+                                                .withValues("group1")
+                                                .build()
+                                ).build()
+                        ).build()
+                ).build()
+        ).build();
+        podSpec1.setAffinity(affinity1);
+        podTemplateSpec1.setSpec(podSpec1);
+        jobSpec1.setTemplate(podTemplateSpec1);
+        jobTemplateSpec1.setSpec(jobSpec1);
+        cronJobSpec1.setJobTemplate(jobTemplateSpec1);
+        cronJob1.setSpec(cronJobSpec1);
+        V1OwnerReference ownerReference1 = new V1OwnerReference();
+        ownerReference1.setApiVersion("v1");
+        ownerReference1.setKind("dummy");
+        ownerReference1.setController(true);
+        cronJob1.getMetadata().setOwnerReferences(List.of(ownerReference1));
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(cronJob1).when(this.cronJobIndexer).getByKey(KeyUtil.buildKey("ns1", "cronjob1"));
+        CronJobReconciler cronJobReconciler = new CronJobReconciler(this.cronJobIndexer, this.reconciliation, this.batchV1Api);
+        cronJobReconciler.reconcile(new Request("ns1", "cronjob1"));
+        try {
+            Mockito.verify(this.batchV1Api).deleteNamespacedCronJob(
+                    Mockito.eq("cronjob1"),
+                    Mockito.eq("ns1"),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.batchV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+}

--- a/src/test/java/io/ten1010/coaster/groupcontroller/controller/workload/deployment/DeploymentReconcilerTest.java
+++ b/src/test/java/io/ten1010/coaster/groupcontroller/controller/workload/deployment/DeploymentReconcilerTest.java
@@ -1,0 +1,341 @@
+package io.ten1010.coaster.groupcontroller.controller.workload.deployment;
+
+import io.kubernetes.client.extended.controller.reconciler.Request;
+import io.kubernetes.client.informer.cache.Indexer;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.AppsV1Api;
+import io.kubernetes.client.openapi.models.*;
+import io.ten1010.coaster.groupcontroller.controller.Reconciliation;
+import io.ten1010.coaster.groupcontroller.core.IndexNames;
+import io.ten1010.coaster.groupcontroller.core.KeyUtil;
+import io.ten1010.coaster.groupcontroller.core.Labels;
+import io.ten1010.coaster.groupcontroller.core.Taints;
+import io.ten1010.coaster.groupcontroller.model.V1Beta1ResourceGroup;
+import io.ten1010.coaster.groupcontroller.model.V1Beta1ResourceGroupSpec;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class DeploymentReconcilerTest {
+
+    Indexer<V1Deployment> deploymentIndexer;
+    Indexer<V1Beta1ResourceGroup> groupIndexer;
+    Reconciliation reconciliation;
+    AppsV1Api appsV1Api;
+
+    @BeforeEach
+    void setUp() {
+        this.deploymentIndexer = Mockito.mock(Indexer.class);
+        this.groupIndexer = Mockito.mock(Indexer.class);
+        this.reconciliation = new Reconciliation(this.groupIndexer);
+        this.appsV1Api = Mockito.mock(AppsV1Api.class);
+    }
+
+    @Test
+    void given_deployment_does_not_have_toleration_and_affinity_when_it_belongs_to_the_resource_group_then_should_update_deployment() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1Deployment deployment1 = new V1Deployment();
+        V1DeploymentSpec deploymentSpec1 = new V1DeploymentSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        podTemplateSpec1.setSpec(new V1PodSpec());
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        podTemplateSpec1.setMetadata(podMeta1);
+        V1ObjectMeta deploymentMeta1 = new V1ObjectMeta();
+        deploymentMeta1.setNamespace("ns1");
+        deploymentMeta1.setName("deployment1");
+        deployment1.setMetadata(deploymentMeta1);
+        deploymentSpec1.setTemplate(podTemplateSpec1);
+        deployment1.setSpec(deploymentSpec1);
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(deployment1).when(this.deploymentIndexer).getByKey(KeyUtil.buildKey("ns1", "deployment1"));
+        DeploymentReconciler deploymentReconciler = new DeploymentReconciler(this.deploymentIndexer, this.reconciliation, this.appsV1Api);
+        deploymentReconciler.reconcile(new Request("ns1", "deployment1"));
+        try {
+            Mockito.verify(this.appsV1Api).replaceNamespacedDeployment(
+                    Mockito.eq("deployment1"),
+                    Mockito.eq("ns1"),
+                    Mockito.argThat(deployment -> {
+                        List<String> tolerationValues = deployment.getSpec().getTemplate().getSpec().getTolerations().stream()
+                                .filter(e -> {
+                                    if (e.getKey() == null) {
+                                        return false;
+                                    }
+                                    return e.getKey().equals(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE);
+                                })
+                                .map(V1Toleration::getValue)
+                                .collect(Collectors.toList());
+                        Set<String> valueSet = new HashSet<>(tolerationValues);
+                        if (!valueSet.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        Set<String> affinityValues = deployment.getSpec().getTemplate().getSpec().getAffinity()
+                                .getNodeAffinity().getRequiredDuringSchedulingIgnoredDuringExecution().getNodeSelectorTerms().stream()
+                                .flatMap(nst -> nst.getMatchExpressions().stream())
+                                .filter(nsr -> nsr.getKey().equals(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE))
+                                .flatMap(nsr -> nsr.getValues().stream())
+                                .collect(Collectors.toSet());
+                        if (!affinityValues.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        return true;
+                    }),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.appsV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_deployment_does_not_have_toleration_when_it_belongs_to_the_resource_group_then_should_update_deployment() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1Deployment deployment1 = new V1Deployment();
+        V1DeploymentSpec deploymentSpec1 = new V1DeploymentSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withRequiredDuringSchedulingIgnoredDuringExecution(
+                        new V1NodeSelectorBuilder().withNodeSelectorTerms(
+                                new V1NodeSelectorTermBuilder().withMatchExpressions(
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                .withOperator("In")
+                                                .withValues("group1")
+                                                .build()
+                                ).build()
+                        ).build()
+                ).build()
+        ).build();
+        podSpec1.setAffinity(affinity1);
+        podTemplateSpec1.setSpec(new V1PodSpec());
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        podTemplateSpec1.setMetadata(podMeta1);
+        V1ObjectMeta deploymentMeta1 = new V1ObjectMeta();
+        deploymentMeta1.setNamespace("ns1");
+        deploymentMeta1.setName("deployment1");
+        deployment1.setMetadata(deploymentMeta1);
+        deploymentSpec1.setTemplate(podTemplateSpec1);
+        deployment1.setSpec(deploymentSpec1);
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(deployment1).when(this.deploymentIndexer).getByKey(KeyUtil.buildKey("ns1", "deployment1"));
+        DeploymentReconciler deploymentReconciler = new DeploymentReconciler(this.deploymentIndexer, this.reconciliation, this.appsV1Api);
+        deploymentReconciler.reconcile(new Request("ns1", "deployment1"));
+        try {
+            Mockito.verify(this.appsV1Api).replaceNamespacedDeployment(
+                    Mockito.eq("deployment1"),
+                    Mockito.eq("ns1"),
+                    Mockito.argThat(deployment -> {
+                        List<String> tolerationValues = deployment.getSpec().getTemplate().getSpec().getTolerations().stream()
+                                .filter(e -> {
+                                    if (e.getKey() == null) {
+                                        return false;
+                                    }
+                                    return e.getKey().equals(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE);
+                                })
+                                .map(V1Toleration::getValue)
+                                .collect(Collectors.toList());
+                        Set<String> valueSet = new HashSet<>(tolerationValues);
+                        if (!valueSet.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        Set<String> affinityValues = deployment.getSpec().getTemplate().getSpec().getAffinity()
+                                .getNodeAffinity().getRequiredDuringSchedulingIgnoredDuringExecution().getNodeSelectorTerms().stream()
+                                .flatMap(nst -> nst.getMatchExpressions().stream())
+                                .filter(nsr -> nsr.getKey().equals(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE))
+                                .flatMap(nsr -> nsr.getValues().stream())
+                                .collect(Collectors.toSet());
+                        if (!affinityValues.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        return true;
+                    }),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.appsV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_deployment_does_not_have_affinity_when_it_belongs_to_the_resource_group_then_should_update_deployment() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1Deployment deployment1 = new V1Deployment();
+        V1DeploymentSpec deploymentSpec1 = new V1DeploymentSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        V1Affinity affinity1 = new V1Affinity();
+        podSpec1.setAffinity(affinity1);
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
+        podTemplateSpec1.setSpec(podSpec1);
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        podTemplateSpec1.setMetadata(podMeta1);
+        V1ObjectMeta deploymentMeta1 = new V1ObjectMeta();
+        deploymentMeta1.setNamespace("ns1");
+        deploymentMeta1.setName("deployment1");
+        deployment1.setMetadata(deploymentMeta1);
+        deploymentSpec1.setTemplate(podTemplateSpec1);
+        deployment1.setSpec(deploymentSpec1);
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(deployment1).when(this.deploymentIndexer).getByKey(KeyUtil.buildKey("ns1", "deployment1"));
+        DeploymentReconciler deploymentReconciler = new DeploymentReconciler(this.deploymentIndexer, this.reconciliation, this.appsV1Api);
+        deploymentReconciler.reconcile(new Request("ns1", "deployment1"));
+        try {
+            Mockito.verify(this.appsV1Api).replaceNamespacedDeployment(
+                    Mockito.eq("deployment1"),
+                    Mockito.eq("ns1"),
+                    Mockito.argThat(deployment -> {
+                        List<String> tolerationValues = deployment.getSpec().getTemplate().getSpec().getTolerations().stream()
+                                .filter(e -> {
+                                    if (e.getKey() == null) {
+                                        return false;
+                                    }
+                                    return e.getKey().equals(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE);
+                                })
+                                .map(V1Toleration::getValue)
+                                .collect(Collectors.toList());
+                        Set<String> valueSet = new HashSet<>(tolerationValues);
+                        if (!valueSet.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        Set<String> affinityValues = deployment.getSpec().getTemplate().getSpec().getAffinity()
+                                .getNodeAffinity().getRequiredDuringSchedulingIgnoredDuringExecution().getNodeSelectorTerms().stream()
+                                .flatMap(nst -> nst.getMatchExpressions().stream())
+                                .filter(nsr -> nsr.getKey().equals(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE))
+                                .flatMap(nsr -> nsr.getValues().stream())
+                                .collect(Collectors.toSet());
+                        if (!affinityValues.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        return true;
+                    }),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.appsV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_deployment_has_unsupported_controller_then_should_delete_deployment() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1Deployment deployment1 = new V1Deployment();
+        V1DeploymentSpec deploymentSpec1 = new V1DeploymentSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withRequiredDuringSchedulingIgnoredDuringExecution(
+                        new V1NodeSelectorBuilder().withNodeSelectorTerms(
+                                new V1NodeSelectorTermBuilder().withMatchExpressions(
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                .withOperator("In")
+                                                .withValues("group1")
+                                                .build()
+                                ).build()
+                        ).build()
+                ).build()
+        ).build();
+        podSpec1.setAffinity(affinity1);
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
+        podTemplateSpec1.setSpec(podSpec1);
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        podTemplateSpec1.setMetadata(podMeta1);
+        V1ObjectMeta deploymentMeta1 = new V1ObjectMeta();
+        deploymentMeta1.setNamespace("ns1");
+        deploymentMeta1.setName("deployment1");
+        deployment1.setMetadata(deploymentMeta1);
+        deploymentSpec1.setTemplate(podTemplateSpec1);
+        deployment1.setSpec(deploymentSpec1);
+        V1OwnerReference ownerReference1 = new V1OwnerReference();
+        ownerReference1.setApiVersion("v1");
+        ownerReference1.setKind("dummy");
+        ownerReference1.setController(true);
+        deployment1.getMetadata().setOwnerReferences(List.of(ownerReference1));
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(deployment1).when(this.deploymentIndexer).getByKey(KeyUtil.buildKey("ns1", "deployment1"));
+        DeploymentReconciler deploymentReconciler = new DeploymentReconciler(this.deploymentIndexer, this.reconciliation, this.appsV1Api);
+        deploymentReconciler.reconcile(new Request("ns1", "deployment1"));
+        try {
+            Mockito.verify(this.appsV1Api).deleteNamespacedDeployment(
+                    Mockito.eq("deployment1"),
+                    Mockito.eq("ns1"),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.appsV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+}

--- a/src/test/java/io/ten1010/coaster/groupcontroller/controller/workload/job/JobReconcilerTest.java
+++ b/src/test/java/io/ten1010/coaster/groupcontroller/controller/workload/job/JobReconcilerTest.java
@@ -1,0 +1,252 @@
+package io.ten1010.coaster.groupcontroller.controller.workload.job;
+
+import io.kubernetes.client.extended.controller.reconciler.Request;
+import io.kubernetes.client.informer.cache.Indexer;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.BatchV1Api;
+import io.kubernetes.client.openapi.models.*;
+import io.ten1010.coaster.groupcontroller.controller.Reconciliation;
+import io.ten1010.coaster.groupcontroller.core.IndexNames;
+import io.ten1010.coaster.groupcontroller.core.KeyUtil;
+import io.ten1010.coaster.groupcontroller.core.Labels;
+import io.ten1010.coaster.groupcontroller.core.Taints;
+import io.ten1010.coaster.groupcontroller.model.V1Beta1ResourceGroup;
+import io.ten1010.coaster.groupcontroller.model.V1Beta1ResourceGroupSpec;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+public class JobReconcilerTest {
+
+    Indexer<V1Job> jobIndexer;
+    Indexer<V1Beta1ResourceGroup> groupIndexer;
+    Reconciliation reconciliation;
+    BatchV1Api batchV1Api;
+
+    @BeforeEach
+    void setUp() {
+        this.jobIndexer = Mockito.mock(Indexer.class);
+        this.groupIndexer = Mockito.mock(Indexer.class);
+        this.reconciliation = new Reconciliation(this.groupIndexer);
+        this.batchV1Api = Mockito.mock(BatchV1Api.class);
+    }
+
+    @Test
+    void given_job_does_not_have_toleration_and_affinity_when_it_belongs_to_the_resource_group_then_should_delete_job() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1Job job1 = new V1Job();
+        V1ObjectMeta jobMeta1 = new V1ObjectMeta();
+        jobMeta1.setNamespace("ns1");
+        jobMeta1.setName("job1");
+        job1.setMetadata(jobMeta1);
+        V1JobSpec jobSpec1 = new V1JobSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        podTemplateSpec1.setSpec(podSpec1);
+        jobSpec1.setTemplate(podTemplateSpec1);
+        job1.setSpec(jobSpec1);
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(job1).when(this.jobIndexer).getByKey(KeyUtil.buildKey("ns1", "job1"));
+        JobReconciler jobReconciler = new JobReconciler(this.jobIndexer, this.reconciliation, this.batchV1Api);
+        jobReconciler.reconcile(new Request("ns1", "job1"));
+        try {
+            Mockito.verify(this.batchV1Api).deleteNamespacedJob(
+                    Mockito.eq("job1"),
+                    Mockito.eq("ns1"),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.batchV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_job_does_not_have_toleration_when_it_belongs_to_the_resource_group_then_should_delete_job() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1Job job1 = new V1Job();
+        V1ObjectMeta jobMeta1 = new V1ObjectMeta();
+        jobMeta1.setNamespace("ns1");
+        jobMeta1.setName("job1");
+        job1.setMetadata(jobMeta1);
+        V1JobSpec jobSpec1 = new V1JobSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withRequiredDuringSchedulingIgnoredDuringExecution(
+                        new V1NodeSelectorBuilder().withNodeSelectorTerms(
+                                new V1NodeSelectorTermBuilder().withMatchExpressions(
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                .withOperator("In")
+                                                .withValues("group1")
+                                                .build()
+                                ).build()
+                        ).build()
+                ).build()
+        ).build();
+        podSpec1.setAffinity(affinity1);
+        podTemplateSpec1.setSpec(podSpec1);
+        jobSpec1.setTemplate(podTemplateSpec1);
+        job1.setSpec(jobSpec1);
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(job1).when(this.jobIndexer).getByKey(KeyUtil.buildKey("ns1", "job1"));
+        JobReconciler jobReconciler = new JobReconciler(this.jobIndexer, this.reconciliation, this.batchV1Api);
+        jobReconciler.reconcile(new Request("ns1", "job1"));
+        try {
+            Mockito.verify(this.batchV1Api).deleteNamespacedJob(
+                    Mockito.eq("job1"),
+                    Mockito.eq("ns1"),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.batchV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_job_does_not_have_affinity_when_it_belongs_to_the_resource_group_then_should_delete_job() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1Job job1 = new V1Job();
+        V1ObjectMeta jobMeta1 = new V1ObjectMeta();
+        jobMeta1.setNamespace("ns1");
+        jobMeta1.setName("job1");
+        job1.setMetadata(jobMeta1);
+        V1JobSpec jobSpec1 = new V1JobSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
+        podTemplateSpec1.setSpec(podSpec1);
+        jobSpec1.setTemplate(podTemplateSpec1);
+        job1.setSpec(jobSpec1);
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(job1).when(this.jobIndexer).getByKey(KeyUtil.buildKey("ns1", "job1"));
+        JobReconciler jobReconciler = new JobReconciler(this.jobIndexer, this.reconciliation, this.batchV1Api);
+        jobReconciler.reconcile(new Request("ns1", "job1"));
+        try {
+            Mockito.verify(this.batchV1Api).deleteNamespacedJob(
+                    Mockito.eq("job1"),
+                    Mockito.eq("ns1"),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.batchV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_job_has_unsupported_controller_then_should_delete_job() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1Job job1 = new V1Job();
+        V1ObjectMeta jobMeta1 = new V1ObjectMeta();
+        jobMeta1.setNamespace("ns1");
+        jobMeta1.setName("job1");
+        job1.setMetadata(jobMeta1);
+        V1JobSpec jobSpec1 = new V1JobSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withRequiredDuringSchedulingIgnoredDuringExecution(
+                        new V1NodeSelectorBuilder().withNodeSelectorTerms(
+                                new V1NodeSelectorTermBuilder().withMatchExpressions(
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                .withOperator("In")
+                                                .withValues("group1")
+                                                .build()
+                                ).build()
+                        ).build()
+                ).build()
+        ).build();
+        podSpec1.setAffinity(affinity1);
+        podTemplateSpec1.setSpec(podSpec1);
+        jobSpec1.setTemplate(podTemplateSpec1);
+        job1.setSpec(jobSpec1);
+        V1OwnerReference ownerReference1 = new V1OwnerReference();
+        ownerReference1.setApiVersion("v1");
+        ownerReference1.setKind("dummy");
+        ownerReference1.setController(true);
+        job1.getMetadata().setOwnerReferences(List.of(ownerReference1));
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(job1).when(this.jobIndexer).getByKey(KeyUtil.buildKey("ns1", "job1"));
+        JobReconciler jobReconciler = new JobReconciler(this.jobIndexer, this.reconciliation, this.batchV1Api);
+        jobReconciler.reconcile(new Request("ns1", "job1"));
+        try {
+            Mockito.verify(this.batchV1Api).deleteNamespacedJob(
+                    Mockito.eq("job1"),
+                    Mockito.eq("ns1"),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.batchV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+}

--- a/src/test/java/io/ten1010/coaster/groupcontroller/controller/workload/pod/PodReconcilerTest.java
+++ b/src/test/java/io/ten1010/coaster/groupcontroller/controller/workload/pod/PodReconcilerTest.java
@@ -197,6 +197,72 @@ class PodReconcilerTest {
     }
 
     @Test
+    void given_pod_has_toleration_which_has_no_key_and_effect_then_should_delete_pod() {
+        V1Pod pod1 = new V1Pod();
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        pod1.setMetadata(podMeta1);
+        V1PodSpec podSpec1 = new V1PodSpec();
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withValue("value1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(tolerationBuilder.build()));
+        pod1.setSpec(podSpec1);
+
+        Mockito.doReturn(pod1).when(this.podIndexer).getByKey(KeyUtil.buildKey("ns1", "pod1"));
+        PodReconciler podReconciler = new PodReconciler(this.podIndexer, this.reconciliation, this.coreV1Api);
+        podReconciler.reconcile(new Request("ns1", "pod1"));
+        try {
+            Mockito.verify(this.coreV1Api).deleteNamespacedPod(
+                    Mockito.eq("pod1"),
+                    Mockito.eq("ns1"),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+        Mockito.verifyNoMoreInteractions(this.coreV1Api);
+    }
+
+    @Test
+    void given_pod_has_toleration_which_its_effect_is_for_no_schedule_then_should_delete_pod() {
+        V1Pod pod1 = new V1Pod();
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        pod1.setMetadata(podMeta1);
+        V1PodSpec podSpec1 = new V1PodSpec();
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withValue("value1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
+        pod1.setSpec(podSpec1);
+
+        Mockito.doReturn(pod1).when(this.podIndexer).getByKey(KeyUtil.buildKey("ns1", "pod1"));
+        PodReconciler podReconciler = new PodReconciler(this.podIndexer, this.reconciliation, this.coreV1Api);
+        podReconciler.reconcile(new Request("ns1", "pod1"));
+        try {
+            Mockito.verify(this.coreV1Api).deleteNamespacedPod(
+                    Mockito.eq("pod1"),
+                    Mockito.eq("ns1"),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+        Mockito.verifyNoMoreInteractions(this.coreV1Api);
+    }
+
+    @Test
     void given_pod_does_not_have_any_affinities_then_should_delete_pod() {
         V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
         V1ObjectMeta meta1 = new V1ObjectMeta();

--- a/src/test/java/io/ten1010/coaster/groupcontroller/controller/workload/replicaset/ReplicaSetReconcilerTest.java
+++ b/src/test/java/io/ten1010/coaster/groupcontroller/controller/workload/replicaset/ReplicaSetReconcilerTest.java
@@ -1,0 +1,340 @@
+package io.ten1010.coaster.groupcontroller.controller.workload.replicaset;
+
+import io.kubernetes.client.extended.controller.reconciler.Request;
+import io.kubernetes.client.informer.cache.Indexer;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.AppsV1Api;
+import io.kubernetes.client.openapi.models.*;
+import io.ten1010.coaster.groupcontroller.controller.Reconciliation;
+import io.ten1010.coaster.groupcontroller.core.IndexNames;
+import io.ten1010.coaster.groupcontroller.core.KeyUtil;
+import io.ten1010.coaster.groupcontroller.core.Labels;
+import io.ten1010.coaster.groupcontroller.core.Taints;
+import io.ten1010.coaster.groupcontroller.model.V1Beta1ResourceGroup;
+import io.ten1010.coaster.groupcontroller.model.V1Beta1ResourceGroupSpec;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ReplicaSetReconcilerTest {
+
+    private Indexer<V1ReplicaSet> replicaSetIndexer;
+    private Indexer<V1Beta1ResourceGroup> groupIndexer;
+    private Reconciliation reconciliation;
+    private AppsV1Api appsV1Api;
+
+    @BeforeEach
+    void setUp() {
+        this.replicaSetIndexer = Mockito.mock(Indexer.class);
+        this.groupIndexer = Mockito.mock(Indexer.class);
+        this.reconciliation = new Reconciliation(this.groupIndexer);
+        this.appsV1Api = Mockito.mock(AppsV1Api.class);
+    }
+
+    @Test
+    void given_replicaset_does_not_have_toleration_and_affinity_when_it_belongs_to_resource_group_then_should_update_replicaset() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1ReplicaSet replicaSet1 = new V1ReplicaSet();
+        V1ObjectMeta rsMeta1 = new V1ObjectMeta();
+        rsMeta1.setName("rs1");
+        rsMeta1.setNamespace("ns1");
+        replicaSet1.setMetadata(rsMeta1);
+        V1ReplicaSetSpec rsSpec1 = new V1ReplicaSetSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        podTemplateSpec1.setSpec(podSpec1);
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        podTemplateSpec1.setMetadata(podMeta1);
+        rsSpec1.setTemplate(podTemplateSpec1);
+        replicaSet1.setSpec(rsSpec1);
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(replicaSet1).when(this.replicaSetIndexer).getByKey(KeyUtil.buildKey("ns1", "rs1"));
+        ReplicaSetReconciler replicaSetReconciler = new ReplicaSetReconciler(this.replicaSetIndexer, this.reconciliation, this.appsV1Api);
+        replicaSetReconciler.reconcile(new Request("ns1", "rs1"));
+        try {
+            Mockito.verify(this.appsV1Api).replaceNamespacedReplicaSet(
+                    Mockito.eq("rs1"),
+                    Mockito.eq("ns1"),
+                    Mockito.argThat(replicaSet -> {
+                        List<String> tolerationValues = replicaSet.getSpec().getTemplate().getSpec().getTolerations().stream()
+                                .filter(e -> {
+                                    if (e.getKey() == null) {
+                                        return false;
+                                    }
+                                    return e.getKey().equals(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE);
+                                })
+                                .map(V1Toleration::getValue)
+                                .collect(Collectors.toList());
+                        Set<String> valueSet = new HashSet<>(tolerationValues);
+                        if (!valueSet.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        Set<String> affinityValues = replicaSet.getSpec().getTemplate().getSpec().getAffinity()
+                                .getNodeAffinity().getRequiredDuringSchedulingIgnoredDuringExecution().getNodeSelectorTerms().stream()
+                                .flatMap(nst -> nst.getMatchExpressions().stream())
+                                .filter(nsr -> nsr.getKey().equals(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE))
+                                .flatMap(nsr -> nsr.getValues().stream())
+                                .collect(Collectors.toSet());
+                        if (!affinityValues.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        return true;
+                    }),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.appsV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_replicaset_does_not_have_toleration_when_it_belongs_to_the_resource_group_then_should_update_replicaset() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1ReplicaSet replicaSet1 = new V1ReplicaSet();
+        V1ObjectMeta rsMeta1 = new V1ObjectMeta();
+        rsMeta1.setName("rs1");
+        rsMeta1.setNamespace("ns1");
+        replicaSet1.setMetadata(rsMeta1);
+        V1ReplicaSetSpec rsSpec1 = new V1ReplicaSetSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withRequiredDuringSchedulingIgnoredDuringExecution(
+                        new V1NodeSelectorBuilder().withNodeSelectorTerms(
+                                new V1NodeSelectorTermBuilder().withMatchExpressions(
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                .withOperator("In")
+                                                .withValues("group1")
+                                                .build()
+                                ).build()
+                        ).build()
+                ).build()
+        ).build();
+        podSpec1.setAffinity(affinity1);
+        podTemplateSpec1.setSpec(podSpec1);
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        podTemplateSpec1.setMetadata(podMeta1);
+        rsSpec1.setTemplate(podTemplateSpec1);
+        replicaSet1.setSpec(rsSpec1);
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(replicaSet1).when(this.replicaSetIndexer).getByKey(KeyUtil.buildKey("ns1", "rs1"));
+        ReplicaSetReconciler replicaSetReconciler = new ReplicaSetReconciler(this.replicaSetIndexer, this.reconciliation, this.appsV1Api);
+        replicaSetReconciler.reconcile(new Request("ns1", "rs1"));
+        try {
+            Mockito.verify(this.appsV1Api).replaceNamespacedReplicaSet(
+                    Mockito.eq("rs1"),
+                    Mockito.eq("ns1"),
+                    Mockito.argThat(replicaSet -> {
+                        List<String> tolerationValues = replicaSet.getSpec().getTemplate().getSpec().getTolerations().stream()
+                                .filter(e -> {
+                                    if (e.getKey() == null) {
+                                        return false;
+                                    }
+                                    return e.getKey().equals(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE);
+                                })
+                                .map(V1Toleration::getValue)
+                                .collect(Collectors.toList());
+                        Set<String> valueSet = new HashSet<>(tolerationValues);
+                        if (!valueSet.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        Set<String> affinityValues = replicaSet.getSpec().getTemplate().getSpec().getAffinity()
+                                .getNodeAffinity().getRequiredDuringSchedulingIgnoredDuringExecution().getNodeSelectorTerms().stream()
+                                .flatMap(nst -> nst.getMatchExpressions().stream())
+                                .filter(nsr -> nsr.getKey().equals(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE))
+                                .flatMap(nsr -> nsr.getValues().stream())
+                                .collect(Collectors.toSet());
+                        if (!affinityValues.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        return true;
+                    }),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.appsV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_replicaset_does_not_have_affinity_when_it_belongs_to_resource_group_then_should_update_replicaset() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1ReplicaSet replicaSet1 = new V1ReplicaSet();
+        V1ObjectMeta rsMeta1 = new V1ObjectMeta();
+        rsMeta1.setName("rs1");
+        rsMeta1.setNamespace("ns1");
+        replicaSet1.setMetadata(rsMeta1);
+        V1ReplicaSetSpec rsSpec1 = new V1ReplicaSetSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
+        podTemplateSpec1.setSpec(podSpec1);
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        podTemplateSpec1.setMetadata(podMeta1);
+        rsSpec1.setTemplate(podTemplateSpec1);
+        replicaSet1.setSpec(rsSpec1);
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(replicaSet1).when(this.replicaSetIndexer).getByKey(KeyUtil.buildKey("ns1", "rs1"));
+        ReplicaSetReconciler replicaSetReconciler = new ReplicaSetReconciler(this.replicaSetIndexer, this.reconciliation, this.appsV1Api);
+        replicaSetReconciler.reconcile(new Request("ns1", "rs1"));
+        try {
+            Mockito.verify(this.appsV1Api).replaceNamespacedReplicaSet(
+                    Mockito.eq("rs1"),
+                    Mockito.eq("ns1"),
+                    Mockito.argThat(replicaSet -> {
+                        List<String> tolerationValues = replicaSet.getSpec().getTemplate().getSpec().getTolerations().stream()
+                                .filter(e -> {
+                                    if (e.getKey() == null) {
+                                        return false;
+                                    }
+                                    return e.getKey().equals(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE);
+                                })
+                                .map(V1Toleration::getValue)
+                                .collect(Collectors.toList());
+                        Set<String> valueSet = new HashSet<>(tolerationValues);
+                        if (!valueSet.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        Set<String> affinityValues = replicaSet.getSpec().getTemplate().getSpec().getAffinity()
+                                .getNodeAffinity().getRequiredDuringSchedulingIgnoredDuringExecution().getNodeSelectorTerms().stream()
+                                .flatMap(nst -> nst.getMatchExpressions().stream())
+                                .filter(nsr -> nsr.getKey().equals(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE))
+                                .flatMap(nsr -> nsr.getValues().stream())
+                                .collect(Collectors.toSet());
+                        if (!affinityValues.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        return true;
+                    }),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.appsV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_replicaset_has_unsupported_controller_then_should_delete_replicaset() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1ReplicaSet replicaSet1 = new V1ReplicaSet();
+        V1ObjectMeta rsMeta1 = new V1ObjectMeta();
+        rsMeta1.setName("rs1");
+        rsMeta1.setNamespace("ns1");
+        replicaSet1.setMetadata(rsMeta1);
+        V1ReplicaSetSpec rsSpec1 = new V1ReplicaSetSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withRequiredDuringSchedulingIgnoredDuringExecution(
+                        new V1NodeSelectorBuilder().withNodeSelectorTerms(
+                                new V1NodeSelectorTermBuilder().withMatchExpressions(
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                .withOperator("In")
+                                                .withValues("group1")
+                                                .build()
+                                ).build()
+                        ).build()
+                ).build()
+        ).build();
+        podSpec1.setAffinity(affinity1);
+        podTemplateSpec1.setSpec(podSpec1);
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        podTemplateSpec1.setMetadata(podMeta1);
+        rsSpec1.setTemplate(podTemplateSpec1);
+        replicaSet1.setSpec(rsSpec1);
+        V1OwnerReference ownerReference1 = new V1OwnerReference();
+        ownerReference1.setApiVersion("v1");
+        ownerReference1.setKind("Deployment");
+        ownerReference1.setController(true);
+        replicaSet1.getMetadata().setOwnerReferences(List.of(ownerReference1));
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(replicaSet1).when(this.replicaSetIndexer).getByKey(KeyUtil.buildKey("ns1", "rs1"));
+        ReplicaSetReconciler replicaSetReconciler = new ReplicaSetReconciler(this.replicaSetIndexer, this.reconciliation, this.appsV1Api);
+        replicaSetReconciler.reconcile(new Request("ns1", "rs1"));
+        try {
+            Mockito.verify(this.appsV1Api).deleteNamespacedReplicaSet(
+                    Mockito.eq("rs1"),
+                    Mockito.eq("ns1"),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.appsV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+}

--- a/src/test/java/io/ten1010/coaster/groupcontroller/controller/workload/replicationcontroller/ReplicationControllerReconcilerTest.java
+++ b/src/test/java/io/ten1010/coaster/groupcontroller/controller/workload/replicationcontroller/ReplicationControllerReconcilerTest.java
@@ -1,0 +1,339 @@
+package io.ten1010.coaster.groupcontroller.controller.workload.replicationcontroller;
+
+import io.kubernetes.client.extended.controller.reconciler.Request;
+import io.kubernetes.client.informer.cache.Indexer;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.*;
+import io.ten1010.coaster.groupcontroller.controller.Reconciliation;
+import io.ten1010.coaster.groupcontroller.core.IndexNames;
+import io.ten1010.coaster.groupcontroller.core.KeyUtil;
+import io.ten1010.coaster.groupcontroller.core.Labels;
+import io.ten1010.coaster.groupcontroller.core.Taints;
+import io.ten1010.coaster.groupcontroller.model.V1Beta1ResourceGroup;
+import io.ten1010.coaster.groupcontroller.model.V1Beta1ResourceGroupSpec;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ReplicationControllerReconcilerTest {
+
+    Indexer<V1ReplicationController> replicationControllerIndexer;
+    Indexer<V1Beta1ResourceGroup> groupIndexer;
+    Reconciliation reconciliation;
+    CoreV1Api coreV1Api;
+
+    @BeforeEach
+    void setUp() {
+        this.replicationControllerIndexer = Mockito.mock(Indexer.class);
+        this.groupIndexer = Mockito.mock(Indexer.class);
+        this.reconciliation = new Reconciliation(this.groupIndexer);
+        this.coreV1Api = Mockito.mock(CoreV1Api.class);
+    }
+
+    @Test
+    void given_replication_controller_does_not_have_toleration_and_affinity_when_it_belongs_to_the_resource_group_then_should_update_replication_controller() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1ReplicationController rc1 = new V1ReplicationController();
+        V1ReplicationControllerSpec rcSpec1 = new V1ReplicationControllerSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        podTemplateSpec1.setSpec(new V1PodSpec());
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        podTemplateSpec1.setMetadata(podMeta1);
+        V1ObjectMeta rcMeta1 = new V1ObjectMeta();
+        rcMeta1.setNamespace("ns1");
+        rcMeta1.setName("rc1");
+        rc1.setMetadata(rcMeta1);
+        rcSpec1.setTemplate(podTemplateSpec1);
+        rc1.setSpec(rcSpec1);
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(rc1).when(this.replicationControllerIndexer).getByKey(KeyUtil.buildKey("ns1", "rc1"));
+        ReplicationControllerReconciler rcReconciler = new ReplicationControllerReconciler(this.replicationControllerIndexer, this.reconciliation, this.coreV1Api);
+        rcReconciler.reconcile(new Request("ns1", "rc1"));
+        try {
+            Mockito.verify(this.coreV1Api).replaceNamespacedReplicationController(
+                    Mockito.eq("rc1"),
+                    Mockito.eq("ns1"),
+                    Mockito.argThat(rc -> {
+                        List<String> tolerationValues = rc.getSpec().getTemplate().getSpec().getTolerations().stream()
+                                .filter(e -> {
+                                    if (e.getKey() == null) {
+                                        return false;
+                                    }
+                                    return e.getKey().equals(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE);
+                                })
+                                .map(V1Toleration::getValue)
+                                .collect(Collectors.toList());
+                        Set<String> valueSet = new HashSet<>(tolerationValues);
+                        if (!valueSet.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        Set<String> affinityValues = rc.getSpec().getTemplate().getSpec().getAffinity()
+                                .getNodeAffinity().getRequiredDuringSchedulingIgnoredDuringExecution().getNodeSelectorTerms().stream()
+                                .flatMap(nst -> nst.getMatchExpressions().stream())
+                                .filter(nsr -> nsr.getKey().equals(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE))
+                                .flatMap(nsr -> nsr.getValues().stream())
+                                .collect(Collectors.toSet());
+                        if (!affinityValues.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        return true;
+                    }),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.coreV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_replication_controller_does_not_have_toleration_when_it_belongs_to_the_resource_group_then_should_update_replication_controller() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1ReplicationController rc1 = new V1ReplicationController();
+        V1ReplicationControllerSpec rcSpec1 = new V1ReplicationControllerSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withRequiredDuringSchedulingIgnoredDuringExecution(
+                        new V1NodeSelectorBuilder().withNodeSelectorTerms(
+                                new V1NodeSelectorTermBuilder().withMatchExpressions(
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                .withOperator("In")
+                                                .withValues("group1")
+                                                .build()
+                                ).build()
+                        ).build()
+                ).build()
+        ).build();
+        podSpec1.setAffinity(affinity1);
+        podTemplateSpec1.setSpec(new V1PodSpec());
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        podTemplateSpec1.setMetadata(podMeta1);
+        V1ObjectMeta rcMeta1 = new V1ObjectMeta();
+        rcMeta1.setNamespace("ns1");
+        rcMeta1.setName("rc1");
+        rc1.setMetadata(rcMeta1);
+        rcSpec1.setTemplate(podTemplateSpec1);
+        rc1.setSpec(rcSpec1);
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(rc1).when(this.replicationControllerIndexer).getByKey(KeyUtil.buildKey("ns1", "rc1"));
+        ReplicationControllerReconciler rcReconciler = new ReplicationControllerReconciler(this.replicationControllerIndexer, this.reconciliation, this.coreV1Api);
+        rcReconciler.reconcile(new Request("ns1", "rc1"));
+        try {
+            Mockito.verify(this.coreV1Api).replaceNamespacedReplicationController(
+                    Mockito.eq("rc1"),
+                    Mockito.eq("ns1"),
+                    Mockito.argThat(rc -> {
+                        List<String> tolerationValues = rc.getSpec().getTemplate().getSpec().getTolerations().stream()
+                                .filter(e -> {
+                                    if (e.getKey() == null) {
+                                        return false;
+                                    }
+                                    return e.getKey().equals(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE);
+                                })
+                                .map(V1Toleration::getValue)
+                                .collect(Collectors.toList());
+                        Set<String> valueSet = new HashSet<>(tolerationValues);
+                        if (!valueSet.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        Set<String> affinityValues = rc.getSpec().getTemplate().getSpec().getAffinity()
+                                .getNodeAffinity().getRequiredDuringSchedulingIgnoredDuringExecution().getNodeSelectorTerms().stream()
+                                .flatMap(nst -> nst.getMatchExpressions().stream())
+                                .filter(nsr -> nsr.getKey().equals(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE))
+                                .flatMap(nsr -> nsr.getValues().stream())
+                                .collect(Collectors.toSet());
+                        if (!affinityValues.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        return true;
+                    }),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.coreV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_replication_controller_does_not_have_affinity_when_it_belongs_to_the_resource_group_then_should_update_replication_controller() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1ReplicationController rc1 = new V1ReplicationController();
+        V1ReplicationControllerSpec rcSpec1 = new V1ReplicationControllerSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
+        podTemplateSpec1.setSpec(podSpec1);
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        podTemplateSpec1.setMetadata(podMeta1);
+        V1ObjectMeta rcMeta1 = new V1ObjectMeta();
+        rcMeta1.setNamespace("ns1");
+        rcMeta1.setName("rc1");
+        rc1.setMetadata(rcMeta1);
+        rcSpec1.setTemplate(podTemplateSpec1);
+        rc1.setSpec(rcSpec1);
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(rc1).when(this.replicationControllerIndexer).getByKey(KeyUtil.buildKey("ns1", "rc1"));
+        ReplicationControllerReconciler rcReconciler = new ReplicationControllerReconciler(this.replicationControllerIndexer, this.reconciliation, this.coreV1Api);
+        rcReconciler.reconcile(new Request("ns1", "rc1"));
+        try {
+            Mockito.verify(this.coreV1Api).replaceNamespacedReplicationController(
+                    Mockito.eq("rc1"),
+                    Mockito.eq("ns1"),
+                    Mockito.argThat(rc -> {
+                        List<String> tolerationValues = rc.getSpec().getTemplate().getSpec().getTolerations().stream()
+                                .filter(e -> {
+                                    if (e.getKey() == null) {
+                                        return false;
+                                    }
+                                    return e.getKey().equals(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE);
+                                })
+                                .map(V1Toleration::getValue)
+                                .collect(Collectors.toList());
+                        Set<String> valueSet = new HashSet<>(tolerationValues);
+                        if (!valueSet.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        Set<String> affinityValues = rc.getSpec().getTemplate().getSpec().getAffinity()
+                                .getNodeAffinity().getRequiredDuringSchedulingIgnoredDuringExecution().getNodeSelectorTerms().stream()
+                                .flatMap(nst -> nst.getMatchExpressions().stream())
+                                .filter(nsr -> nsr.getKey().equals(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE))
+                                .flatMap(nsr -> nsr.getValues().stream())
+                                .collect(Collectors.toSet());
+                        if (!affinityValues.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        return true;
+                    }),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.coreV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_replication_controller_has_unsupported_controller_then_should_delete_replication_controller() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1ReplicationController rc1 = new V1ReplicationController();
+        V1ReplicationControllerSpec rcSpec1 = new V1ReplicationControllerSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withRequiredDuringSchedulingIgnoredDuringExecution(
+                        new V1NodeSelectorBuilder().withNodeSelectorTerms(
+                                new V1NodeSelectorTermBuilder().withMatchExpressions(
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                .withOperator("In")
+                                                .withValues("group1")
+                                                .build()
+                                ).build()
+                        ).build()
+                ).build()
+        ).build();
+        podSpec1.setAffinity(affinity1);
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
+        podTemplateSpec1.setSpec(podSpec1);
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        podTemplateSpec1.setMetadata(podMeta1);
+        V1ObjectMeta rcMeta1 = new V1ObjectMeta();
+        rcMeta1.setNamespace("ns1");
+        rcMeta1.setName("rc1");
+        rc1.setMetadata(rcMeta1);
+        rcSpec1.setTemplate(podTemplateSpec1);
+        rc1.setSpec(rcSpec1);
+        V1OwnerReference ownerReference1 = new V1OwnerReference();
+        ownerReference1.setApiVersion("v1");
+        ownerReference1.setKind("dummy");
+        ownerReference1.setController(true);
+        rc1.getMetadata().setOwnerReferences(List.of(ownerReference1));
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(rc1).when(this.replicationControllerIndexer).getByKey(KeyUtil.buildKey("ns1", "rc1"));
+        ReplicationControllerReconciler rcReconciler = new ReplicationControllerReconciler(this.replicationControllerIndexer, this.reconciliation, this.coreV1Api);
+        rcReconciler.reconcile(new Request("ns1", "rc1"));
+        try {
+            Mockito.verify(this.coreV1Api).deleteNamespacedReplicationController(
+                    Mockito.eq("rc1"),
+                    Mockito.eq("ns1"),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.coreV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+}

--- a/src/test/java/io/ten1010/coaster/groupcontroller/controller/workload/statefulset/StatefulSetReconcilerTest.java
+++ b/src/test/java/io/ten1010/coaster/groupcontroller/controller/workload/statefulset/StatefulSetReconcilerTest.java
@@ -1,0 +1,341 @@
+package io.ten1010.coaster.groupcontroller.controller.workload.statefulset;
+
+import io.kubernetes.client.extended.controller.reconciler.Request;
+import io.kubernetes.client.informer.cache.Indexer;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.AppsV1Api;
+import io.kubernetes.client.openapi.models.*;
+import io.ten1010.coaster.groupcontroller.controller.Reconciliation;
+import io.ten1010.coaster.groupcontroller.core.IndexNames;
+import io.ten1010.coaster.groupcontroller.core.KeyUtil;
+import io.ten1010.coaster.groupcontroller.core.Labels;
+import io.ten1010.coaster.groupcontroller.core.Taints;
+import io.ten1010.coaster.groupcontroller.model.V1Beta1ResourceGroup;
+import io.ten1010.coaster.groupcontroller.model.V1Beta1ResourceGroupSpec;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class StatefulSetReconcilerTest {
+
+    Indexer<V1StatefulSet> statefulSetIndexer;
+    Indexer<V1Beta1ResourceGroup> groupIndexer;
+    Reconciliation reconciliation;
+    AppsV1Api appsV1Api;
+
+    @BeforeEach
+    void setUp() {
+        this.statefulSetIndexer = Mockito.mock(Indexer.class);
+        this.groupIndexer = Mockito.mock(Indexer.class);
+        this.reconciliation = new Reconciliation(this.groupIndexer);
+        this.appsV1Api = Mockito.mock(AppsV1Api.class);
+    }
+
+    @Test
+    void given_stateful_set_does_not_have_toleration_and_affinity_when_it_belongs_to_the_resource_group_then_should_update_stateful_set() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1StatefulSet statefulSet1 = new V1StatefulSet();
+        V1StatefulSetSpec statefulSetSpec1 = new V1StatefulSetSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        podTemplateSpec1.setSpec(new V1PodSpec());
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        podTemplateSpec1.setMetadata(podMeta1);
+        V1ObjectMeta statefulSetMeta1 = new V1ObjectMeta();
+        statefulSetMeta1.setNamespace("ns1");
+        statefulSetMeta1.setName("statefulSet1");
+        statefulSet1.setMetadata(statefulSetMeta1);
+        statefulSetSpec1.setTemplate(podTemplateSpec1);
+        statefulSet1.setSpec(statefulSetSpec1);
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(statefulSet1).when(this.statefulSetIndexer).getByKey(KeyUtil.buildKey("ns1", "statefulSet1"));
+        StatefulSetReconciler statefulSetReconciler = new StatefulSetReconciler(this.statefulSetIndexer, this.reconciliation, this.appsV1Api);
+        statefulSetReconciler.reconcile(new Request("ns1", "statefulSet1"));
+        try {
+            Mockito.verify(this.appsV1Api).replaceNamespacedStatefulSet(
+                    Mockito.eq("statefulSet1"),
+                    Mockito.eq("ns1"),
+                    Mockito.argThat(statefulSet -> {
+                        List<String> tolerationValues = statefulSet.getSpec().getTemplate().getSpec().getTolerations().stream()
+                                .filter(e -> {
+                                    if (e.getKey() == null) {
+                                        return false;
+                                    }
+                                    return e.getKey().equals(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE);
+                                })
+                                .map(V1Toleration::getValue)
+                                .collect(Collectors.toList());
+                        Set<String> valueSet = new HashSet<>(tolerationValues);
+                        if (!valueSet.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        Set<String> affinityValues = statefulSet.getSpec().getTemplate().getSpec().getAffinity()
+                                .getNodeAffinity().getRequiredDuringSchedulingIgnoredDuringExecution().getNodeSelectorTerms().stream()
+                                .flatMap(nst -> nst.getMatchExpressions().stream())
+                                .filter(nsr -> nsr.getKey().equals(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE))
+                                .flatMap(nsr -> nsr.getValues().stream())
+                                .collect(Collectors.toSet());
+                        if (!affinityValues.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        return true;
+                    }),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.appsV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_stateful_set_does_not_have_toleration_when_it_belongs_to_the_resource_group_then_should_update_stateful_set() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1StatefulSet statefulSet1 = new V1StatefulSet();
+        V1StatefulSetSpec statefulSetSpec1 = new V1StatefulSetSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withRequiredDuringSchedulingIgnoredDuringExecution(
+                        new V1NodeSelectorBuilder().withNodeSelectorTerms(
+                                new V1NodeSelectorTermBuilder().withMatchExpressions(
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                .withOperator("In")
+                                                .withValues("group1")
+                                                .build()
+                                ).build()
+                        ).build()
+                ).build()
+        ).build();
+        podSpec1.setAffinity(affinity1);
+        podTemplateSpec1.setSpec(new V1PodSpec());
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        podTemplateSpec1.setMetadata(podMeta1);
+        V1ObjectMeta statefulSetMeta1 = new V1ObjectMeta();
+        statefulSetMeta1.setNamespace("ns1");
+        statefulSetMeta1.setName("statefulSet1");
+        statefulSet1.setMetadata(statefulSetMeta1);
+        statefulSetSpec1.setTemplate(podTemplateSpec1);
+        statefulSet1.setSpec(statefulSetSpec1);
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(statefulSet1).when(this.statefulSetIndexer).getByKey(KeyUtil.buildKey("ns1", "statefulSet1"));
+        StatefulSetReconciler statefulSetReconciler = new StatefulSetReconciler(this.statefulSetIndexer, this.reconciliation, this.appsV1Api);
+        statefulSetReconciler.reconcile(new Request("ns1", "statefulSet1"));
+        try {
+            Mockito.verify(this.appsV1Api).replaceNamespacedStatefulSet(
+                    Mockito.eq("statefulSet1"),
+                    Mockito.eq("ns1"),
+                    Mockito.argThat(statefulSet -> {
+                        List<String> tolerationValues = statefulSet.getSpec().getTemplate().getSpec().getTolerations().stream()
+                                .filter(e -> {
+                                    if (e.getKey() == null) {
+                                        return false;
+                                    }
+                                    return e.getKey().equals(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE);
+                                })
+                                .map(V1Toleration::getValue)
+                                .collect(Collectors.toList());
+                        Set<String> valueSet = new HashSet<>(tolerationValues);
+                        if (!valueSet.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        Set<String> affinityValues = statefulSet.getSpec().getTemplate().getSpec().getAffinity()
+                                .getNodeAffinity().getRequiredDuringSchedulingIgnoredDuringExecution().getNodeSelectorTerms().stream()
+                                .flatMap(nst -> nst.getMatchExpressions().stream())
+                                .filter(nsr -> nsr.getKey().equals(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE))
+                                .flatMap(nsr -> nsr.getValues().stream())
+                                .collect(Collectors.toSet());
+                        if (!affinityValues.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        return true;
+                    }),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.appsV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_stateful_set_does_not_have_affinity_when_it_belongs_to_the_resource_group_then_should_update_stateful_set() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1StatefulSet statefulSet1 = new V1StatefulSet();
+        V1StatefulSetSpec statefulSetSpec1 = new V1StatefulSetSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        V1Affinity affinity1 = new V1Affinity();
+        podSpec1.setAffinity(affinity1);
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
+        podTemplateSpec1.setSpec(podSpec1);
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        podTemplateSpec1.setMetadata(podMeta1);
+        V1ObjectMeta statefulSetMeta1 = new V1ObjectMeta();
+        statefulSetMeta1.setNamespace("ns1");
+        statefulSetMeta1.setName("statefulSet1");
+        statefulSet1.setMetadata(statefulSetMeta1);
+        statefulSetSpec1.setTemplate(podTemplateSpec1);
+        statefulSet1.setSpec(statefulSetSpec1);
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(statefulSet1).when(this.statefulSetIndexer).getByKey(KeyUtil.buildKey("ns1", "statefulSet1"));
+        StatefulSetReconciler statefulSetReconciler = new StatefulSetReconciler(this.statefulSetIndexer, this.reconciliation, this.appsV1Api);
+        statefulSetReconciler.reconcile(new Request("ns1", "statefulSet1"));
+        try {
+            Mockito.verify(this.appsV1Api).replaceNamespacedStatefulSet(
+                    Mockito.eq("statefulSet1"),
+                    Mockito.eq("ns1"),
+                    Mockito.argThat(statefulSet -> {
+                        List<String> tolerationValues = statefulSet.getSpec().getTemplate().getSpec().getTolerations().stream()
+                                .filter(e -> {
+                                    if (e.getKey() == null) {
+                                        return false;
+                                    }
+                                    return e.getKey().equals(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE);
+                                })
+                                .map(V1Toleration::getValue)
+                                .collect(Collectors.toList());
+                        Set<String> valueSet = new HashSet<>(tolerationValues);
+                        if (!valueSet.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        Set<String> affinityValues = statefulSet.getSpec().getTemplate().getSpec().getAffinity()
+                                .getNodeAffinity().getRequiredDuringSchedulingIgnoredDuringExecution().getNodeSelectorTerms().stream()
+                                .flatMap(nst -> nst.getMatchExpressions().stream())
+                                .filter(nsr -> nsr.getKey().equals(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE))
+                                .flatMap(nsr -> nsr.getValues().stream())
+                                .collect(Collectors.toSet());
+                        if (!affinityValues.equals(Set.of("group1"))) {
+                            return false;
+                        }
+                        return true;
+                    }),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.appsV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_stateful_set_has_unsupported_controller_then_should_delete_stateful_set() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+
+        V1StatefulSet statefulSet1 = new V1StatefulSet();
+        V1StatefulSetSpec statefulSetSpec1 = new V1StatefulSetSpec();
+        V1PodTemplateSpec podTemplateSpec1 = new V1PodTemplateSpec();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withRequiredDuringSchedulingIgnoredDuringExecution(
+                        new V1NodeSelectorBuilder().withNodeSelectorTerms(
+                                new V1NodeSelectorTermBuilder().withMatchExpressions(
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                .withOperator("In")
+                                                .withValues("group1")
+                                                .build()
+                                ).build()
+                        ).build()
+                ).build()
+        ).build();
+        podSpec1.setAffinity(affinity1);
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
+        podTemplateSpec1.setSpec(podSpec1);
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        podTemplateSpec1.setMetadata(podMeta1);
+        V1ObjectMeta statefulSetMeta1 = new V1ObjectMeta();
+        statefulSetMeta1.setNamespace("ns1");
+        statefulSetMeta1.setName("statefulSet1");
+        statefulSet1.setMetadata(statefulSetMeta1);
+        statefulSetSpec1.setTemplate(podTemplateSpec1);
+        statefulSet1.setSpec(statefulSetSpec1);
+        V1OwnerReference ownerReference1 = new V1OwnerReference();
+        ownerReference1.setApiVersion("v1");
+        ownerReference1.setKind("dummy");
+        ownerReference1.setController(true);
+        statefulSet1.getMetadata().setOwnerReferences(List.of(ownerReference1));
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(statefulSet1).when(this.statefulSetIndexer).getByKey(KeyUtil.buildKey("ns1", "statefulSet1"));
+        StatefulSetReconciler statefulSetReconciler = new StatefulSetReconciler(this.statefulSetIndexer, this.reconciliation, this.appsV1Api);
+        statefulSetReconciler.reconcile(new Request("ns1", "statefulSet1"));
+        try {
+            Mockito.verify(this.appsV1Api).deleteNamespacedStatefulSet(
+                    Mockito.eq("statefulSet1"),
+                    Mockito.eq("ns1"),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+            Mockito.verifyNoMoreInteractions(this.appsV1Api);
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+    }
+
+}


### PR DESCRIPTION
## Motivation
workload controller reconciler에 대한 테스트코드를 작성하였습니다.

각 controller의 테스트케이스는 다음과 같습니다.
- 해당 오브젝트에 toleration, affinity가 없는 경우, 삭제 또는 업데이트 검증
- 해당 오브젝트에 toleration이 없는 경우, 삭제 또는 업데이트 검증
- 해당 오브젝트에 affinity가 없는 경우, 삭제 또는 업데이트 검증
- 해당 오브젝트가 unsupported controller를 지닌 경우, 해당 오브젝트 삭제 검증

## Key Changes
- DaemonSetReconcilerTest
	- optimize import

- CronJobReconcilerTest
	- given_cronjob_does_not_have_toleration_and_affinity_when_it_belongs_to_the_resource_group_then_should_update_cronjob
	- given_cronjob_does_not_have_toleration_when_it_belongs_to_the_resource_group_then_should_update_cronjob
	- given_cronjob_does_not_have_affinity_when_it_belongs_to_the_resource_group_then_should_update_cronjob
	- given_cronjob_has_unsupported_controller_then_should_delete_cronjob

- DeploymentReconcilerTest
	- given_deployment_does_not_have_toleration_and_affinity_when_it_belongs_to_the_resource_group_then_should_update_deployment
	- given_deployment_does_not_have_toleration_when_it_belongs_to_the_resource_group_then_should_update_deployment
	- given_deployment_does_not_have_affinity_when_it_belongs_to_the_resource_group_then_should_update_deployment
	- given_deployment_has_unsupported_controller_then_should_delete_deployment

- JobReconcilerTest
	- given_job_does_not_have_toleration_and_affinity_when_it_belongs_to_the_resource_group_then_should_delete_job
	- given_job_does_not_have_toleration_when_it_belongs_to_the_resource_group_then_should_delete_job
	- given_job_does_not_have_affinity_when_it_belongs_to_the_resource_group_then_should_delete_job
	- given_job_has_unsupported_controller_then_should_delete_job

- ReplicaSetReconcilerTest
	- given_replicaset_does_not_have_toleration_and_affinity_when_it_belongs_to_resource_group_then_should_update_replicaset
	- given_replicaset_does_not_have_toleration_when_it_belongs_to_the_resource_group_then_should_update_replicaset
	- given_replicaset_does_not_have_affinity_when_it_belongs_to_resource_group_then_should_update_replicaset
	- given_replicaset_has_unsupported_controller_then_should_delete_replicaset

- ReplicationControllerReconcilerTest
	- given_replication_controller_does_not_have_toleration_and_affinity_when_it_belongs_to_the_resource_group_then_should_update_replication_controller
	- given_replication_controller_does_not_have_toleration_when_it_belongs_to_the_resource_group_then_should_update_replication_controller
	- given_replication_controller_does_not_have_affinity_when_it_belongs_to_the_resource_group_then_should_update_replication_controller
	- given_replication_controller_has_unsupported_controller_then_should_delete_replication_controller


- StatefulSetReconcilerTest
	- given_stateful_set_does_not_have_toleration_and_affinity_when_it_belongs_to_the_resource_group_then_should_update_stateful_set
	- given_stateful_set_does_not_have_toleration_when_it_belongs_to_the_resource_group_then_should_update_stateful_set
	- given_stateful_set_does_not_have_affinity_when_it_belongs_to_the_resource_group_then_should_update_stateful_set
	- given_stateful_set_has_unsupported_controller_then_should_delete_stateful_set
