### PR TITLE
fix(AIP-1304): k8s 하위객체 user label patch하게 변경

### DIFF
--- a/src/main/java/io/ten1010/aipub/projectcontroller/configuration/ControllerConfiguration.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/configuration/ControllerConfiguration.java
@@ -61,7 +61,6 @@ public class ControllerConfiguration {
   public ControllerManager controllerManager(
       SharedInformerFactory sharedInformerFactory, List<Controller> controllers,
       List<WorkloadControllerFactory<?>> workloadControllerFactories) {
-    System.out.println(controllers);
     ControllerManagerBuilder builder = ControllerBuilder.controllerManagerBuilder(
         sharedInformerFactory);
     controllers.forEach(builder::addController);

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/aipub/AipubUserRoleBindingReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/aipub/AipubUserRoleBindingReconciler.java
@@ -110,7 +110,6 @@ public class AipubUserRoleBindingReconciler extends AbstractReconciler {
         deleteRoleBinding(roleBindingOpt.get());
         return new Result(false);
       }
-      System.out.println();
       if (ProjectUtils.getStatusAllBoundAipubUsers(projectOpt.get()).stream()
           .noneMatch(e -> e.equals(username))) {
         deleteRoleBinding(roleBindingOpt.get());

--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/UserLabelSynchronizer.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/UserLabelSynchronizer.java
@@ -16,8 +16,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Call;
-import okhttp3.MediaType;
-import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.jspecify.annotations.Nullable;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -270,17 +268,13 @@ public class UserLabelSynchronizer {
       Map<String, Object> labels = new HashMap<>();
       labels.put(LabelConstants.OBJECT_OWN_USERNAME_KEY, username);
       labels.put(LabelConstants.OBJECT_OWN_USERID_KEY, userid);
-      String patchBody = this.mapper.writeValueAsString(
+      byte[] bodyBytes = this.mapper.writeValueAsBytes(
           Map.of("metadata", Map.of("labels", labels)));
-
-      RequestBody body = RequestBody.create(
-          patchBody,
-          MediaType.parse("application/merge-patch+json"));
 
       Call call = this.apiClient.buildCall(
           this.apiClient.getBasePath(), path, "PATCH",
           List.of(), List.of(),
-          body,
+          bodyBytes,
           Map.of("Content-Type", "application/merge-patch+json"),
           Map.of(), Map.of(),
           new String[]{"BearerToken"}, null);

--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/UserLabelSynchronizer.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/UserLabelSynchronizer.java
@@ -27,6 +27,7 @@ import org.springframework.context.event.EventListener;
 public class UserLabelSynchronizer {
 
   private static final long SYNC_INTERVAL_MS = 300_000; // 5 minutes
+  private static final String LOG_PREFIX = "[USER-LABEL-SYNC]";
 
   private final ApiResourceDiscovery apiResourceDiscovery;
   private final ApiClient apiClient;
@@ -46,80 +47,128 @@ public class UserLabelSynchronizer {
 
   @EventListener(ApplicationReadyEvent.class)
   public void onApplicationReady() {
-    log.info("Application ready, starting UserLabelSynchronizer with interval {}ms", SYNC_INTERVAL_MS);
+    log.info("{} Application ready, starting UserLabelSynchronizer with interval {}ms",
+        LOG_PREFIX, SYNC_INTERVAL_MS);
     this.scheduler.scheduleWithFixedDelay(this::sync, 0, SYNC_INTERVAL_MS, TimeUnit.MILLISECONDS);
   }
 
   void sync() {
+    long startNanos = System.nanoTime();
+    log.info("{} Sync cycle started", LOG_PREFIX);
     try {
-      run();
+      Counters counters = run();
+      long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
+      log.info("{} Sync cycle done: pods={}, processed={}, skippedNoWorkloadLabel={}, "
+              + "ownerLookupFailed={}, alreadyInSync={}, patched={}, patchFailed={}, elapsedMs={}",
+          LOG_PREFIX, counters.totalPods, counters.processed, counters.skippedNoWorkloadLabel,
+          counters.ownerLookupFailed, counters.alreadyInSync, counters.patched,
+          counters.patchFailed, elapsedMs);
     } catch (Exception e) {
-      log.warn("Failed to sync user labels", e);
+      long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
+      log.warn("{} Sync cycle failed after {}ms", LOG_PREFIX, elapsedMs, e);
     }
   }
 
-  private void run() {
+  private Counters run() {
+    Counters c = new Counters();
+
     JsonNode podList = listPodsWithWorkloadLabel();
     if (podList == null) {
-      return;
+      log.warn("{} Pod list fetch returned null — sync cycle aborted", LOG_PREFIX);
+      return c;
     }
     JsonNode items = podList.path("items");
     if (!items.isArray()) {
-      return;
+      log.warn("{} Pod list items not array — sync cycle aborted", LOG_PREFIX);
+      return c;
     }
+    c.totalPods = items.size();
+    log.info("{} Listed {} pods with workload-kind label", LOG_PREFIX, c.totalPods);
 
     Map<String, String @Nullable []> cache = new HashMap<>();
 
     for (JsonNode pod : items) {
+      String namespace = pod.path("metadata").path("namespace").textValue();
+      String podName = pod.path("metadata").path("name").textValue();
+      if (namespace == null || podName == null) {
+        c.skippedNoWorkloadLabel++;
+        continue;
+      }
+
       JsonNode labels = pod.path("metadata").path("labels");
       if (!labels.isObject()) {
+        log.info("{} Skip pod {}/{}: no labels object", LOG_PREFIX, namespace, podName);
+        c.skippedNoWorkloadLabel++;
         continue;
       }
 
       JsonNode kindNode = labels.get(LabelConstants.WORKLOAD_KIND_KEY);
       JsonNode nameNode = labels.get(LabelConstants.WORKLOAD_NAME_KEY);
       if (kindNode == null || nameNode == null) {
+        log.info("{} Skip pod {}/{}: missing workload-kind/workload-name label",
+            LOG_PREFIX, namespace, podName);
+        c.skippedNoWorkloadLabel++;
         continue;
       }
       String kind = kindNode.textValue();
       String name = nameNode.textValue();
       if (kind == null || name == null) {
+        log.info("{} Skip pod {}/{}: workload-kind/workload-name label has null text",
+            LOG_PREFIX, namespace, podName);
+        c.skippedNoWorkloadLabel++;
         continue;
       }
 
-      String namespace = pod.path("metadata").path("namespace").textValue();
-      String podName = pod.path("metadata").path("name").textValue();
-      if (namespace == null || podName == null) {
-        continue;
-      }
+      c.processed++;
+      log.info("{} Processing pod {}/{}: owner={}/{}", LOG_PREFIX, namespace, podName, kind, name);
 
-      String cacheKey = kind + "/" + name;
+      String cacheKey = namespace + "::" + kind + "/" + name;
+      String @Nullable [] ownerLabels;
       if (cache.containsKey(cacheKey)) {
-        syncPodIfNeeded(pod, labels, podName, namespace, cache.get(cacheKey));
+        ownerLabels = cache.get(cacheKey);
+        log.info("{} Owner cache hit for {} → username={}, userid={}",
+            LOG_PREFIX, cacheKey,
+            ownerLabels == null ? null : ownerLabels[0],
+            ownerLabels == null ? null : ownerLabels[1]);
       } else {
-        String @Nullable [] ownerLabels = getOwnerUserLabels(kind, name, namespace);
-        if (ownerLabels == null) {
-          continue;
-        }
+        ownerLabels = getOwnerUserLabels(kind, name, namespace);
         cache.put(cacheKey, ownerLabels);
-        syncPodIfNeeded(pod, labels, podName, namespace, ownerLabels);
+      }
+
+      if (ownerLabels == null) {
+        c.ownerLookupFailed++;
+        log.warn("{} Owner lookup failed for pod {}/{}: owner={}/{} returned null — patch skipped",
+            LOG_PREFIX, namespace, podName, kind, name);
+        continue;
+      }
+
+      SyncResult result = syncPodIfNeeded(labels, podName, namespace, ownerLabels);
+      switch (result) {
+        case ALREADY_IN_SYNC -> c.alreadyInSync++;
+        case PATCHED -> c.patched++;
+        case PATCH_FAILED -> c.patchFailed++;
       }
     }
+
+    return c;
   }
 
-  private void syncPodIfNeeded(JsonNode pod, JsonNode labels, String podName, String namespace,
+  private SyncResult syncPodIfNeeded(JsonNode labels, String podName, String namespace,
       String[] ownerLabels) {
     String currentUsername = getTextValue(labels, LabelConstants.OBJECT_OWN_USERNAME_KEY);
     String currentUserid = getTextValue(labels, LabelConstants.OBJECT_OWN_USERID_KEY);
 
     if (Objects.equals(ownerLabels[0], currentUsername)
         && Objects.equals(ownerLabels[1], currentUserid)) {
-      return;
+      log.info("{} Pod {}/{} already in sync (username={}, userid={})",
+          LOG_PREFIX, namespace, podName, currentUsername, currentUserid);
+      return SyncResult.ALREADY_IN_SYNC;
     }
 
-    log.debug("Syncing user labels for pod {}/{}: username=[{}→{}], userid=[{}→{}]",
-        namespace, podName, currentUsername, ownerLabels[0], currentUserid, ownerLabels[1]);
-    patchPodLabels(podName, namespace, ownerLabels[0], ownerLabels[1]);
+    log.info("{} Patching pod {}/{}: username=[{}→{}], userid=[{}→{}]",
+        LOG_PREFIX, namespace, podName,
+        currentUsername, ownerLabels[0], currentUserid, ownerLabels[1]);
+    return patchPodLabels(podName, namespace, ownerLabels[0], ownerLabels[1]);
   }
 
   @Nullable
@@ -143,9 +192,12 @@ public class UserLabelSynchronizer {
     List<ApiResourceDiscovery.ResourceInfo> resources =
         this.apiResourceDiscovery.getResourcesByKind(kind);
     if (resources.isEmpty()) {
-      log.debug("No API resources found for kind: {}", kind);
+      log.warn("{} Owner lookup: no API resources found for kind={} (discovery snapshot miss)",
+          LOG_PREFIX, kind);
       return null;
     }
+    log.info("{} Owner lookup {}/{} ns={}: trying {} candidate resource(s)",
+        LOG_PREFIX, kind, name, namespace, resources.size());
 
     for (ApiResourceDiscovery.ResourceInfo resourceInfo : resources) {
       String apiVersion = resourceInfo.apiVersion();
@@ -157,6 +209,8 @@ public class UserLabelSynchronizer {
       try {
         namespaced = this.apiResourceDiscovery.isNamespaced(groupResource);
       } catch (GroupResourceNotFoundException e) {
+        log.info("{} Owner lookup: groupResource={} not in discovery — skipping candidate",
+            LOG_PREFIX, groupResource);
         continue;
       }
 
@@ -175,22 +229,30 @@ public class UserLabelSynchronizer {
         }
       }
 
+      log.info("{} Owner lookup attempt: GET {}", LOG_PREFIX, path);
       JsonNode obj = fetchJson(path);
       if (obj == null) {
+        log.info("{} Owner lookup attempt returned null (404 or fetch error): {}",
+            LOG_PREFIX, path);
         continue;
       }
 
       JsonNode labels = obj.path("metadata").path("labels");
       if (!labels.isObject()) {
+        log.warn("{} Owner object {}/{} has no labels object — returning null",
+            LOG_PREFIX, kind, name);
         return null;
       }
 
       String username = getTextValue(labels, LabelConstants.OBJECT_OWN_USERNAME_KEY);
       String userid = getTextValue(labels, LabelConstants.OBJECT_OWN_USERID_KEY);
+      log.info("{} Owner labels resolved {}/{} ns={}: username={}, userid={}",
+          LOG_PREFIX, kind, name, namespace, username, userid);
       return new String[]{username, userid};
     }
 
-    log.debug("Failed to find object {}/{}", kind, name);
+    log.warn("{} Owner lookup exhausted all candidates for {}/{} ns={} — returning null",
+        LOG_PREFIX, kind, name, namespace);
     return null;
   }
 
@@ -201,7 +263,7 @@ public class UserLabelSynchronizer {
     return fetchJson(path);
   }
 
-  private void patchPodLabels(String name, String namespace,
+  private SyncResult patchPodLabels(String name, String namespace,
       @Nullable String username, @Nullable String userid) {
     String path = "/api/v1/namespaces/" + namespace + "/pods/" + name;
     try {
@@ -224,16 +286,24 @@ public class UserLabelSynchronizer {
           new String[]{"BearerToken"}, null);
 
       try (Response response = call.execute()) {
-        if (!response.isSuccessful()) {
-          if (response.code() == 404) {
-            log.debug("Pod not found for patch: {}/{}", namespace, name);
-            return;
-          }
-          log.warn("Failed to patch pod {}/{}: status={}", namespace, name, response.code());
+        if (response.isSuccessful()) {
+          log.info("{} Patched pod {}/{} (status={})",
+              LOG_PREFIX, namespace, name, response.code());
+          return SyncResult.PATCHED;
         }
+        if (response.code() == 404) {
+          log.info("{} Pod {}/{} not found for patch (already deleted?)",
+              LOG_PREFIX, namespace, name);
+          return SyncResult.PATCH_FAILED;
+        }
+        String errorBody = response.body() != null ? response.body().string() : "";
+        log.warn("{} Failed to patch pod {}/{}: status={}, body={}",
+            LOG_PREFIX, namespace, name, response.code(), errorBody);
+        return SyncResult.PATCH_FAILED;
       }
     } catch (Exception e) {
-      log.warn("Failed to patch pod {}/{}", namespace, name, e);
+      log.warn("{} Failed to patch pod {}/{}", LOG_PREFIX, namespace, name, e);
+      return SyncResult.PATCH_FAILED;
     }
   }
 
@@ -251,7 +321,9 @@ public class UserLabelSynchronizer {
           if (response.code() == 404) {
             return null;
           }
-          log.warn("Failed to fetch: {} status={}", path, response.code());
+          String errorBody = response.body() != null ? response.body().string() : "";
+          log.warn("{} fetchJson failed: path={}, status={}, body={}",
+              LOG_PREFIX, path, response.code(), errorBody);
           return null;
         }
         if (response.body() == null) {
@@ -260,9 +332,25 @@ public class UserLabelSynchronizer {
         return this.mapper.readTree(response.body().string());
       }
     } catch (Exception e) {
-      log.warn("Failed to fetch: {}", path, e);
+      log.warn("{} fetchJson threw exception: path={}", LOG_PREFIX, path, e);
       return null;
     }
+  }
+
+  private enum SyncResult {
+    ALREADY_IN_SYNC,
+    PATCHED,
+    PATCH_FAILED,
+  }
+
+  private static final class Counters {
+    int totalPods;
+    int processed;
+    int skippedNoWorkloadLabel;
+    int ownerLookupFailed;
+    int alreadyInSync;
+    int patched;
+    int patchFailed;
   }
 
 }


### PR DESCRIPTION
## Summary

- `UserLabelSynchronizer.patchPodLabels`가 `ApiClient.buildCall`의 body 파라미터에 okhttp `RequestBody`를 그대로 넘기고 있었음. K8s java client는 그 Object를 Jackson으로 재직렬화하기 때문에 `RequestBody`가 `{}`로 변환되어 빈 merge-patch가 K8s API에 전달됨. 200 OK 응답은 받지만 라벨은 변경되지 않는 silent failure.
- 같은 코드 베이스의 `ApiResourceDiscovery.executeConfigMapWrite`와 동일하게 `byte[]`로 raw JSON을 직접 넘기도록 수정.
- 진단 과정에서 추가한 상세 INFO 로깅을 함께 머지하여 향후 sync 동작을 추적 가능하게 함 (`[USER-LABEL-SYNC]` prefix, cycle 카운터 요약, owner lookup 경로, patch 시도/결과).
- 별건으로 발견된 잔여 디버그 `System.out.println` 두 곳 제거.


## Verification

운영 클러스터(`aipub/project-controller`)에서 검증 완료:
- 수정 전: status=200 응답에도 Pod 라벨 변화 없음
- 수정 후: `Patching pod test-namespace/sftp-th-4a5b48eb: username=[aipubadmin→taehyeong-qa-01]` 로그 + 실제 Pod 라벨 변경 확인

## Out of Scope

- Service / 기타 CR의 라벨 sync는 여전히 지원 안 됨 (Synchronizer가 구조상 Pod-only). 별도 작업으로 진행 예정.

## Test plan

- [x] `UserLabelSynchronizerTest` 7개 모두 통과
- [x] 운영 클러스터에서 실제 transfer 케이스에 대해 Pod 라벨 patch 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)