### PR TITLE
fix: fix a bug in affinity reconciliation

### DIFF
--- a/src/main/java/io/ten1010/coaster/groupcontroller/controller/Reconciliation.java
+++ b/src/main/java/io/ten1010/coaster/groupcontroller/controller/Reconciliation.java
@@ -153,6 +153,9 @@ public class Reconciliation {
     }
 
     private static List<V1NodeSelectorRequirement> buildResourceGroupExclusiveMatchExpressions(List<V1Beta1ResourceGroup> groups) {
+        if (groups.isEmpty()) {
+            return new ArrayList<>();
+        }
         V1NodeSelectorRequirement expression = new V1NodeSelectorRequirementBuilder()
                 .withKey(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE)
                 .withOperator("In")

--- a/src/test/java/io/ten1010/coaster/groupcontroller/controller/workload/pod/PodReconcilerTest.java
+++ b/src/test/java/io/ten1010/coaster/groupcontroller/controller/workload/pod/PodReconcilerTest.java
@@ -197,7 +197,7 @@ class PodReconcilerTest {
     }
 
     @Test
-    void given_pod_does_not_have_affinity_for_group_then_should_delete_pod() {
+    void given_pod_does_not_have_any_affinities_then_should_delete_pod() {
         V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
         V1ObjectMeta meta1 = new V1ObjectMeta();
         meta1.setName("group1");
@@ -243,7 +243,181 @@ class PodReconcilerTest {
     }
 
     @Test
-    void given_pod_has_proper_node_affinity_then_do_nothing() {
+    void given_pod_has_affinity_not_for_group_then_should_delete_pod() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+        V1Pod pod1 = new V1Pod();
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        pod1.setMetadata(podMeta1);
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withRequiredDuringSchedulingIgnoredDuringExecution(
+                        new V1NodeSelectorBuilder().withNodeSelectorTerms(
+                                new V1NodeSelectorTermBuilder().withMatchExpressions(
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey("kubernetes.io/hostname")
+                                                .withOperator("In")
+                                                .withValues("cpu1")
+                                                .build()
+                                ).build()
+                        ).build()
+                ).build()
+        ).build();
+        V1PodSpec podSpec1 = new V1PodSpec();
+        podSpec1.setAffinity(affinity1);
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(
+                tolerationBuilder.withEffect("NoSchedule").build(),
+                tolerationBuilder.withEffect("NoExecute").build()
+        ));
+        pod1.setSpec(podSpec1);
+
+        Mockito.doReturn(pod1).when(this.podIndexer).getByKey(KeyUtil.buildKey("ns1", "pod1"));
+        PodReconciler podReconciler = new PodReconciler(this.podIndexer, this.reconciliation, this.coreV1Api);
+        podReconciler.reconcile(new Request("ns1", "pod1"));
+        try {
+            Mockito.verify(this.coreV1Api).deleteNamespacedPod(
+                    Mockito.eq("pod1"),
+                    Mockito.eq("ns1"),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+        } catch (ApiException e) {
+            Assertions.fail();
+        }
+        Mockito.verifyNoMoreInteractions(this.coreV1Api);
+    }
+
+    @Test
+    void given_pod_has_affinities_including_one_for_group_then_do_nothing() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+        V1Pod pod1 = new V1Pod();
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        pod1.setMetadata(podMeta1);
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withRequiredDuringSchedulingIgnoredDuringExecution(
+                        new V1NodeSelectorBuilder().withNodeSelectorTerms(
+                                new V1NodeSelectorTermBuilder().withMatchExpressions(
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey("kubernetes.io/hostname")
+                                                .withOperator("In")
+                                                .withValues("cpu1")
+                                                .build(),
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                .withOperator("In")
+                                                .withValues("group1")
+                                                .build()
+                                ).build()
+                        ).build()
+                ).build()
+        ).build();
+        V1PodSpec podSpec1 = new V1PodSpec();
+
+        podSpec1.setAffinity(affinity1);
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
+        pod1.setSpec(podSpec1);
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(pod1).when(this.podIndexer).getByKey(KeyUtil.buildKey("ns1", "pod1"));
+        PodReconciler podReconciler = new PodReconciler(this.podIndexer, this.reconciliation, this.coreV1Api);
+        podReconciler.reconcile(new Request("ns1", "pod1"));
+        try {
+            Mockito.verifyNoInteractions(this.coreV1Api);
+        } catch (Exception e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_pod_has_affinities_including_one_for_not_existing_group_then_do_nothing() {
+        V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
+        V1ObjectMeta meta1 = new V1ObjectMeta();
+        meta1.setName("group1");
+        group1.setMetadata(meta1);
+        V1Beta1ResourceGroupSpec spec1 = new V1Beta1ResourceGroupSpec();
+        spec1.setNamespaces(List.of("ns1"));
+        group1.setSpec(spec1);
+        V1Pod pod1 = new V1Pod();
+        V1ObjectMeta podMeta1 = new V1ObjectMeta();
+        podMeta1.setNamespace("ns1");
+        podMeta1.setName("pod1");
+        pod1.setMetadata(podMeta1);
+        V1Affinity affinity1 = new V1AffinityBuilder().withNodeAffinity(
+                new V1NodeAffinityBuilder().withRequiredDuringSchedulingIgnoredDuringExecution(
+                        new V1NodeSelectorBuilder().withNodeSelectorTerms(
+                                new V1NodeSelectorTermBuilder().withMatchExpressions(
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey("kubernetes.io/hostname")
+                                                .withOperator("In")
+                                                .withValues("cpu1")
+                                                .build(),
+                                        new V1NodeSelectorRequirementBuilder()
+                                                .withKey(Labels.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                                                .withOperator("In")
+                                                .withValues("group2")
+                                                .build()
+                                ).build()
+                        ).build()
+                ).build()
+        ).build();
+        V1PodSpec podSpec1 = new V1PodSpec();
+
+        podSpec1.setAffinity(affinity1);
+        V1TolerationBuilder tolerationBuilder = new V1TolerationBuilder()
+                .withKey(Taints.KEY_RESOURCE_GROUP_EXCLUSIVE)
+                .withValue("group1")
+                .withOperator("Equal");
+        podSpec1.setTolerations(List.of(tolerationBuilder.withEffect("NoSchedule").build()));
+        pod1.setSpec(podSpec1);
+        Mockito.doReturn(List.of(group1))
+                .when(this.groupIndexer)
+                .byIndex(IndexNames.BY_NAMESPACE_NAME_TO_GROUP_OBJECT, "ns1");
+        Mockito.doReturn(pod1).when(this.podIndexer).getByKey(KeyUtil.buildKey("ns1", "pod1"));
+        PodReconciler podReconciler = new PodReconciler(this.podIndexer, this.reconciliation, this.coreV1Api);
+        podReconciler.reconcile(new Request("ns1", "pod1"));
+        try {
+            Mockito.verify(this.coreV1Api).deleteNamespacedPod(
+                    Mockito.eq("pod1"),
+                    Mockito.eq("ns1"),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null),
+                    Mockito.eq(null));
+        } catch (Exception e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void given_pod_has_exclusive_node_affinity_only_then_do_nothing() {
         V1Beta1ResourceGroup group1 = new V1Beta1ResourceGroup();
         V1ObjectMeta meta1 = new V1ObjectMeta();
         meta1.setName("group1");


### PR DESCRIPTION
## Motivation

Affinity에서 기존에 정의된 non-exclusive NodeSelectorTerm을 만족하는 노드가 존재하는 경우, resource group에서 정의하고 있지 않은 다른 노드에 오브젝트가 스케쥴되는 문제되는 문제가 발생하였습니다.

Affinity Reconciliation에서 존재하는 모든 NodeSelectorTerm에 group exclusive match expression이 추가될 수 있도록 수정하였습니다.

해당 조건에 대한 테스트케이스를 추가하였습니다.
추가된 테스트케이스는 다음과 같습니다.
- 주어진 pod에 resource group에 대한 affinity가 없는 경우, 해당 pod 삭제
- 주어진 pod의 여러 affinity들 중 resource group affinity가 존재하는 경우에 대한 검증
- 주어진 pod의 affinity의 non-exclusive NodeSelectorTerm들 모두 group exclusive match expression을 지닌 경우에 대한 검증
- 주어진 pod의 여러 affinity들 중 resource group affinity가 존재하지만, 해당 resource group이 없는 경우, 해당 pod 삭제


## Key Changes


- Reconcilation
	- reconcileAffinity()
		- AffinityBuilder를 조건에 따라 재사용하며 affinity reconciliation 수행
		- 기존에 존재하는 terms들의 exclusive match expression을 수정 또는 추가하는 방식으로 변경
	- reconcileMatchExpression()
		- group과 기존의 term이 지닌고 있는 match expression에 대한 reconciliation 수행
	- extractNonResourceGroupExclusiveMatchExpressions()
		- 주어진 match expression에서 non-exclusive에 해당하는 match expression 추출
	- buildResourceGroupExclusiveMatchExpressions()
		- group exclusive match expressions 생성
