### PR TITLE
chore: ChainJob CRD 변경에 따른 startAt 필드 추가

### DIFF
--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/dto/V1alpha1ChainJobSpec.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/dto/V1alpha1ChainJobSpec.java
@@ -1,5 +1,6 @@
 package io.ten1010.aipub.projectcontroller.domain.k8s.dto;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import lombok.Data;
 import org.jspecify.annotations.Nullable;
@@ -9,6 +10,8 @@ public class V1alpha1ChainJobSpec {
 
   @Nullable
   private Long activeDeadlineSeconds;
+  @Nullable
+  private OffsetDateTime startAt;
   @Nullable
   private Boolean suspend;
   @Nullable


### PR DESCRIPTION
## 요약
- ChainJob CRD 스펙 변경에 따라 `V1alpha1ChainJobSpec` DTO에 신규 필드 `startAt` (`OffsetDateTime`) 추가
- `startAt`은 ChainJob의 실행 시작 시각을 지정하는 필드로, 미설정 시 즉시 실행됨

## 변경 파일
- `V1alpha1ChainJobSpec.java`: `startAt` 필드 및 `java.time.OffsetDateTime` import 추가

## 테스트 계획
- [x] Maven 컴파일 정상 확인
- [ ] ChainJob 관련 informer/indexer 동작에 영향 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)