### PR TITLE
feat(AIP-1998): reconcile 제외 워크로드를 라벨 셀렉터 설정으로 분리

### DIFF
--- a/docs/AIP-1998-kubevirt-virt-handler-diagnosis.md
+++ b/docs/AIP-1998-kubevirt-virt-handler-diagnosis.md
@@ -1,38 +1,55 @@
-# AIP-1998 — KubeVirt virt-handler 파드 churn 진단 노트
+# AIP-1998 — KubeVirt virt-handler 파드 churn 진단/조치 노트
 
-> 퇴근 전 인계용 메모. 집에서 이어서 확인하기 위한 스냅샷.
-> 진단 로그 커밋(`[AIP-1998-EXCLUDE]`)이 적용된 이미지로 배포한 뒤의 관찰 기록이다.
+> 원인 확정 및 조치 완료 기록. (초기 인계 메모 → 클러스터 실측으로 결론 확정)
 
 ## TL;DR
 
-- **project controller ↔ virt-operator 패치 루프 자체(AIP-1998 본래 문제)는 fix가 동작 중.** project controller 로그에 virt-handler를 skip하는 로그가 정상적으로 찍힌다.
-- **그런데 virt-handler 파드는 여전히 약 30초 주기로 죽고, DaemonSet generation도 계속 오른다.**
-- generation이 계속 오른다 = **누군가 DaemonSet 템플릿(spec)을 반복적으로 패치하고 있다.** project controller는 skip 중이므로 **그 writer는 project controller가 아니다.** → virt-operator 또는 coaster(GPU 오퍼레이터) 등 다른 주체가 유력.
-- 즉 **남은 churn은 AIP-1998(project controller)과 별개의 원인**이며, 별도 진단이 필요하다. AIP-1998 PR 자체는 이대로 머지 가능하고, 진단 로그 커밋만 나중에 revert하면 된다.
+- virt-handler 파드가 ~10~30초 주기로 재생성되고 DaemonSet generation이 무한 증가하던 현상의 원인은 **virt-handler DS 템플릿을 두고 벌어지는 두 개의 독립적인 패치 전쟁**이었다.
+  - **War A** — `template.spec.affinity` 를 두고 **coaster ↔ virt-operator** 가 다툼.
+  - **War B** — `template.spec.tolerations` 를 두고 **project-controller ↔ virt-operator** 가 다툼.
+- 두 전쟁 모두 "제3의 writer가 virt-operator 소유 DS를 직접 패치 → virt-operator가 KubeVirt CR 기준 desired로 되돌림" 이라는 동일 구조다.
+- 조치: **(A)** KubeVirt CR `spec.workloads.nodePlacement.affinity` 에 coaster의 evict-ds affinity를 동일하게 선언, **(B)** project-controller의 `kubevirt.io` reconcile 제외 유지. 두 조치는 서로 독립적이며 **둘 다 필요**하다(실험으로 확인).
 
-## 확정된 사실 (fix 동작 증거)
+## 근본 원인: virt-operator의 DaemonSet 소유/재조정
 
-project controller 로그:
+KubeVirt `pkg/virt-operator/resource/apply/apps.go` 의 `syncDaemonSet`:
+
+- `DaemonSetIsUpToDate(...)` + generation 비교(`GetExpectedGeneration`)로 실제 DS가 desired와 다른지 감지한다.
+- `placement.InjectPlacementMetadata(kv.Spec.Workloads, &daemonSet.Spec.Template.Spec, ...)` 로 **KubeVirt CR `spec.workloads` 기준의 desired 템플릿(affinity/nodeSelector/tolerations)을 강제**한다.
+- 차이가 있으면 `patchDaemonSet` 으로 되돌린다.
+
+즉 **누가 virt-handler DS 템플릿을 직접 패치하든, 그 값이 KubeVirt CR에 반영돼 있지 않으면 virt-operator가 매번 원복**한다. 상대 writer가 다시 쓰면 → 무한 패치 루프 → generation 증가 → rolling update → 파드 churn.
+
+> 일반 DaemonSet(csi-nfs-node, dcgm-exporter 등)은 이런 능동적 소유자가 없어 외부 주입이 그대로 유지되므로 문제가 없다. **virt-handler만 소유자(virt-operator)가 지속 reconcile하기 때문에** 전쟁이 난다.
+
+## War A — affinity (coaster ↔ virt-operator)
+
+- coaster(GPU 오퍼레이터)는 GPU 재구성 시 노드에서 DaemonSet을 드레인하기 위해 **클러스터의 거의 모든 DaemonSet에 evict-ds nodeAffinity를 주입**한다. virt-handler에 주입하는 값은:
+
+  ```yaml
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: gpuconfig.coaster.ten1010.io/evict-ds
+          operator: DoesNotExist
+  ```
+
+- KubeVirt CR에는 affinity가 선언돼 있지 않았으므로(→ virt-operator의 desired에는 affinity 없음), virt-operator가 이 affinity를 drift로 보고 계속 제거 → coaster가 재주입 → 전쟁.
+- managedFields상 affinity 필드 소유자는 `OpenAPI-Generator` (coaster의 Kubernetes 클라이언트 기본 field manager).
+
+**직접 관찰(조치 전):**
 
 ```
-[AIP-1998-EXCLUDE] reconcile skipped for excluded workload: kind=V1DaemonSet namespace=kubevirt name=virt-handler
+gen=15853  affinityKey=[gpuconfig.coaster.ten1010.io/evict-ds]   ← coaster 주입
+gen=15854  affinityKey=[]                                         ← virt-operator 제거 (gen++)
+gen=15857  affinityKey=[gpuconfig.coaster.ten1010.io/evict-ds]    ← coaster 재주입 (gen++)
 ```
 
-→ `reconcile-excluded-label-selectors` 의 `kubevirt.io` 셀렉터가 적용되어, project controller의 DaemonSet reconciler가 virt-handler를 더 이상 패치하지 않는다. (scale-to-0 테스트 때도 generation 증가가 멈췄던 것과 일관)
-
-## 미해결: 남은 30초 주기 파드 churn
-
-관찰된 증상:
-
-- virt-handler 파드가 Running 까지 갔다가 `Killing/Stopping` 되고 **새 파드 이름으로 재생성**된다 (컨테이너 in-place 재시작이 아님, RESTARTS=0).
-- 이벤트:
-  - `Warning FailedUpdate  daemonSet virt-handler rollout failed`
-  - `Warning PodFailed     Pod is in Failed state` (반복)
-- **DaemonSet generation 계속 증가** (project controller skip 중인데도) → 다른 writer가 템플릿을 패치 중.
-
-유력 단서 — DaemonSet 템플릿의 nodeAffinity:
+**조치 A:** KubeVirt CR에 coaster가 원하는 affinity를 **정확히 동일하게** 선언 → virt-operator의 desired에 포함되어 더 이상 원복하지 않음. 값이 다르면(예: 키 추가) 새 전쟁이 나므로 관찰된 단일 키를 그대로 사용해야 한다.
 
 ```yaml
+# KubeVirt CR spec.workloads.nodePlacement
 affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
@@ -40,52 +57,52 @@ affinity:
       - matchExpressions:
         - key: gpuconfig.coaster.ten1010.io/evict-ds
           operator: DoesNotExist
+tolerations:                       # 기존 유지
+- { effect: NoSchedule, key: project.aipub.ten1010.io/project-managed, operator: Exists }
+- { effect: NoExecute,  key: project.aipub.ten1010.io/project-managed, operator: Exists }
 ```
 
-- `evict-ds`(DaemonSet 축출)라는 이름 + reservedNamespace 목록에 `coaster`가 포함됨.
-- 가설: **coaster(GPU 오퍼레이터)가 노드에 `gpuconfig.coaster.ten1010.io/evict-ds` 라벨을 붙였다/뗐다 하며 virt-handler 파드를 축출·재생성**시키고 있을 가능성. 또는 virt-operator가 자신의 desired state와 어긋남을 감지해 파드를 지우는 루프.
-- generation이 오르는 것까지 설명하려면, 누군가 **템플릿(affinity 등)을 주기적으로 바꾸는** 쪽을 의심해야 한다 (coaster ↔ virt-operator 간 또다른 2-writer 충돌 가능성).
+**검증(조치 후):** apply 직후 gen +1(반영) 후 **고정**, affinity present 유지, 파드 안정(RESTARTS=0, AGE 지속 증가).
 
-## 집에서 확인할 진단 명령
+## War B — tolerations (project-controller ↔ virt-operator)
 
-```bash
-# 1. 파드가 왜 죽는지 — Last State / Exit Code / 종료 사유
-kubectl describe pod -n kubevirt <virt-handler-파드명> | grep -A15 "State\|Last State\|Events"
+`kubevirt.io` 제외를 걷어내고 project-controller를 재기동해 **격리 실험**으로 확정했다.
 
-# 2. 직전 컨테이너 종료 로그
-kubectl logs -n kubevirt <virt-handler-파드명> --previous
+- virt-handler DS는 **ownerReference가 없어서**, project-controller의 `WorkloadControllerReconciler` owner-ref skip에 걸리지 않는다. `kubevirt` 네임스페이스는 reserved 목록에 없어 project는 null.
+- 제외가 없으면 reconciler가 tolerations를 재조정: CR의 `project-managed Exists` 를 **per-node `project-managed Equal value=node01/node02`** 로 치환(`buildProjectManagedTolerations`). virt-operator는 CR 기준 `Exists`로 원복 → 전쟁.
+- managedFields상 tolerations를 쓰는 writer는 `Kubernetes Java Client` (**project-controller**의 field manager). → affinity를 쓰던 `OpenAPI-Generator`(coaster)와 **field manager 이름이 달라 둘이 명확히 구분**된다.
 
-# 3. 노드에 evict-ds 라벨이 붙는지 (핵심 가설) — 시간차로 여러 번 확인
-kubectl get node node02 --show-labels | tr ',' '\n' | grep -i "coaster\|evict\|gpu"
-kubectl get node node01 --show-labels | tr ',' '\n' | grep -i "coaster\|evict\|gpu"
+**직접 관찰(제외 제거 상태):** tolerations가 두 값 사이를 flip하며 generation 증가, 파드 ~7초 주기 롤링.
 
-# 4. 누가 파드를 지우는지 — virt-operator가 지우는지 확인
-kubectl logs -n kubevirt -l kubevirt.io=virt-operator --tail=200 | grep -i "virt-handler\|delete\|evict"
-
-# 5. coaster 컴포넌트 확인
-kubectl get pods -n coaster 2>/dev/null
-
-# 6. DaemonSet generation이 정말 계속 오르는지 + 무엇이 바뀌는지
-kubectl get ds virt-handler -n kubevirt -w
-#   generation이 오르는 순간 spec diff를 떠서 어떤 필드가 바뀌는지 확인
-kubectl get ds virt-handler -n kubevirt -o yaml > /tmp/ds-1.yaml
-# (수 초 후)
-kubectl get ds virt-handler -n kubevirt -o yaml > /tmp/ds-2.yaml
-diff /tmp/ds-1.yaml /tmp/ds-2.yaml
+```
+gen=16607 tolOperators=[Exists Equal Equal Equal Equal]   ← project-controller (per-node Equal)
+gen=16608 tolOperators=[Exists Exists Exists]             ← virt-operator 원복 (gen++)
+gen=16611 tolOperators=[Exists Equal Equal Equal Equal]   ← project-controller 재적용 (gen++)
+gen=16614 tolOperators=[Exists Exists Exists]             ← virt-operator 원복 (gen++)
 ```
 
-**핵심 질문**: 6번 diff에서 generation이 오를 때 **어떤 spec 필드가 바뀌는가?** 그게 바뀌는 필드를 보면 어떤 writer(virt-operator vs coaster)인지 특정할 수 있다. 그리고 3번에서 node01/node02에 `evict-ds` 라벨이 들락거리는지 확인.
+**조치 B:** project-controller의 `app.aipub.reconcile-excluded-label-selectors` 에 `kubevirt.io` 유지(운영에서는 `project-controller-envs` ConfigMap의 `APP_AIPUB_RECONCILE_EXCLUDED_LABEL_SELECTORS`). 제외가 걸리면 reconciler·Pod/Deployment webhook 3개 지점 모두 virt-handler를 건드리지 않는다.
 
-## 정리 표
+**검증(제외 복구 후):** gen 고정, tolerations가 `[Exists Exists Exists]`(virt-operator desired)로 정착, 파드 안정. Pod webhook 로그에 `allowed without patch ... virt-handler-` 재확인.
 
-| 항목 | 상태 |
-|---|---|
-| project controller ↔ virt-operator 패치 루프 (AIP-1998) | **해결** (skip 로그 확인) |
-| AIP-1998 fix 동작 | **검증 완료** |
-| 남은 30초 파드 churn + generation 증가 | **별개 원인 (project controller 아님)** — coaster `evict-ds` / virt-operator 재패치 추정, 추가 진단 필요 |
+## 두 전쟁 요약
 
-## 후속 작업
+| | War A | War B |
+|---|---|---|
+| 다투는 필드 | `template.spec.affinity` | `template.spec.tolerations` |
+| 상대 writer | coaster (`OpenAPI-Generator`) | project-controller (`Kubernetes Java Client`) |
+| 트리거 | coaster의 evict-ds affinity 주입 | project-controller의 per-node tolerations 재조정 |
+| 조치 | KubeVirt CR에 affinity 동일 선언 | project-controller `kubevirt.io` 제외 유지 |
+| 상태 | **해결** | **해결(제외 유지)** |
 
-- AIP-1998 PR(#69 resource-group-controller, #140 aipub-installer)은 이대로 머지 가능.
-- 진단 로그 커밋(`[AIP-1998-EXCLUDE]`)은 검증 종료 후 `git revert` 로 되돌린다.
-- 남은 churn은 coaster/kubevirt 쪽 별도 티켓으로 분리해 다루는 것을 권장.
+## 현재 적용 상태
+
+- KubeVirt CR: `spec.workloads.nodePlacement.affinity` 에 evict-ds affinity 추가 적용됨. (설치 소스: `mdc-root:/root/kubevirt/pjw/kubevirt-cr.yaml`, 리포 사본: `kubernetes/kubevirt-cr-pjw.yaml`)
+- project-controller: `kubevirt.io` 제외 유지, 재기동 완료.
+
+## 남은 과제 / 주의
+
+- **근본 해결(권장)**: coaster가 오퍼레이터 소유(virt-operator 등) DaemonSet을 직접 패치하지 않고, 해당 오퍼레이터의 API(KubeVirt CR nodePlacement 등)를 통해 배치를 구성하도록 개선. 별도 티켓 권장.
+- **취약한 결합**: 조치 A는 coaster가 virt-handler에 주입하는 affinity 값과 CR 값이 **정확히 일치**해야 no-op이 된다. coaster가 주입 형태를 바꾸면(예: `tpc-discovery.coaster.ten1010.io/evict-ds` 키 추가) War A가 재발하므로 CR도 함께 갱신해야 한다.
+- **Helm 관리**: `project-controller-envs`, KubeVirt CR 모두 배포 도구로 관리되므로, 위 조치는 각 설치 매니페스트/차트에도 반영해야 재배포 시 유지된다.
+- 진단용 임시 로그 커밋(`[AIP-1998-EXCLUDE]`)은 검증 완료 후 히스토리에서 제거함(별도 revert 커밋 없이 정리).

--- a/docs/AIP-1998-kubevirt-virt-handler-diagnosis.md
+++ b/docs/AIP-1998-kubevirt-virt-handler-diagnosis.md
@@ -1,0 +1,91 @@
+# AIP-1998 — KubeVirt virt-handler 파드 churn 진단 노트
+
+> 퇴근 전 인계용 메모. 집에서 이어서 확인하기 위한 스냅샷.
+> 진단 로그 커밋(`[AIP-1998-EXCLUDE]`)이 적용된 이미지로 배포한 뒤의 관찰 기록이다.
+
+## TL;DR
+
+- **project controller ↔ virt-operator 패치 루프 자체(AIP-1998 본래 문제)는 fix가 동작 중.** project controller 로그에 virt-handler를 skip하는 로그가 정상적으로 찍힌다.
+- **그런데 virt-handler 파드는 여전히 약 30초 주기로 죽고, DaemonSet generation도 계속 오른다.**
+- generation이 계속 오른다 = **누군가 DaemonSet 템플릿(spec)을 반복적으로 패치하고 있다.** project controller는 skip 중이므로 **그 writer는 project controller가 아니다.** → virt-operator 또는 coaster(GPU 오퍼레이터) 등 다른 주체가 유력.
+- 즉 **남은 churn은 AIP-1998(project controller)과 별개의 원인**이며, 별도 진단이 필요하다. AIP-1998 PR 자체는 이대로 머지 가능하고, 진단 로그 커밋만 나중에 revert하면 된다.
+
+## 확정된 사실 (fix 동작 증거)
+
+project controller 로그:
+
+```
+[AIP-1998-EXCLUDE] reconcile skipped for excluded workload: kind=V1DaemonSet namespace=kubevirt name=virt-handler
+```
+
+→ `reconcile-excluded-label-selectors` 의 `kubevirt.io` 셀렉터가 적용되어, project controller의 DaemonSet reconciler가 virt-handler를 더 이상 패치하지 않는다. (scale-to-0 테스트 때도 generation 증가가 멈췄던 것과 일관)
+
+## 미해결: 남은 30초 주기 파드 churn
+
+관찰된 증상:
+
+- virt-handler 파드가 Running 까지 갔다가 `Killing/Stopping` 되고 **새 파드 이름으로 재생성**된다 (컨테이너 in-place 재시작이 아님, RESTARTS=0).
+- 이벤트:
+  - `Warning FailedUpdate  daemonSet virt-handler rollout failed`
+  - `Warning PodFailed     Pod is in Failed state` (반복)
+- **DaemonSet generation 계속 증가** (project controller skip 중인데도) → 다른 writer가 템플릿을 패치 중.
+
+유력 단서 — DaemonSet 템플릿의 nodeAffinity:
+
+```yaml
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: gpuconfig.coaster.ten1010.io/evict-ds
+          operator: DoesNotExist
+```
+
+- `evict-ds`(DaemonSet 축출)라는 이름 + reservedNamespace 목록에 `coaster`가 포함됨.
+- 가설: **coaster(GPU 오퍼레이터)가 노드에 `gpuconfig.coaster.ten1010.io/evict-ds` 라벨을 붙였다/뗐다 하며 virt-handler 파드를 축출·재생성**시키고 있을 가능성. 또는 virt-operator가 자신의 desired state와 어긋남을 감지해 파드를 지우는 루프.
+- generation이 오르는 것까지 설명하려면, 누군가 **템플릿(affinity 등)을 주기적으로 바꾸는** 쪽을 의심해야 한다 (coaster ↔ virt-operator 간 또다른 2-writer 충돌 가능성).
+
+## 집에서 확인할 진단 명령
+
+```bash
+# 1. 파드가 왜 죽는지 — Last State / Exit Code / 종료 사유
+kubectl describe pod -n kubevirt <virt-handler-파드명> | grep -A15 "State\|Last State\|Events"
+
+# 2. 직전 컨테이너 종료 로그
+kubectl logs -n kubevirt <virt-handler-파드명> --previous
+
+# 3. 노드에 evict-ds 라벨이 붙는지 (핵심 가설) — 시간차로 여러 번 확인
+kubectl get node node02 --show-labels | tr ',' '\n' | grep -i "coaster\|evict\|gpu"
+kubectl get node node01 --show-labels | tr ',' '\n' | grep -i "coaster\|evict\|gpu"
+
+# 4. 누가 파드를 지우는지 — virt-operator가 지우는지 확인
+kubectl logs -n kubevirt -l kubevirt.io=virt-operator --tail=200 | grep -i "virt-handler\|delete\|evict"
+
+# 5. coaster 컴포넌트 확인
+kubectl get pods -n coaster 2>/dev/null
+
+# 6. DaemonSet generation이 정말 계속 오르는지 + 무엇이 바뀌는지
+kubectl get ds virt-handler -n kubevirt -w
+#   generation이 오르는 순간 spec diff를 떠서 어떤 필드가 바뀌는지 확인
+kubectl get ds virt-handler -n kubevirt -o yaml > /tmp/ds-1.yaml
+# (수 초 후)
+kubectl get ds virt-handler -n kubevirt -o yaml > /tmp/ds-2.yaml
+diff /tmp/ds-1.yaml /tmp/ds-2.yaml
+```
+
+**핵심 질문**: 6번 diff에서 generation이 오를 때 **어떤 spec 필드가 바뀌는가?** 그게 바뀌는 필드를 보면 어떤 writer(virt-operator vs coaster)인지 특정할 수 있다. 그리고 3번에서 node01/node02에 `evict-ds` 라벨이 들락거리는지 확인.
+
+## 정리 표
+
+| 항목 | 상태 |
+|---|---|
+| project controller ↔ virt-operator 패치 루프 (AIP-1998) | **해결** (skip 로그 확인) |
+| AIP-1998 fix 동작 | **검증 완료** |
+| 남은 30초 파드 churn + generation 증가 | **별개 원인 (project controller 아님)** — coaster `evict-ds` / virt-operator 재패치 추정, 추가 진단 필요 |
+
+## 후속 작업
+
+- AIP-1998 PR(#69 resource-group-controller, #140 aipub-installer)은 이대로 머지 가능.
+- 진단 로그 커밋(`[AIP-1998-EXCLUDE]`)은 검증 종료 후 `git revert` 로 되돌린다.
+- 남은 churn은 coaster/kubevirt 쪽 별도 티켓으로 분리해 다루는 것을 권장.

--- a/kubernetes/kubevirt-cr-pjw.yaml
+++ b/kubernetes/kubevirt-cr-pjw.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: kubevirt.io/v1
+kind: KubeVirt
+metadata:
+  name: kubevirt
+  namespace: kubevirt
+spec:
+  certificateRotateStrategy: {}
+  configuration:
+    developerConfiguration:
+      featureGates: []
+    imagePullPolicy: IfNotPresent
+  customizeComponents: {}
+  imagePullPolicy: IfNotPresent
+  workloadUpdateStrategy: {}
+  workloads:
+    nodePlacement:
+      # AIP-1998: coaster(gpuconfig-controller)가 virt-handler DS 템플릿에 주입하는
+      # evict-ds nodeAffinity와 "정확히 동일한" 값을 KubeVirt CR에 선언한다.
+      # 이렇게 해야 virt-operator의 desired 템플릿에 이 affinity가 포함되어
+      # coaster의 주입을 drift로 보지 않고 되돌리지 않는다 → generation churn 전쟁 종료.
+      # 값이 coaster가 원하는 것과 다르면(예: 키 추가) 새로운 전쟁이 발생하므로
+      # 관찰된 단일 키를 그대로 사용한다.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: gpuconfig.coaster.ten1010.io/evict-ds
+                    operator: DoesNotExist
+      tolerations:
+        - effect: NoSchedule
+          key: project.aipub.ten1010.io/project-managed
+          operator: Exists
+        - effect: NoExecute
+          key: project.aipub.ten1010.io/project-managed
+          operator: Exists

--- a/src/main/java/io/ten1010/aipub/projectcontroller/configuration/AipubProperties.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/configuration/AipubProperties.java
@@ -22,5 +22,12 @@ public class AipubProperties {
   private String password;
   private List<String> reservedNamespace = new ArrayList<>();
   private List<String> addOwnerExceptGvkList = new ArrayList<>();
+  /**
+   * project controller가 reconcile/mutating 대상에서 제외할 워크로드의 라벨 셀렉터 목록.
+   * {@code "key=value"}(값 일치) 또는 {@code "key"}(존재만 확인) 형태를 지원하며, 하나라도
+   * 매칭되면 제외한다. virt-operator처럼 자체 워크로드를 직접 소유하는 인프라 오퍼레이터와의
+   * 소유권 충돌을 막기 위한 용도다.
+   */
+  private List<String> reconcileExcludedLabelSelectors = new ArrayList<>();
 
 }

--- a/src/main/java/io/ten1010/aipub/projectcontroller/configuration/DomainConfiguration.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/configuration/DomainConfiguration.java
@@ -6,6 +6,7 @@ import io.kubernetes.client.util.KubeConfig;
 import io.ten1010.aipub.projectcontroller.domain.k8s.DockerConfigJsonResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.K8sApiProvider;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ReconciliationService;
+import io.ten1010.aipub.projectcontroller.domain.k8s.util.WorkloadExclusionResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.SubjectResolver;
 import java.io.FileReader;
 import java.io.IOException;
@@ -49,7 +50,8 @@ public class DomainConfiguration {
   public ReconciliationService reconciliationService(SubjectResolver subjectResolver,
       DockerConfigJsonResolver dockerConfigJsonResolver, AipubProperties aipubProperties) {
     return new ReconciliationService(subjectResolver, dockerConfigJsonResolver,
-        aipubProperties.getReservedNamespace());
+        aipubProperties.getReservedNamespace(),
+        new WorkloadExclusionResolver(aipubProperties.getReconcileExcludedLabelSelectors()));
   }
 
 }

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/workload/WorkloadControllerReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/workload/WorkloadControllerReconciler.java
@@ -66,7 +66,7 @@ public class WorkloadControllerReconciler extends AbstractReconciler {
       return new Result(false);
     }
     KubernetesObject controller = controllerOpt.get();
-    if (K8sObjectUtils.isCiliumComponent(controller)) {
+    if (this.reconciliationService.isExcludedFromReconciliation(controller)) {
       return new Result(false);
     }
     if (K8sObjectUtils.findControllerOwnerReference(controller).isPresent()) {

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationService.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationService.java
@@ -45,6 +45,7 @@ import io.ten1010.aipub.projectcontroller.domain.k8s.util.NodeUtils;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.ProjectUtils;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.ResourceQuotaUtils;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.UsernameUtils;
+import io.ten1010.aipub.projectcontroller.domain.k8s.util.WorkloadExclusionResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.WorkloadUtils;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -72,9 +73,11 @@ public class ReconciliationService {
   private final Gson gson;
   private final ObjectMapper mapper;
   private final List<String> reservedNamespaces;
+  private final WorkloadExclusionResolver workloadExclusionResolver;
 
   public ReconciliationService(SubjectResolver subjectResolver,
-      DockerConfigJsonResolver dockerConfigJsonResolver, List<String> reservedNamespaces) {
+      DockerConfigJsonResolver dockerConfigJsonResolver, List<String> reservedNamespaces,
+      WorkloadExclusionResolver workloadExclusionResolver) {
     this.subjectResolver = subjectResolver;
     this.dockerConfigJsonResolver = dockerConfigJsonResolver;
     this.roleNameResolver = new RoleNameResolver();
@@ -83,6 +86,16 @@ public class ReconciliationService {
     this.gson = new Gson();
     this.mapper = new ObjectMapperFactory().createObjectMapper();
     this.reservedNamespaces = reservedNamespaces;
+    this.workloadExclusionResolver = workloadExclusionResolver;
+  }
+
+  /**
+   * 주어진 워크로드가 reconcile/mutating 대상에서 제외되어야 하는지 판정한다. virt-operator처럼
+   * 자체 워크로드를 직접 소유하는 인프라 오퍼레이터의 객체를 project controller가 건드리지 않도록
+   * {@code app.aipub.reconcile-excluded-label-selectors} 설정으로 지정한다.
+   */
+  public boolean isExcludedFromReconciliation(KubernetesObject object) {
+    return this.workloadExclusionResolver.isExcluded(object);
   }
 
   private static List<V1OwnerReference> removeOwnerReferencesThatReferToProjectKind(

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/util/K8sObjectUtils.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/util/K8sObjectUtils.java
@@ -16,20 +16,6 @@ import java.util.Optional;
 
 public abstract class K8sObjectUtils {
 
-  private static final String PART_OF_LABEL_KEY = "app.kubernetes.io/part-of";
-  private static final String CILIUM_PART_OF_VALUE = "cilium";
-
-  public static boolean isCiliumComponent(KubernetesObject object) {
-    if (object.getMetadata() == null) {
-      return false;
-    }
-    Map<String, String> labels = object.getMetadata().getLabels();
-    if (labels == null) {
-      return false;
-    }
-    return CILIUM_PART_OF_VALUE.equals(labels.get(PART_OF_LABEL_KEY));
-  }
-
   public static String getApiVersion(KubernetesObject object) {
     Objects.requireNonNull(object.getApiVersion());
     return object.getApiVersion();

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/util/WorkloadExclusionResolver.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/util/WorkloadExclusionResolver.java
@@ -1,0 +1,77 @@
+package io.ten1010.aipub.projectcontroller.domain.k8s.util;
+
+import io.kubernetes.client.common.KubernetesObject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * project controller가 reconcile/mutating 대상에서 제외할 워크로드를 라벨 셀렉터로 판정한다.
+ *
+ * <p>각 셀렉터 문자열은 다음 두 형태를 지원한다.
+ * <ul>
+ *   <li>{@code "key=value"} : 라벨 {@code key} 의 값이 {@code value} 와 정확히 일치하면 매칭</li>
+ *   <li>{@code "key"} : 라벨 {@code key} 가 존재하면(값 무관) 매칭</li>
+ * </ul>
+ *
+ * <p>여러 셀렉터 중 하나라도 매칭되면 제외 대상으로 본다(OR). KubeVirt(virt-operator)처럼
+ * 자체 컴포넌트를 직접 소유하는 인프라 오퍼레이터의 워크로드를 project controller가 건드리지
+ * 않도록 하기 위한 용도다. 제외 대상 목록은 {@code app.aipub.reconcile-excluded-label-selectors}
+ * 설정으로 주입되며, 책임과 관리 주체를 project controller로 일원화한다.
+ */
+public class WorkloadExclusionResolver {
+
+  private record LabelSelector(String key, String value) {
+
+    boolean matches(Map<String, String> labels) {
+      if (!labels.containsKey(key)) {
+        return false;
+      }
+      return value == null || value.equals(labels.get(key));
+    }
+  }
+
+  private final List<LabelSelector> selectors;
+
+  public WorkloadExclusionResolver(List<String> rawSelectors) {
+    this.selectors = parse(rawSelectors);
+  }
+
+  private static List<LabelSelector> parse(List<String> rawSelectors) {
+    List<LabelSelector> parsed = new ArrayList<>();
+    if (rawSelectors == null) {
+      return parsed;
+    }
+    for (String raw : rawSelectors) {
+      if (raw == null) {
+        continue;
+      }
+      String trimmed = raw.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+      int idx = trimmed.indexOf('=');
+      if (idx < 0) {
+        parsed.add(new LabelSelector(trimmed, null));
+      } else {
+        String key = trimmed.substring(0, idx).trim();
+        String value = trimmed.substring(idx + 1).trim();
+        if (!key.isEmpty()) {
+          parsed.add(new LabelSelector(key, value));
+        }
+      }
+    }
+    return parsed;
+  }
+
+  public boolean isExcluded(KubernetesObject object) {
+    if (selectors.isEmpty() || object.getMetadata() == null) {
+      return false;
+    }
+    Map<String, String> labels = object.getMetadata().getLabels();
+    if (labels == null || labels.isEmpty()) {
+      return false;
+    }
+    return selectors.stream().anyMatch(selector -> selector.matches(labels));
+  }
+}

--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/DeploymentReviewHandler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/DeploymentReviewHandler.java
@@ -47,7 +47,7 @@ public class DeploymentReviewHandler extends AbstractReviewHandler<V1Deployment>
 
     V1Deployment deployment = getRequestObject(review);
 
-    if (K8sObjectUtils.isCiliumComponent(deployment)) {
+    if (this.reconciliationService.isExcludedFromReconciliation(deployment)) {
       V1AdmissionReviewUtils.allow(review);
       return;
     }

--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/PodReviewHandler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/PodReviewHandler.java
@@ -47,7 +47,7 @@ public class PodReviewHandler extends AbstractReviewHandler<V1Pod> {
 
     V1Pod pod = getRequestObject(review);
 
-    if (K8sObjectUtils.isCiliumComponent(pod)) {
+    if (this.reconciliationService.isExcludedFromReconciliation(pod)) {
       V1AdmissionReviewUtils.allow(review);
       return;
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -34,3 +34,6 @@ app:
       - "aipub.ten1010.io/v1/Commit"
       - "aipub.ten1010.io/v1alpha1/UserAuthorityReview"
       - "aipub.ten1010.io/v1/UserAuthorityReview"
+    reconcile-excluded-label-selectors:
+      - "app.kubernetes.io/part-of=cilium"
+      - "kubevirt.io"

--- a/src/test/java/io/ten1010/aipub/projectcontroller/domain/k8s/util/WorkloadExclusionResolverTest.java
+++ b/src/test/java/io/ten1010/aipub/projectcontroller/domain/k8s/util/WorkloadExclusionResolverTest.java
@@ -1,0 +1,96 @@
+package io.ten1010.aipub.projectcontroller.domain.k8s.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.kubernetes.client.openapi.models.V1DaemonSet;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class WorkloadExclusionResolverTest {
+
+  private static V1DaemonSet daemonSetWithLabels(Map<String, String> labels) {
+    return new V1DaemonSet().metadata(new V1ObjectMeta().labels(labels));
+  }
+
+  @Test
+  @DisplayName("key=value 셀렉터는 라벨 값이 정확히 일치할 때만 제외한다")
+  void givenKeyValueSelector_whenLabelMatches_thenExcluded() {
+    WorkloadExclusionResolver resolver = new WorkloadExclusionResolver(
+        List.of("app.kubernetes.io/part-of=cilium"));
+
+    assertThat(resolver.isExcluded(
+        daemonSetWithLabels(Map.of("app.kubernetes.io/part-of", "cilium")))).isTrue();
+    assertThat(resolver.isExcluded(
+        daemonSetWithLabels(Map.of("app.kubernetes.io/part-of", "calico")))).isFalse();
+  }
+
+  @Test
+  @DisplayName("key 셀렉터(값 생략)는 라벨 키가 존재하면 값과 무관하게 제외한다")
+  void givenKeyOnlySelector_whenLabelKeyExists_thenExcluded() {
+    WorkloadExclusionResolver resolver = new WorkloadExclusionResolver(List.of("kubevirt.io"));
+
+    assertThat(resolver.isExcluded(
+        daemonSetWithLabels(Map.of("kubevirt.io", "virt-handler")))).isTrue();
+    assertThat(resolver.isExcluded(
+        daemonSetWithLabels(Map.of("kubevirt.io", "")))).isTrue();
+    assertThat(resolver.isExcluded(
+        daemonSetWithLabels(Map.of("other.io", "x")))).isFalse();
+  }
+
+  @Test
+  @DisplayName("여러 셀렉터 중 하나라도 매칭되면 제외한다(OR)")
+  void givenMultipleSelectors_whenAnyMatches_thenExcluded() {
+    WorkloadExclusionResolver resolver = new WorkloadExclusionResolver(
+        List.of("app.kubernetes.io/part-of=cilium", "kubevirt.io"));
+
+    assertThat(resolver.isExcluded(
+        daemonSetWithLabels(Map.of("kubevirt.io", "virt-handler")))).isTrue();
+    assertThat(resolver.isExcluded(
+        daemonSetWithLabels(Map.of("app.kubernetes.io/part-of", "cilium")))).isTrue();
+    assertThat(resolver.isExcluded(
+        daemonSetWithLabels(Map.of("app.kubernetes.io/name", "coredns")))).isFalse();
+  }
+
+  @Test
+  @DisplayName("공백/빈 항목/null 셀렉터는 무시한다")
+  void givenBlankOrNullSelectors_thenIgnored() {
+    WorkloadExclusionResolver resolver = new WorkloadExclusionResolver(
+        java.util.Arrays.asList("  ", "", "  kubevirt.io  ", null));
+
+    assertThat(resolver.isExcluded(
+        daemonSetWithLabels(Map.of("kubevirt.io", "virt-api")))).isTrue();
+    assertThat(resolver.isExcluded(
+        daemonSetWithLabels(Map.of("unrelated", "x")))).isFalse();
+  }
+
+  @Test
+  @DisplayName("셀렉터 목록이 비어 있으면 어떤 워크로드도 제외하지 않는다")
+  void givenEmptySelectors_thenNothingExcluded() {
+    WorkloadExclusionResolver resolver = new WorkloadExclusionResolver(List.of());
+
+    assertThat(resolver.isExcluded(
+        daemonSetWithLabels(Map.of("kubevirt.io", "virt-handler")))).isFalse();
+  }
+
+  @Test
+  @DisplayName("metadata나 labels가 없으면 제외하지 않는다")
+  void givenNoMetadataOrLabels_thenNotExcluded() {
+    WorkloadExclusionResolver resolver = new WorkloadExclusionResolver(List.of("kubevirt.io"));
+
+    assertThat(resolver.isExcluded(new V1DaemonSet())).isFalse();
+    assertThat(resolver.isExcluded(
+        new V1DaemonSet().metadata(new V1ObjectMeta()))).isFalse();
+  }
+
+  @Test
+  @DisplayName("null 셀렉터 목록이 주입돼도 안전하게 동작한다")
+  void givenNullSelectorList_thenNothingExcluded() {
+    WorkloadExclusionResolver resolver = new WorkloadExclusionResolver(null);
+
+    assertThat(resolver.isExcluded(
+        daemonSetWithLabels(Map.of("kubevirt.io", "virt-handler")))).isFalse();
+  }
+}


### PR DESCRIPTION
## 배경

virt-operator처럼 자체 워크로드(DaemonSet 등)를 직접 소유하는 인프라 오퍼레이터의 객체를 project controller가 reconcile/mutating하면, 두 컨트롤러가 같은 `spec`을 두고 다투며 **무한 패치 루프**가 발생한다.

실제 사례: kubevirt `virt-handler` DaemonSet이 약 30초 주기로 재시작.
- virt-operator가 자기 desired state로 DaemonSet을 계속 reconcile
- project controller가 `daemonSetFilter`(PodTemplateSpec 변경 시 트리거)로 toleration을 재작성
- 서로 되돌리며 rolling update 무한 반복 → 파드가 Ready 못 됨

## 변경

기존에는 cilium 컴포넌트만 `K8sObjectUtils.isCiliumComponent`로 **하드코딩** 제외했다. 이를 `app.aipub.reconcile-excluded-label-selectors` **설정 기반 제외**로 일반화한다.

- `WorkloadExclusionResolver` 추가: `"key=value"`(값 일치) / `"key"`(존재만 확인) 라벨 셀렉터 목록을 파싱해 **OR 매칭**으로 제외 여부 판정
- `ReconciliationService.isExcludedFromReconciliation`으로 위임 → reconciler + 두 mutating webhook(Pod/Deployment) **3개 지점 공통** 사용 (팩토리 plumbing 없이 기존 주입 경로 재사용)
- `K8sObjectUtils.isCiliumComponent` 제거, `application.yaml` 기본값으로 `app.kubernetes.io/part-of=cilium` + `kubevirt.io` seeding (기존 cilium 동작 보존)

## 설계 의도

- 제외 **책임과 설정을 project controller로 일원화** — 외부 사용자가 어노테이션/라벨로 감독 밖에서 제외 대상을 바꾸는 것을 배제
- 향후 multus, nvidia-device-plugin 등 인프라 오퍼레이터는 설정에 셀렉터 한 줄 추가 + 재시작으로 처리 (재빌드 불필요)

## 테스트

- `WorkloadExclusionResolverTest` 7개 케이스 추가
- 전체 85개 테스트 통과

## 관련

- installer 차트 설정 노출: ten1010-io/aipub-installer `feature/AIP-1998`