### PR TITLE
feat(rbac): ImageBuild 권한을 프로젝트 멤버 Role 에 반영

### DIFF
--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/aipub/AipubUserRoleControllerFactory.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/aipub/AipubUserRoleControllerFactory.java
@@ -19,6 +19,7 @@ import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1beta1Workspace;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubUser;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubVolume;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ChainJob;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ImageBuild;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Operation;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Project;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1SftpServer;
@@ -69,6 +70,8 @@ public class AipubUserRoleControllerFactory implements ControllerFactory {
             V1alpha1AipubVolume.class)::hasSynced)
         .withReadyFunc(this.sharedInformerFactory.getExistingSharedIndexInformer(
             V1alpha1SftpServer.class)::hasSynced)
+        .withReadyFunc(this.sharedInformerFactory.getExistingSharedIndexInformer(
+            V1alpha1ImageBuild.class)::hasSynced)
         .watch(this::createRoleWatch)
         .watch(this::createProjectWatch)
         .watch(this::createAipubUserWatch)
@@ -79,6 +82,7 @@ public class AipubUserRoleControllerFactory implements ControllerFactory {
         .watch(this::createOperationWatch)
         .watch(this::createAipubVolumeWatch)
         .watch(this::createSftpServerWatch)
+        .watch(this::createImageBuildWatch)
         .withReconciler(new AipubUserRoleReconciler(this.sharedInformerFactory, this.k8sApiProvider,
             this.reconciliationService))
         .build();
@@ -163,6 +167,14 @@ public class AipubUserRoleControllerFactory implements ControllerFactory {
         V1alpha1SftpServer.class);
     watch.setOnUpdateFilter(this.onUpdateFilterFactory.sftpServerFilter());
     watch.setRequestBuilder(this.requestBuilderFactory.sftpServerToAipubUserRoles());
+    return watch;
+  }
+
+  private ControllerWatch<V1alpha1ImageBuild> createImageBuildWatch(WorkQueue<Request> workQueue) {
+    DefaultControllerWatch<V1alpha1ImageBuild> watch = new DefaultControllerWatch<>(workQueue,
+        V1alpha1ImageBuild.class);
+    watch.setOnUpdateFilter(this.onUpdateFilterFactory.imageBuildFilter());
+    watch.setRequestBuilder(this.requestBuilderFactory.imageBuildToAipubUserRoles());
     return watch;
   }
 

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/aipub/AipubUserRoleReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/aipub/AipubUserRoleReconciler.java
@@ -26,6 +26,7 @@ import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1beta1Workspace;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubUser;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubVolume;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ChainJob;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ImageBuild;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Operation;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Project;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1SftpServer;
@@ -56,6 +57,7 @@ public class AipubUserRoleReconciler extends AbstractReconciler {
   private final Indexer<V1alpha1Operation> operationIndexer;
   private final Indexer<V1alpha1AipubVolume> aipubVolumeIndexer;
   private final Indexer<V1alpha1SftpServer> sftpServerIndexer;
+  private final Indexer<V1alpha1ImageBuild> imageBuildIndexer;
   private final BoundObjectResolver boundObjectResolver;
   private final RbacAuthorizationV1Api rbacAuthorizationV1Api;
 
@@ -98,6 +100,9 @@ public class AipubUserRoleReconciler extends AbstractReconciler {
         .getIndexer();
     this.sftpServerIndexer = sharedInformerFactory
         .getExistingSharedIndexInformer(V1alpha1SftpServer.class)
+        .getIndexer();
+    this.imageBuildIndexer = sharedInformerFactory
+        .getExistingSharedIndexInformer(V1alpha1ImageBuild.class)
         .getIndexer();
     this.boundObjectResolver = new BoundObjectResolver(sharedInformerFactory);
     this.rbacAuthorizationV1Api = new RbacAuthorizationV1Api(k8sApiProvider.getApiClient());
@@ -152,6 +157,8 @@ public class AipubUserRoleReconciler extends AbstractReconciler {
         IndexerConstants.NAMESPACE_TO_OBJECTS_INDEXER_NAME, request.getNamespace());
     List<V1alpha1SftpServer> sftpServers = this.sftpServerIndexer.byIndex(
         IndexerConstants.NAMESPACE_TO_OBJECTS_INDEXER_NAME, request.getNamespace());
+    List<V1alpha1ImageBuild> imageBuilds = this.imageBuildIndexer.byIndex(
+        IndexerConstants.NAMESPACE_TO_OBJECTS_INDEXER_NAME, request.getNamespace());
     workloads.addAll(v1beta1Workspaces);
     workloads.addAll(chainJobs);
     workloads.addAll(jobs);
@@ -159,6 +166,7 @@ public class AipubUserRoleReconciler extends AbstractReconciler {
     workloads.addAll(operations);
     workloads.addAll(aipubVolumes);
     workloads.addAll(sftpServers);
+    workloads.addAll(imageBuilds);
 
     List<V1OwnerReference> reconciledReferences = this.reconciliationService.reconcileOwnerReferences(
         roleOpt.orElse(null), userOpt.get());

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/watch/OnUpdateFilterFactory.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/watch/OnUpdateFilterFactory.java
@@ -21,6 +21,7 @@ import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1beta1Workspace;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubUser;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubVolume;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ChainJob;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ImageBuild;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ImageHub;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1NodeGroup;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Operation;
@@ -321,6 +322,12 @@ public class OnUpdateFilterFactory {
             ||
             !WorkloadUtils.getPodTemplateSpec(oldObj)
                 .equals(WorkloadUtils.getPodTemplateSpec(newObj));
+  }
+
+  public BiPredicate<V1alpha1ImageBuild, V1alpha1ImageBuild> imageBuildFilter() {
+    return (oldObj, newObj) ->
+        !K8sObjectUtils.getOwnerReferences(oldObj).equals(K8sObjectUtils.getOwnerReferences(newObj))
+            || !K8sObjectUtils.getLabels(oldObj).equals(K8sObjectUtils.getLabels(newObj));
   }
 
 }

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/watch/RequestBuilderFactory.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/watch/RequestBuilderFactory.java
@@ -23,6 +23,7 @@ import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1beta1Workspace;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubUser;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubVolume;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ChainJob;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ImageBuild;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ImageHub;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1NodeGroup;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Operation;
@@ -408,6 +409,19 @@ public class RequestBuilderFactory {
     return sftpServer -> {
       String projName = K8sObjectUtils.getNamespace(sftpServer);
       Optional<String> usernameOpt = UsernameUtils.getUsername(sftpServer);
+
+      if (usernameOpt.isPresent()) {
+        String roleName = this.aipubUserRoleNameResolver.resolveRoleName(usernameOpt.get());
+        return List.of(new Request(projName, roleName));
+      }
+      return List.of();
+    };
+  }
+
+  public Function<V1alpha1ImageBuild, List<Request>> imageBuildToAipubUserRoles() {
+    return imageBuild -> {
+      String projName = K8sObjectUtils.getNamespace(imageBuild);
+      Optional<String> usernameOpt = UsernameUtils.getUsername(imageBuild);
 
       if (usernameOpt.isPresent()) {
         String roleName = this.aipubUserRoleNameResolver.resolveRoleName(usernameOpt.get());

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/K8sApiProvider.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/K8sApiProvider.java
@@ -10,6 +10,8 @@ import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubVolume;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubVolumeList;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ChainJob;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ChainJobList;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ImageBuild;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ImageBuildList;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ImageHub;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ImageHubList;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1NodeGroup;
@@ -38,6 +40,7 @@ public class K8sApiProvider {
   private final GenericKubernetesApi<V1alpha1Operation, V1alpha1OperationList> operationApi;
   private final GenericKubernetesApi<V1alpha1AipubVolume, V1alpha1AipubVolumeList> aipubVolumeApi;
   private final GenericKubernetesApi<V1alpha1SftpServer, V1alpha1SftpServerList> sftpServerApi;
+  private final GenericKubernetesApi<V1alpha1ImageBuild, V1alpha1ImageBuildList> imageBuildApi;
 
   public K8sApiProvider(ApiClient apiClient) {
     this.apiClient = apiClient;
@@ -51,6 +54,7 @@ public class K8sApiProvider {
     this.operationApi = createOperationApi(apiClient);
     this.aipubVolumeApi = createAipubVolumeApi(apiClient);
     this.sftpServerApi = createSftpServerApi(apiClient);
+    this.imageBuildApi = createImageBuildApi(apiClient);
   }
 
   private static GenericKubernetesApi<V1alpha1Project, V1alpha1ProjectList> createProjectApi(
@@ -165,6 +169,18 @@ public class K8sApiProvider {
         ProjectApiConstants.AIPUB_GROUP,
         ProjectApiConstants.VERSION_V1ALPHA1,
         ProjectApiConstants.SFTP_SERVER_RESOURCE_PLURAL,
+        apiClient
+    );
+  }
+
+  private static GenericKubernetesApi<V1alpha1ImageBuild, V1alpha1ImageBuildList> createImageBuildApi(
+      ApiClient apiClient) {
+    return new GenericKubernetesApi<>(
+        V1alpha1ImageBuild.class,
+        V1alpha1ImageBuildList.class,
+        ProjectApiConstants.AIPUB_GROUP,
+        ProjectApiConstants.VERSION_V1ALPHA1,
+        ProjectApiConstants.IMAGE_BUILD_RESOURCE_PLURAL,
         apiClient
     );
   }

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ProjectApiConstants.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ProjectApiConstants.java
@@ -69,6 +69,9 @@ public final class ProjectApiConstants {
   public static final String SFTP_SERVER_RESOURCE_KIND = "SFTPServer";
   public static final String SFTP_SERVER_RESOURCE_PLURAL = "sftpservers";
 
+  public static final String IMAGE_BUILD_RESOURCE_KIND = "ImageBuild";
+  public static final String IMAGE_BUILD_RESOURCE_PLURAL = "imagebuilds";
+
   private ProjectApiConstants() {
   }
 

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationService.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationService.java
@@ -654,6 +654,11 @@ public class ReconciliationService {
             .withResources("commits")
             .withVerbs("*")
             .build();
+        V1PolicyRule imageBuildApiRule = new V1PolicyRuleBuilder()
+            .withApiGroups(ProjectApiConstants.AIPUB_GROUP)
+            .withResources(ProjectApiConstants.IMAGE_BUILD_RESOURCE_PLURAL)
+            .withVerbs("*")
+            .build();
         //todo --
 
         yield List.of(
@@ -671,7 +676,8 @@ public class ReconciliationService {
             aipubSFtpServerApiRule,
             aipubVolumesApiRule,
             resourceQuotaApiRule,
-            commitApiRule
+            commitApiRule,
+            imageBuildApiRule
         );
       }
 
@@ -759,6 +765,11 @@ public class ReconciliationService {
             .withResources("commits")
             .withVerbs(BASIC_VERBS)
             .build();
+        V1PolicyRule imageBuildApiRule = new V1PolicyRuleBuilder()
+            .withApiGroups(ProjectApiConstants.AIPUB_GROUP)
+            .withResources(ProjectApiConstants.IMAGE_BUILD_RESOURCE_PLURAL)
+            .withVerbs(BASIC_VERBS)
+            .build();
         //todo --
 
         yield List.of(
@@ -776,7 +787,8 @@ public class ReconciliationService {
             aipubSFtpServerApiRule,
             aipubVolumesApiRule,
             resourceQuotaApiRule,
-            commitApiRule
+            commitApiRule,
+            imageBuildApiRule
         );
       }
     };

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/WorkloadResourceResolver.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/WorkloadResourceResolver.java
@@ -3,6 +3,7 @@ package io.ten1010.aipub.projectcontroller.domain.k8s;
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.openapi.models.V1CronJob;
 import io.kubernetes.client.openapi.models.V1Job;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ImageBuild;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -21,6 +22,7 @@ public class WorkloadResourceResolver {
         case "Job" -> "jobs";
         case "CronJob" -> "cronjobs";
         case "ChainJob" -> "chainjobs";
+        case "ImageBuild" -> "imagebuilds";
         default -> null;
       };
       if (resourceName != null) {
@@ -32,6 +34,9 @@ public class WorkloadResourceResolver {
     }
     if (workload instanceof V1CronJob) {
       return Optional.of("cronjobs");
+    }
+    if (workload instanceof V1alpha1ImageBuild) {
+      return Optional.of("imagebuilds");
     }
     return Optional.empty();
   }

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/dto/V1alpha1ImageBuild.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/dto/V1alpha1ImageBuild.java
@@ -1,0 +1,18 @@
+package io.ten1010.aipub.projectcontroller.domain.k8s.dto;
+
+import io.kubernetes.client.common.KubernetesObject;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import lombok.Data;
+import org.jspecify.annotations.Nullable;
+
+@Data
+public class V1alpha1ImageBuild implements KubernetesObject {
+
+  @Nullable
+  private String apiVersion;
+  @Nullable
+  private String kind;
+  @Nullable
+  private V1ObjectMeta metadata;
+
+}

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/dto/V1alpha1ImageBuildList.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/dto/V1alpha1ImageBuildList.java
@@ -1,0 +1,21 @@
+package io.ten1010.aipub.projectcontroller.domain.k8s.dto;
+
+import io.kubernetes.client.common.KubernetesListObject;
+import io.kubernetes.client.openapi.models.V1ListMeta;
+import java.util.List;
+import lombok.Data;
+import org.jspecify.annotations.Nullable;
+
+@Data
+public class V1alpha1ImageBuildList implements KubernetesListObject {
+
+  @Nullable
+  private String apiVersion;
+  @Nullable
+  private String kind;
+  @Nullable
+  private V1ListMeta metadata;
+  @Nullable
+  private List<V1alpha1ImageBuild> items;
+
+}

--- a/src/main/java/io/ten1010/aipub/projectcontroller/informer/SharedInformerFactoryProvider.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/informer/SharedInformerFactoryProvider.java
@@ -31,6 +31,7 @@ import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1beta1Workspace;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubUser;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubVolume;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ChainJob;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ImageBuild;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ImageHub;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1NodeGroup;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Operation;
@@ -84,6 +85,7 @@ public class SharedInformerFactoryProvider {
     registerAipubVolumeInformer(informerFactory);
     registerChainJobInformer(informerFactory);
     registerSftpServerInformer(informerFactory);
+    registerImageBuildInformer(informerFactory);
     registerPodInformer(informerFactory);
     this.registrars.forEach(e -> e.registerInformer(informerFactory));
 
@@ -353,6 +355,16 @@ public class SharedInformerFactoryProvider {
     SharedIndexInformer<V1alpha1SftpServer> informer = informerFactory.sharedIndexInformerFor(
         this.k8sApiProvider.getSftpServerApi(),
         V1alpha1SftpServer.class,
+        DEFAULT_RESYNC_PERIOD);
+    informer.addIndexers(Map.of(
+        IndexerConstants.NAMESPACE_TO_OBJECTS_INDEXER_NAME,
+        obj -> List.of(K8sObjectUtils.getNamespace(obj))));
+  }
+
+  private void registerImageBuildInformer(SharedInformerFactory informerFactory) {
+    SharedIndexInformer<V1alpha1ImageBuild> informer = informerFactory.sharedIndexInformerFor(
+        this.k8sApiProvider.getImageBuildApi(),
+        V1alpha1ImageBuild.class,
         DEFAULT_RESYNC_PERIOD);
     informer.addIndexers(Map.of(
         IndexerConstants.NAMESPACE_TO_OBJECTS_INDEXER_NAME,


### PR DESCRIPTION
## 배경 / 목적

project controller 가 프로젝트 멤버에게 같은 namespace 의 `ImageBuild`(`imagebuilds.aipub.ten1010.io`) 에 대한 권한을 부여하도록 RBAC 리컨실 로직을 확장한다. imagekit(ImageKit) 의 빌드 트리거/조회 플로우가 멤버 권한 체계 안에서 동작하도록 하기 위함이다.

## 권한 모델

`workspaces`/`operations`/`chainjobs` 등 기존 aipub CR 과 동일한 패턴을 따른다.

| 동작 | 부여 주체 | 구현 |
|---|---|---|
| **get / list / watch** | 같은 namespace 의 모든 멤버 | project Role (DEVELOPER `BASIC_VERBS`, MANAGER `*`) |
| **create** | 모든 멤버 (생성자가 됨) | DEVELOPER `BASIC_VERBS` 에 포함 |
| **update / patch / delete** | ① 생성자 본인 ② project manager ③ aipub admin | ① AipubUser per-user Role(resourceName 한정) ② MANAGER `*` ③ `oidc:aipub-admin` → `cluster-admin`(기존) |

- 생성자 매칭은 `aipub.ten1010.io/username` 라벨(`UsernameUtils`)로 이뤄진다.
- 이 라벨은 imagekit-web 이 CR 생성 시 설정하며, **user-v2 mutating webhook(`aipub.ten1010.io/*` CREATE 적용)** 이 서버 사이드로 강제하므로 클라이언트 스푸핑 위험이 없다.

## 변경 내용

- `ProjectApiConstants` — `IMAGE_BUILD_*` 상수
- **신규 DTO** `V1alpha1ImageBuild`, `V1alpha1ImageBuildList`
- `K8sApiProvider` — `imageBuildApi` (group `aipub.ten1010.io/v1alpha1`, plural `imagebuilds`)
- `SharedInformerFactoryProvider` — ImageBuild informer + namespace 인덱서
- `ReconciliationService.reconcileProjectRoleRules` — MANAGER `*` / DEVELOPER `BASIC_VERBS` 규칙
- `AipubUserRoleReconciler` — per-user 소유 워크로드 목록에 imagebuilds 추가
- `WorkloadResourceResolver` — `ImageBuild` → `imagebuilds` 매핑 (informer list 단계 TypeMeta 누락 대비 instanceof 폴백)
- `OnUpdateFilterFactory` / `RequestBuilderFactory` / `AipubUserRoleControllerFactory` — ImageBuild watch 트리거(생성/소유자 변경/삭제 시 per-user Role 재조정)

## 검증

- `./mvnw -o clean compile` → BUILD SUCCESS
- `./mvnw -o test` → **78 tests, 0 failures, 0 errors**
- 컨트롤러 SA(`*/*/*`)·aipub admin(`cluster-admin`) 은 기존 매니페스트로 충족 → k8s 매니페스트 변경 없음

## 운영 전제

컨트롤러가 시작 시 `imagebuilds.aipub.ten1010.io` CRD 를 list/watch 하므로, 해당 CRD 가 클러스터에 설치돼 있어야 AipubUserRole 컨트롤러가 ready 상태가 된다(operations/workspaces 등 다른 CR informer 와 동일한 전제).

🤖 Generated with [Claude Code](https://claude.com/claude-code)