### PR TITLE
fix(AIP-1421): tcpportvalidator/ingresshostpathvalidator CRD 이름 변경 반영

### DIFF
--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ProjectApiConstants.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ProjectApiConstants.java
@@ -32,11 +32,11 @@ public final class ProjectApiConstants {
   public static final String NODE_RESOURCE_RESOURCE_KIND = "NodeResources";
   public static final String NODE_RESOURCE_RESOURCE_PLURAL = "noderesources";
 
-  public static final String TCP_PORT_VALIDATORS_RESOURCE_KIND = "TCPPortValidator";
-  public static final String TCP_PORT_VALIDATORS_RESOURCE_PLURAL = "tcpportvalidators";
+  public static final String TCP_PORT_VALIDATION_RESOURCE_KIND = "TCPPortValidation";
+  public static final String TCP_PORT_VALIDATION_RESOURCE_PLURAL = "tcpportvalidations";
 
-  public static final String INGRESS_HOST_PATH_VALIDATORS_RESOURCE_KIND = "IngressHostPathValidator";
-  public static final String INGRESS_HOST_PATH_VALIDATORS_RESOURCE_PLURAL = "ingresshostpathvalidators";
+  public static final String HOST_PATH_VALIDATION_RESOURCE_KIND = "HostPathValidation";
+  public static final String HOST_PATH_VALIDATION_RESOURCE_PLURAL = "hostpathvalidations";
 
   public static final String USER_WORKSPACE_RECLAIM_RESOURCE_KIND = "UserWorkspaceReclaim";
   public static final String USER_WORKSPACE_RECLAIM_RESOURCE_PLURAL = "userworkspacereclaims";

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationService.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationService.java
@@ -464,23 +464,23 @@ public class ReconciliationService {
       reconciled.add(resourceSetApiRule);
     }
 
-    V1PolicyRule tcpPortValidatorsApiRule = switch (projectRoleEnum) {
+    V1PolicyRule tcpPortValidationsApiRule = switch (projectRoleEnum) {
       case PROJECT_MANAGER, PROJECT_DEVELOPER -> new V1PolicyRuleBuilder()
           .withApiGroups(ProjectApiConstants.AIPUB_GROUP)
-          .withResources(ProjectApiConstants.TCP_PORT_VALIDATORS_RESOURCE_PLURAL)
+          .withResources(ProjectApiConstants.TCP_PORT_VALIDATION_RESOURCE_PLURAL)
           .withVerbs("create")
           .build();
     };
-    reconciled.add(tcpPortValidatorsApiRule);
+    reconciled.add(tcpPortValidationsApiRule);
 
-    V1PolicyRule ingressHostPathValidatorsApiRule = switch (projectRoleEnum) {
+    V1PolicyRule hostPathValidationsApiRule = switch (projectRoleEnum) {
       case PROJECT_MANAGER, PROJECT_DEVELOPER -> new V1PolicyRuleBuilder()
           .withApiGroups(ProjectApiConstants.AIPUB_GROUP)
-          .withResources(ProjectApiConstants.INGRESS_HOST_PATH_VALIDATORS_RESOURCE_PLURAL)
+          .withResources(ProjectApiConstants.HOST_PATH_VALIDATION_RESOURCE_PLURAL)
           .withVerbs("create")
           .build();
     };
-    reconciled.add(ingressHostPathValidatorsApiRule);
+    reconciled.add(hostPathValidationsApiRule);
 
     V1PolicyRule nodeGpuUsagesApiRule = switch (projectRoleEnum) {
       case PROJECT_MANAGER, PROJECT_DEVELOPER -> new V1PolicyRuleBuilder()


### PR DESCRIPTION
CRD가 tcpportvalidation, hostpathvalidation 으로 rename됨에 따라 ProjectApiConstants 상수와 ReconciliationService의 PolicyRule 빌더 참조를 갱신. PROJECT_MANAGER/PROJECT_DEVELOPER 의 create 권한은 새 plural 이름으로 유지됨.