### PR TITLE
feat: K8s CronJob에 owner-based 권한 부여 경로 추가 (AIP-1290)

### DIFF
--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/aipub/AipubUserRoleControllerFactory.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/aipub/AipubUserRoleControllerFactory.java
@@ -6,6 +6,7 @@ import io.kubernetes.client.extended.controller.builder.ControllerBuilder;
 import io.kubernetes.client.extended.controller.reconciler.Request;
 import io.kubernetes.client.extended.workqueue.WorkQueue;
 import io.kubernetes.client.informer.SharedInformerFactory;
+import io.kubernetes.client.openapi.models.V1CronJob;
 import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1Role;
 import io.ten1010.aipub.projectcontroller.controller.ControllerFactory;
@@ -61,6 +62,8 @@ public class AipubUserRoleControllerFactory implements ControllerFactory {
         .withReadyFunc(this.sharedInformerFactory.getExistingSharedIndexInformer(
             V1Job.class)::hasSynced)
         .withReadyFunc(this.sharedInformerFactory.getExistingSharedIndexInformer(
+            V1CronJob.class)::hasSynced)
+        .withReadyFunc(this.sharedInformerFactory.getExistingSharedIndexInformer(
             V1alpha1Operation.class)::hasSynced)
         .withReadyFunc(this.sharedInformerFactory.getExistingSharedIndexInformer(
             V1alpha1AipubVolume.class)::hasSynced)
@@ -72,6 +75,7 @@ public class AipubUserRoleControllerFactory implements ControllerFactory {
         .watch(this::createWorkspaceWatch)
         .watch(this::createAipubJobWatch)
         .watch(this::createJobWatch)
+        .watch(this::createCronJobWatch)
         .watch(this::createOperationWatch)
         .watch(this::createAipubVolumeWatch)
         .watch(this::createSftpServerWatch)
@@ -125,6 +129,14 @@ public class AipubUserRoleControllerFactory implements ControllerFactory {
     DefaultControllerWatch<V1Job> watch = new DefaultControllerWatch<>(workQueue, V1Job.class);
     watch.setOnUpdateFilter(this.onUpdateFilterFactory.jobFilter());
     watch.setRequestBuilder(this.requestBuilderFactory.jobToAipubUserRoles());
+    return watch;
+  }
+
+  private ControllerWatch<V1CronJob> createCronJobWatch(WorkQueue<Request> workQueue) {
+    DefaultControllerWatch<V1CronJob> watch = new DefaultControllerWatch<>(workQueue,
+        V1CronJob.class);
+    watch.setOnUpdateFilter(this.onUpdateFilterFactory.cronJobFilter());
+    watch.setRequestBuilder(this.requestBuilderFactory.cronJobToAipubUserRoles());
     return watch;
   }
 

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/aipub/AipubUserRoleReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/aipub/AipubUserRoleReconciler.java
@@ -7,6 +7,7 @@ import io.kubernetes.client.informer.SharedInformerFactory;
 import io.kubernetes.client.informer.cache.Indexer;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.RbacAuthorizationV1Api;
+import io.kubernetes.client.openapi.models.V1CronJob;
 import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1OwnerReference;
 import io.kubernetes.client.openapi.models.V1PolicyRule;
@@ -51,6 +52,7 @@ public class AipubUserRoleReconciler extends AbstractReconciler {
   private final Indexer<V1Workspace> workspaceIndexer;
   private final Indexer<V1alpha1AipubJob> aipubJobIndexer;
   private final Indexer<V1Job> jobIndexer;
+  private final Indexer<V1CronJob> cronJobIndexer;
   private final Indexer<V1alpha1Operation> operationIndexer;
   private final Indexer<V1alpha1AipubVolume> aipubVolumeIndexer;
   private final Indexer<V1alpha1SftpServer> sftpServerIndexer;
@@ -84,6 +86,9 @@ public class AipubUserRoleReconciler extends AbstractReconciler {
         .getIndexer();
     this.jobIndexer = sharedInformerFactory
         .getExistingSharedIndexInformer(V1Job.class)
+        .getIndexer();
+    this.cronJobIndexer = sharedInformerFactory
+        .getExistingSharedIndexInformer(V1CronJob.class)
         .getIndexer();
     this.operationIndexer = sharedInformerFactory
         .getExistingSharedIndexInformer(V1alpha1Operation.class)
@@ -139,6 +144,8 @@ public class AipubUserRoleReconciler extends AbstractReconciler {
         IndexerConstants.NAMESPACE_TO_OBJECTS_INDEXER_NAME, request.getNamespace());
     List<V1Job> jobs = this.jobIndexer.byIndex(
         IndexerConstants.NAMESPACE_TO_OBJECTS_INDEXER_NAME, request.getNamespace());
+    List<V1CronJob> cronJobs = this.cronJobIndexer.byIndex(
+        IndexerConstants.NAMESPACE_TO_OBJECTS_INDEXER_NAME, request.getNamespace());
     List<V1alpha1Operation> operations = this.operationIndexer.byIndex(
         IndexerConstants.NAMESPACE_TO_OBJECTS_INDEXER_NAME, request.getNamespace());
     List<V1alpha1AipubVolume> aipubVolumes = this.aipubVolumeIndexer.byIndex(
@@ -148,6 +155,7 @@ public class AipubUserRoleReconciler extends AbstractReconciler {
     workloads.addAll(workspaces);
     workloads.addAll(aipubJobs);
     workloads.addAll(jobs);
+    workloads.addAll(cronJobs);
     workloads.addAll(operations);
     workloads.addAll(aipubVolumes);
     workloads.addAll(sftpServers);

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/watch/RequestBuilderFactory.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/watch/RequestBuilderFactory.java
@@ -4,6 +4,7 @@ import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.extended.controller.reconciler.Request;
 import io.kubernetes.client.informer.SharedInformerFactory;
 import io.kubernetes.client.informer.cache.Indexer;
+import io.kubernetes.client.openapi.models.V1CronJob;
 import io.kubernetes.client.openapi.models.V1DaemonSet;
 import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1Namespace;
@@ -355,6 +356,19 @@ public class RequestBuilderFactory {
     return job -> {
       String projName = K8sObjectUtils.getNamespace(job);
       Optional<String> usernameOpt = UsernameUtils.getUsername(job);
+
+      if (usernameOpt.isPresent()) {
+        String roleName = this.aipubUserRoleNameResolver.resolveRoleName(usernameOpt.get());
+        return List.of(new Request(projName, roleName));
+      }
+      return List.of();
+    };
+  }
+
+  public Function<V1CronJob, List<Request>> cronJobToAipubUserRoles() {
+    return cronJob -> {
+      String projName = K8sObjectUtils.getNamespace(cronJob);
+      Optional<String> usernameOpt = UsernameUtils.getUsername(cronJob);
 
       if (usernameOpt.isPresent()) {
         String roleName = this.aipubUserRoleNameResolver.resolveRoleName(usernameOpt.get());

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/WorkloadResourceResolver.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/WorkloadResourceResolver.java
@@ -1,6 +1,7 @@
 package io.ten1010.aipub.projectcontroller.domain.k8s;
 
 import io.kubernetes.client.common.KubernetesObject;
+import io.kubernetes.client.openapi.models.V1CronJob;
 import io.kubernetes.client.openapi.models.V1Job;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -19,6 +20,7 @@ public class WorkloadResourceResolver {
         case "SFTPServer" -> "sftpservers";
         case "FtpServer" -> "ftpservers";
         case "Job" -> "jobs";
+        case "CronJob" -> "cronjobs";
         default -> null;
       };
       if (resourceName != null) {
@@ -28,14 +30,18 @@ public class WorkloadResourceResolver {
     if (workload instanceof V1Job) {
       return Optional.of("jobs");
     }
+    if (workload instanceof V1CronJob) {
+      return Optional.of("cronjobs");
+    }
     return Optional.empty();
   }
 
   public String resolveGroup(KubernetesObject workload) {
-    if (workload instanceof V1Job) {
+    if (workload instanceof V1Job || workload instanceof V1CronJob) {
       return "batch";
     }
-    if ("Job".equals(workload.getKind())) {
+    String kind = workload.getKind();
+    if ("Job".equals(kind) || "CronJob".equals(kind)) {
       return "batch";
     }
     return ProjectApiConstants.AIPUB_GROUP;


### PR DESCRIPTION
K8s Job 대응(#59)과 동일 패턴으로 batch/v1 CronJob도 aipub-user Role의 owner-based update/patch/delete 권한 메커니즘에 포함.

- WorkloadResourceResolver: "CronJob" -> "cronjobs" 매핑 (kind switch + V1CronJob instanceof fallback) 및 resolveGroup에서 V1CronJob → "batch"
- AipubUserRoleReconciler: Indexer<V1CronJob> 주입, workloads에 합치기
- AipubUserRoleControllerFactory: createCronJobWatch + V1CronJob hasSynced
- RequestBuilderFactory: cronJobToAipubUserRoles 추가

재사용: CronJobInformerRegistrar(이미 빈 등록), OnUpdateFilterFactory.cronJobFilter().