### PR TITLE
feat: skip cilium components in workload reconciliation

### DIFF
--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/workload/WorkloadControllerReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/workload/WorkloadControllerReconciler.java
@@ -19,14 +19,10 @@ import io.ten1010.aipub.projectcontroller.domain.k8s.ReconciliationService;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Project;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.K8sObjectUtils;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
 public class WorkloadControllerReconciler extends AbstractReconciler {
-
-  private static final String PART_OF_LABEL_KEY = "app.kubernetes.io/part-of";
-  private static final String CILIUM_PART_OF_VALUE = "cilium";
 
   private final KeyResolver keyResolver;
   private final ReconciliationService reconciliationService;
@@ -70,7 +66,7 @@ public class WorkloadControllerReconciler extends AbstractReconciler {
       return new Result(false);
     }
     KubernetesObject controller = controllerOpt.get();
-    if (isCiliumComponent(controller)) {
+    if (K8sObjectUtils.isCiliumComponent(controller)) {
       return new Result(false);
     }
     if (K8sObjectUtils.findControllerOwnerReference(controller).isPresent()) {
@@ -90,17 +86,6 @@ public class WorkloadControllerReconciler extends AbstractReconciler {
 
     return this.controllerObjectReconciler.reconcileController(controller, reconciledTolerations,
         reconciledSelectorTerms, reconciledImagePullSecrets);
-  }
-
-  private static boolean isCiliumComponent(KubernetesObject controller) {
-    if (controller.getMetadata() == null) {
-      return false;
-    }
-    Map<String, String> labels = controller.getMetadata().getLabels();
-    if (labels == null) {
-      return false;
-    }
-    return CILIUM_PART_OF_VALUE.equals(labels.get(PART_OF_LABEL_KEY));
   }
 
   private String createRequestDescription(Request request) {

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/workload/WorkloadControllerReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/workload/WorkloadControllerReconciler.java
@@ -19,10 +19,14 @@ import io.ten1010.aipub.projectcontroller.domain.k8s.ReconciliationService;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Project;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.K8sObjectUtils;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
 public class WorkloadControllerReconciler extends AbstractReconciler {
+
+  private static final String PART_OF_LABEL_KEY = "app.kubernetes.io/part-of";
+  private static final String CILIUM_PART_OF_VALUE = "cilium";
 
   private final KeyResolver keyResolver;
   private final ReconciliationService reconciliationService;
@@ -66,6 +70,9 @@ public class WorkloadControllerReconciler extends AbstractReconciler {
       return new Result(false);
     }
     KubernetesObject controller = controllerOpt.get();
+    if (isCiliumComponent(controller)) {
+      return new Result(false);
+    }
     if (K8sObjectUtils.findControllerOwnerReference(controller).isPresent()) {
       return new Result(false);
     }
@@ -83,6 +90,17 @@ public class WorkloadControllerReconciler extends AbstractReconciler {
 
     return this.controllerObjectReconciler.reconcileController(controller, reconciledTolerations,
         reconciledSelectorTerms, reconciledImagePullSecrets);
+  }
+
+  private static boolean isCiliumComponent(KubernetesObject controller) {
+    if (controller.getMetadata() == null) {
+      return false;
+    }
+    Map<String, String> labels = controller.getMetadata().getLabels();
+    if (labels == null) {
+      return false;
+    }
+    return CILIUM_PART_OF_VALUE.equals(labels.get(PART_OF_LABEL_KEY));
   }
 
   private String createRequestDescription(Request request) {

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/util/K8sObjectUtils.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/util/K8sObjectUtils.java
@@ -16,6 +16,20 @@ import java.util.Optional;
 
 public abstract class K8sObjectUtils {
 
+  private static final String PART_OF_LABEL_KEY = "app.kubernetes.io/part-of";
+  private static final String CILIUM_PART_OF_VALUE = "cilium";
+
+  public static boolean isCiliumComponent(KubernetesObject object) {
+    if (object.getMetadata() == null) {
+      return false;
+    }
+    Map<String, String> labels = object.getMetadata().getLabels();
+    if (labels == null) {
+      return false;
+    }
+    return CILIUM_PART_OF_VALUE.equals(labels.get(PART_OF_LABEL_KEY));
+  }
+
   public static String getApiVersion(KubernetesObject object) {
     Objects.requireNonNull(object.getApiVersion());
     return object.getApiVersion();

--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscovery.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscovery.java
@@ -26,15 +26,25 @@ public class ApiResourceDiscovery {
   public ApiResourceDiscovery(ApiClient apiClient) {
     this.apiClient = apiClient;
     this.mapper = new ObjectMapperFactory().createObjectMapper();
+    log.info("Initializing API resource discovery");
     this.snapshot = buildSnapshot();
     updateConfigMap(this.snapshot);
   }
 
   public void refresh() {
-    log.debug("Refreshing API resource discovery");
+    log.info("Refreshing API resource discovery");
+    long startNanos = System.nanoTime();
     Snapshot newSnapshot = buildSnapshot();
     this.snapshot = newSnapshot;
     updateConfigMap(newSnapshot);
+    long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
+    log.info("API resource discovery refresh complete: plurals={}, namespacedInfo={}, kinds={}, "
+            + "groupResources={}, durationMs={}",
+        newSnapshot.plurals().size(),
+        newSnapshot.namespacedInfo().size(),
+        newSnapshot.kindDict().size(),
+        newSnapshot.groupResources().size(),
+        elapsedMs);
   }
 
   /**
@@ -44,6 +54,7 @@ public class ApiResourceDiscovery {
   private void updateConfigMap(Snapshot snapshot) {
     String configMapName = "api-resources";
     String configMapNamespace = "aipub";
+    int entryCount = snapshot.kindDict().size();
 
     try {
       ObjectNode body = this.mapper.createObjectNode();
@@ -60,16 +71,27 @@ public class ApiResourceDiscovery {
       String itemPath = collectionPath + "/" + configMapName;
 
       int putStatus = executeConfigMapWrite(itemPath, "PUT", bodyBytes);
+      if (putStatus >= 200 && putStatus < 300) {
+        log.info("api-resources ConfigMap updated: namespace={}, name={}, entries={}, payloadBytes={}",
+            configMapNamespace, configMapName, entryCount, bodyBytes.length);
+        return;
+      }
       if (putStatus == 404) {
         int postStatus = executeConfigMapWrite(collectionPath, "POST", bodyBytes);
         if (postStatus >= 200 && postStatus < 300) {
-          log.debug("Created api-resources ConfigMap with {} entries", snapshot.kindDict().size());
+          log.info("api-resources ConfigMap created: namespace={}, name={}, entries={}, payloadBytes={}",
+              configMapNamespace, configMapName, entryCount, bodyBytes.length);
+        } else {
+          log.error("api-resources ConfigMap create failed after PUT 404: namespace={}, name={}, "
+                  + "postStatus={}", configMapNamespace, configMapName, postStatus);
         }
-      } else if (putStatus >= 200 && putStatus < 300) {
-        log.debug("Updated api-resources ConfigMap with {} entries", snapshot.kindDict().size());
+        return;
       }
+      log.error("api-resources ConfigMap update failed: namespace={}, name={}, putStatus={}, entries={}",
+          configMapNamespace, configMapName, putStatus, entryCount);
     } catch (Exception e) {
-      log.warn("Failed to update api-resources ConfigMap", e);
+      log.error("api-resources ConfigMap update threw exception: namespace={}, name={}, entries={}",
+          configMapNamespace, configMapName, entryCount, e);
     }
   }
 
@@ -82,12 +104,19 @@ public class ApiResourceDiscovery {
         Map.of(), Map.of(),
         new String[]{"BearerToken"}, null);
     try (Response response = call.execute()) {
-      if (!response.isSuccessful()) {
-        String errorBody = response.body() != null ? response.body().string() : "";
-        log.warn("api-resources ConfigMap {} failed: status={} body={}",
-            method, response.code(), errorBody);
+      int code = response.code();
+      if (response.isSuccessful()) {
+        return code;
       }
-      return response.code();
+      String errorBody = response.body() != null ? response.body().string() : "";
+      if (code == 404 && "PUT".equals(method)) {
+        log.info("api-resources ConfigMap not found on PUT, will fall back to POST: path={}, body={}",
+            path, errorBody);
+      } else {
+        log.error("api-resources ConfigMap {} request failed: path={}, status={}, body={}",
+            method, path, code, errorBody);
+      }
+      return code;
     }
   }
 
@@ -97,6 +126,11 @@ public class ApiResourceDiscovery {
     Map<String, String> groupVersions = new HashMap<>();
     Map<String, List<String>> kindDict = new HashMap<>();
     Set<String> groupResources = new HashSet<>();
+
+    int coreCount = 0;
+    int nonCoreGroupVersionCount = 0;
+    int nonCoreResourceCount = 0;
+    List<String> failedGroupVersions = new ArrayList<>();
 
     // Core API resources (/api/v1)
     try {
@@ -115,10 +149,13 @@ public class ApiResourceDiscovery {
           namespacedInfo.put(groupResource, namespaced);
           groupResources.add(groupResource);
           kindDict.computeIfAbsent(kind, k -> new ArrayList<>()).add(groupResource);
+          coreCount++;
         }
+      } else {
+        log.error("Core API discovery returned null: path=/api/v1");
       }
     } catch (Exception e) {
-      log.warn("Failed to discover core API resources", e);
+      log.error("Core API discovery threw exception: path=/api/v1", e);
     }
 
     // Non-core API resources (/apis)
@@ -129,37 +166,58 @@ public class ApiResourceDiscovery {
           String groupName = group.path("name").textValue();
           for (JsonNode version : group.path("versions")) {
             String groupVersion = version.path("groupVersion").textValue();
+            nonCoreGroupVersionCount++;
             try {
               JsonNode resources = fetchJson("/apis/" + groupVersion);
-              if (resources != null) {
-                for (JsonNode resource : resources.path("resources")) {
-                  String name = resource.path("name").textValue();
-                  if (name.contains("/")) {
-                    continue;
-                  }
-                  String kind = resource.path("kind").textValue();
-                  boolean namespaced = resource.path("namespaced").booleanValue();
-
-                  String groupResource = groupName + "/" + name;
-                  plurals.put(groupVersion + "/" + kind, name);
-                  namespacedInfo.put(groupResource, namespaced);
-                  groupVersions.put(groupResource, groupVersion);
-                  groupResources.add(groupResource);
-                  kindDict.computeIfAbsent(kind, k -> new ArrayList<>()).add(groupResource);
+              if (resources == null) {
+                failedGroupVersions.add(groupVersion);
+                continue;
+              }
+              int beforeCount = nonCoreResourceCount;
+              for (JsonNode resource : resources.path("resources")) {
+                String name = resource.path("name").textValue();
+                if (name.contains("/")) {
+                  continue;
                 }
+                String kind = resource.path("kind").textValue();
+                boolean namespaced = resource.path("namespaced").booleanValue();
+
+                String groupResource = groupName + "/" + name;
+                plurals.put(groupVersion + "/" + kind, name);
+                namespacedInfo.put(groupResource, namespaced);
+                groupVersions.put(groupResource, groupVersion);
+                groupResources.add(groupResource);
+                kindDict.computeIfAbsent(kind, k -> new ArrayList<>()).add(groupResource);
+                nonCoreResourceCount++;
+              }
+              if (log.isDebugEnabled()) {
+                log.debug("Discovered API group/version: groupVersion={}, resources={}",
+                    groupVersion, nonCoreResourceCount - beforeCount);
               }
             } catch (Exception e) {
-              log.warn("Failed to discover API resources for {}", groupVersion, e);
+              failedGroupVersions.add(groupVersion);
+              log.error("API group/version discovery threw exception: groupVersion={}",
+                  groupVersion, e);
             }
           }
         }
+      } else {
+        log.error("API groups discovery returned null: path=/apis");
       }
     } catch (Exception e) {
-      log.warn("Failed to discover API groups", e);
+      log.error("API groups discovery threw exception: path=/apis", e);
     }
 
-    log.info("Discovered {} API resource plurals, {} namespaced info entries",
-        plurals.size(), namespacedInfo.size());
+    if (!failedGroupVersions.isEmpty()) {
+      log.error("API discovery completed with {} failed group/versions: {}",
+          failedGroupVersions.size(), failedGroupVersions);
+    }
+    log.info("API discovery summary: coreResources={}, nonCoreGroupVersions={}, "
+            + "nonCoreResources={}, plurals={}, namespacedInfo={}, kinds={}, groupResources={}, "
+            + "failedGroupVersions={}",
+        coreCount, nonCoreGroupVersionCount, nonCoreResourceCount,
+        plurals.size(), namespacedInfo.size(), kindDict.size(), groupResources.size(),
+        failedGroupVersions.size());
 
     return new Snapshot(plurals, namespacedInfo, groupVersions, kindDict, groupResources);
   }
@@ -278,17 +336,20 @@ public class ApiResourceDiscovery {
           Map.of(), Map.of(), Map.of(),
           new String[]{"BearerToken"}, null);
       try (Response response = call.execute()) {
+        int code = response.code();
         if (!response.isSuccessful()) {
-          log.warn("Failed to fetch API resource: {} status={}", path, response.code());
+          String errorBody = response.body() != null ? response.body().string() : "";
+          log.error("API fetch failed: path={}, status={}, body={}", path, code, errorBody);
           return null;
         }
         if (response.body() == null) {
+          log.error("API fetch returned empty body: path={}, status={}", path, code);
           return null;
         }
         return this.mapper.readTree(response.body().string());
       }
     } catch (Exception e) {
-      log.warn("Failed to fetch API resource: {}", path, e);
+      log.error("API fetch threw exception: path={}", path, e);
       return null;
     }
   }

--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscovery.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscovery.java
@@ -55,23 +55,39 @@ public class ApiResourceDiscovery {
         data.put(entry.getKey(), String.join(",", entry.getValue()));
       }
 
-      String path = "/api/v1/namespaces/" + configMapNamespace + "/configmaps/" + configMapName;
-      Call call = this.apiClient.buildCall(
-          this.apiClient.getBasePath(), path, "PUT",
-          List.of(), List.of(),
-          this.mapper.writeValueAsBytes(body),
-          Map.of("Content-Type", "application/json"),
-          Map.of(), Map.of(),
-          new String[]{"BearerToken"}, null);
-      try (Response response = call.execute()) {
-        if (!response.isSuccessful()) {
-          log.warn("Failed to update api-resources ConfigMap: status={}", response.code());
-        } else {
-          log.debug("Updated api-resources ConfigMap with {} entries", snapshot.kindDict().size());
+      byte[] bodyBytes = this.mapper.writeValueAsBytes(body);
+      String collectionPath = "/api/v1/namespaces/" + configMapNamespace + "/configmaps";
+      String itemPath = collectionPath + "/" + configMapName;
+
+      int putStatus = executeConfigMapWrite(itemPath, "PUT", bodyBytes);
+      if (putStatus == 404) {
+        int postStatus = executeConfigMapWrite(collectionPath, "POST", bodyBytes);
+        if (postStatus >= 200 && postStatus < 300) {
+          log.debug("Created api-resources ConfigMap with {} entries", snapshot.kindDict().size());
         }
+      } else if (putStatus >= 200 && putStatus < 300) {
+        log.debug("Updated api-resources ConfigMap with {} entries", snapshot.kindDict().size());
       }
     } catch (Exception e) {
       log.warn("Failed to update api-resources ConfigMap", e);
+    }
+  }
+
+  private int executeConfigMapWrite(String path, String method, byte[] bodyBytes) throws Exception {
+    Call call = this.apiClient.buildCall(
+        this.apiClient.getBasePath(), path, method,
+        List.of(), List.of(),
+        bodyBytes,
+        Map.of("Content-Type", "application/json"),
+        Map.of(), Map.of(),
+        new String[]{"BearerToken"}, null);
+    try (Response response = call.execute()) {
+      if (!response.isSuccessful()) {
+        String errorBody = response.body() != null ? response.body().string() : "";
+        log.warn("api-resources ConfigMap {} failed: status={} body={}",
+            method, response.code(), errorBody);
+      }
+      return response.code();
     }
   }
 

--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscovery.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscovery.java
@@ -59,7 +59,7 @@ public class ApiResourceDiscovery {
       Call call = this.apiClient.buildCall(
           this.apiClient.getBasePath(), path, "PUT",
           List.of(), List.of(),
-          this.mapper.writeValueAsString(body),
+          this.mapper.writeValueAsBytes(body),
           Map.of("Content-Type", "application/json"),
           Map.of(), Map.of(),
           new String[]{"BearerToken"}, null);

--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/DeploymentReviewHandler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/DeploymentReviewHandler.java
@@ -46,6 +46,12 @@ public class DeploymentReviewHandler extends AbstractReviewHandler<V1Deployment>
     Objects.requireNonNull(review.getRequest());
 
     V1Deployment deployment = getRequestObject(review);
+
+    if (K8sObjectUtils.isCiliumComponent(deployment)) {
+      V1AdmissionReviewUtils.allow(review);
+      return;
+    }
+
     V1alpha1Project project = this.projectIndexer.getByKey(K8sObjectUtils.getNamespace(deployment));
 
     V1PodTemplateSpec podTemplateSpec = WorkloadUtils.getPodTemplateSpec(deployment);

--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/PodReviewHandler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/PodReviewHandler.java
@@ -47,6 +47,11 @@ public class PodReviewHandler extends AbstractReviewHandler<V1Pod> {
 
     V1Pod pod = getRequestObject(review);
 
+    if (K8sObjectUtils.isCiliumComponent(pod)) {
+      V1AdmissionReviewUtils.allow(review);
+      return;
+    }
+
     List<V1Node> allowedProjectNodeObjects;
     try {
       allowedProjectNodeObjects = this.podNodesResolver.getNodes(pod);


### PR DESCRIPTION
## Summary
- `WorkloadControllerReconciler.reconcileInternal`에서 cilium 컴포넌트를 reconciliation 대상에서 제외
- `app.kubernetes.io/part-of=cilium` 레이블 기반으로 식별 (cilium, cilium-envoy, cilium-operator, hubble-* 모두 커버)

## Why
`ReconciliationService.reconcileTolerations()`의 `replaceAllKeyAllEffectTolerations`는 `operator: Exists`(key/effect 없는 matches-all toleration)를 발견하면 두 개의 toleration으로 쪼개서 교체합니다:
- `NoExecute`의 모든 key (그대로 유지)
- `NoSchedule`은 `node-role.kubernetes.io/control-plane`만

cilium DaemonSet은 CNI라서 원래 `operator: Exists` 하나로 모든 taint를 무시하도록 설계되어 있는데, 변환 후에는 `node.kubernetes.io/not-ready:NoSchedule` 같은 NoSchedule taint를 견디지 못합니다.

결과적으로:
1. 노드 시작 시 `not-ready:NoSchedule` taint가 있는 상태
2. cilium pod가 schedule 안 됨
3. CNI 없으니 노드 영원히 NotReady
4. 클러스터 네트워킹 전체 다운

## Approach
- 시스템 네임스페이스(kube-system) 전체를 스킵하는 방식 대신 cilium만 정확히 타겟팅 (kube-proxy, coredns 등 다른 시스템 워크로드의 기존 reconciliation 동작은 유지)
- 이름 하드코딩 대신 cilium 공식 레이블 `app.kubernetes.io/part-of=cilium`를 사용하여 향후 추가 컴포넌트도 자동 커버

## Test plan
- [ ] cilium DaemonSet apply 후 reconciler가 toleration을 건드리지 않는지 확인
- [ ] cilium-envoy DaemonSet 동일 확인
- [ ] cilium 관련 없는 사용자 프로젝트 워크로드는 기존대로 reconciliation 되는지 확인
- [ ] kube-system의 다른 시스템 워크로드(coredns 등)는 기존대로 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)