### PR TITLE
fix: ImagePullSecret 미생성(robot race) 및 Job 422 무한 재시도 수정

### DIFF
--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/ImageRegistryRobotControllerFactory.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/ImageRegistryRobotControllerFactory.java
@@ -8,8 +8,10 @@ import io.kubernetes.client.extended.workqueue.WorkQueue;
 import io.kubernetes.client.informer.SharedInformerFactory;
 import io.ten1010.aipub.projectcontroller.controller.watch.DefaultControllerWatch;
 import io.ten1010.aipub.projectcontroller.controller.watch.OnUpdateFilterFactory;
+import io.ten1010.aipub.projectcontroller.controller.watch.RequestBuilderFactory;
 import io.ten1010.aipub.projectcontroller.domain.aipubbackend.ImageRegistryRobotService;
 import io.ten1010.aipub.projectcontroller.domain.aipubbackend.ImageRegistryRobotUsernameResolver;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ImageHub;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Project;
 
 public class ImageRegistryRobotControllerFactory implements ControllerFactory {
@@ -18,6 +20,7 @@ public class ImageRegistryRobotControllerFactory implements ControllerFactory {
   private final ImageRegistryRobotUsernameResolver usernameResolver;
   private final SharedInformerFactory sharedInformerFactory;
   private final OnUpdateFilterFactory onUpdateFilterFactory;
+  private final RequestBuilderFactory requestBuilderFactory;
 
   public ImageRegistryRobotControllerFactory(
       ImageRegistryRobotService robotService,
@@ -27,6 +30,7 @@ public class ImageRegistryRobotControllerFactory implements ControllerFactory {
     this.usernameResolver = usernameResolver;
     this.sharedInformerFactory = sharedInformerFactory;
     this.onUpdateFilterFactory = new OnUpdateFilterFactory();
+    this.requestBuilderFactory = new RequestBuilderFactory(sharedInformerFactory);
   }
 
   @Override
@@ -36,7 +40,10 @@ public class ImageRegistryRobotControllerFactory implements ControllerFactory {
         .withWorkerCount(1)
         .withReadyFunc(this.sharedInformerFactory.getExistingSharedIndexInformer(
             V1alpha1Project.class)::hasSynced)
+        .withReadyFunc(this.sharedInformerFactory.getExistingSharedIndexInformer(
+            V1alpha1ImageHub.class)::hasSynced)
         .watch(this::createProjectWatch)
+        .watch(this::createImageHubWatch)
         .withReconciler(new ImageRegistryRobotReconciler(this.robotService, this.usernameResolver,
             this.sharedInformerFactory))
         .build();
@@ -46,6 +53,14 @@ public class ImageRegistryRobotControllerFactory implements ControllerFactory {
     DefaultControllerWatch<V1alpha1Project> watch = new DefaultControllerWatch<>(workQueue,
         V1alpha1Project.class);
     watch.setOnUpdateFilter(this.onUpdateFilterFactory.projectSpecBindingImageHubsFieldFilter());
+    return watch;
+  }
+
+  private ControllerWatch<V1alpha1ImageHub> createImageHubWatch(WorkQueue<Request> workQueue) {
+    DefaultControllerWatch<V1alpha1ImageHub> watch = new DefaultControllerWatch<>(workQueue,
+        V1alpha1ImageHub.class);
+    watch.setOnUpdateFilter(this.onUpdateFilterFactory.imageHubSpecFieldFilter());
+    watch.setRequestBuilder(this.requestBuilderFactory.imageHubToBoundProjects());
     return watch;
   }
 

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/ImageRegistryRobotReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/ImageRegistryRobotReconciler.java
@@ -120,8 +120,15 @@ public class ImageRegistryRobotReconciler extends AbstractReconciler {
     return ProjectUtils.getSpecBindingImageHubs(project).stream()
         .map(e -> this.imageHubIndexer.getByKey(this.keyResolver.resolveKey(e)))
         .filter(Objects::nonNull)
+        .filter(ImageRegistryRobotReconciler::hasSpecId)
         .map(ImageRegistryRobotReconciler::createPermission)
         .toList();
+  }
+
+  private static boolean hasSpecId(V1alpha1ImageHub imageHub) {
+    return imageHub.getSpec() != null
+        && imageHub.getSpec().getId() != null
+        && !imageHub.getSpec().getId().isBlank();
   }
 
 }

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/workload/JobWorkloadControllerFactory.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/workload/JobWorkloadControllerFactory.java
@@ -29,8 +29,13 @@ import io.ten1010.aipub.projectcontroller.domain.k8s.util.WorkloadUtils;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JobWorkloadControllerFactory extends WorkloadControllerFactory {
+
+  private static final Logger log = LoggerFactory.getLogger(JobWorkloadControllerFactory.class);
+  private static final int HTTP_UNPROCESSABLE_ENTITY = 422;
 
   private final BatchV1Api batchV1Api;
   private final OnUpdateFilterFactory onUpdateFilterFactory;
@@ -154,7 +159,22 @@ public class JobWorkloadControllerFactory extends WorkloadControllerFactory {
           .endSpec()
           .build();
     }
-    updateJob(K8sObjectUtils.getNamespace(controller), K8sObjectUtils.getName(controller), edited);
+    try {
+      updateJob(K8sObjectUtils.getNamespace(controller), K8sObjectUtils.getName(controller), edited);
+    } catch (ApiException e) {
+      // A Job's spec.template is immutable after creation. When an existing Job's desired
+      // tolerations/affinity/imagePullSecrets drift from the template it was created with, the
+      // API server rejects the update with 422. There is nothing we can do about an already
+      // admitted Job, so treat it as terminal instead of requeueing forever and spamming error
+      // logs. The initial injection is applied when the Job is first admitted.
+      if (e.getCode() == HTTP_UNPROCESSABLE_ENTITY) {
+        log.debug(
+            "Skipping update of Job [namespace={} name={}] because its spec.template is immutable",
+            K8sObjectUtils.getNamespace(controller), K8sObjectUtils.getName(controller));
+        return new Result(false);
+      }
+      throw e;
+    }
     return new Result(false);
   }
 


### PR DESCRIPTION
## 개요

aipub `project-controller`에서 관찰된 서로 **독립적인 두 결함**을 수정합니다.

1. **ImagePullSecret 간헐적 미생성** (ai-harness 등) — Harbor robot이 아예 생성되지 않아 발생
2. **job-controller의 반복 422 로그 스팸** — 이미 생성된 Job의 immutable한 `spec.template` 갱신 시도

> cluster3(idc1)에서 재현 확인. 두 문제의 근본 원인·증거·수정 상세는 아래 참고.

---

## Issue 1 — ImagePullSecret 미생성 (robot race)

ImagePullSecret 발급은 **두 리컨실러**로 분리돼 있다. robot을 *만드는* `ImageRegistryRobotReconciler`와, robot을 *조회해서* secret을 만드는 `ImageRegistrySecretReconciler`.

**근본 원인**
- `ImageRegistryRobotReconciler`는 **Project 이벤트(`spec.binding.imageHubs` 변경)로만** 트리거되고 **ImageHub는 watch하지 않으며** informer **resync도 없다**(`DefaultControllerWatch` = `Duration.ZERO`).
- Project가 바인딩된 ImageHub보다 먼저 리컨실되면(ai-harness: Project `02:32:10Z` → ImageHub `02:32:44Z`, +34s) `createPermissions()`가 빈 리스트를 반환 → **robot을 만들지 않고 `Result(false)`로 종료(requeue 없음)**.
- 이후 재트리거 경로가 없어 robot이 **영구 누락** → `ImageRegistrySecretReconciler`가 60초마다 실패:
  ```
  ERROR ImageRegistrySecretReconciler - [namespace=ai-harness name=image-registry-secret-...-ai-harness]
  IllegalStateException: Could not find image registry robot for robot$project-aipub-ten1010-io-ai-harness
  ```
- Project·ImageHub 생성 순서/캐시 동기화 타이밍에 좌우되므로 **간헐적**으로 나타남.

**증거**
- ai-harness 네임스페이스 secret 0개, Harbor `robot` 테이블에 ai-harness robot 없음(존재 robot 10개 전부 6/23~6/24 생성분 → 페이지네이션 문제 아님)
- robot 리컨실러 에러 0건 → 생성 실패가 아니라 빈 permissions no-op 종료

**수정**
- `ImageRegistryRobotControllerFactory`: ImageHub add/spec-update를 바인딩 Project로 매핑하는 watch 추가(`imageHubToBoundProjects` + `imageHubSpecFieldFilter`), readyFunc에 ImageHub informer sync 대기 추가
- `ImageRegistryRobotReconciler`: `spec.id`가 아직 없는 ImageHub는 permission 생성에서 제외(`ImageHubUtils.getSpecId` NPE 방지 + 미완성 ImageHub로 robot 생성 방지)

---

## Issue 2 — job-controller 반복 422

**근본 원인**
- `JobWorkloadControllerFactory.reconcileController`가 tolerations/affinity/imagePullSecrets diff 발생 시 `spec.template`을 포함한 Job을 `replaceNamespacedJob`으로 교체 → Job `spec.template`은 **immutable**이라 API가 `422 field is immutable`로 거부 → 60초마다 무한 재시도.
- 로그의 422 **360건 전부 `[job-controller-1]`**, AIPub 백엔드 robot API의 422(`statusCode=422`)는 **0건**(백엔드와 무관).
- 초기 주입은 admission 시점에 반영돼 있어 **Job 동작엔 영향 없음** — 무한 재시도 + 로그 스팸이 실질 피해.

**수정**
- `JobWorkloadControllerFactory`: immutable 422를 terminal로 처리(`Result(false)` + debug 로그). 다른 워크로드 타입은 각자 `reconcileController`를 구현하므로 무영향.

---

## 재배포 시 자동 복구

수동 조치 없이 **재배포만으로** 현재 막힌 ai-harness가 복구됩니다.
- startup 시 readyFunc가 ImageHub informer sync까지 대기 → 모든 Project 재평가 시 ImageHub 캐시가 채워진 상태 → 누락 robot 생성
- ImageHub ADD 이벤트도 바인딩 Project로 매핑되어 robot 리컨실 트리거(이중 안전장치)
- robot 생성 후 secret 리컨실러(이미 60초 주기 재시도 중)가 다음 주기에 secret 생성

## 검증 (배포 후)

```
kubectl -n ai-harness get secret image-registry-secret-project-aipub-ten1010-io-ai-harness
# Harbor robot 테이블에 project-aipub-ten1010-io-ai-harness 존재
# 로그: ai-harness "Could not find image registry robot" 중단
# 로그: job-controller 422 ERROR 스팸 중단
```

## 영향 / 롤백
- Breaking change 없음(watch/필터 추가 방향). robot 컨트롤러 리컨실 이벤트가 ImageHub 수에 비례해 소폭 증가.
- Fix 2(422)는 Job에만 적용, 타 워크로드 무영향.
- 롤백: 3개 파일 revert.
- `mvn compile` PASS.

## 후속(선택)
`ImageRegistrySecretReconciler`/`ImageRegistryRobotReconciler`의 robot 조회가 `pageSize=100` 고정이라, robot이 100개를 넘으면 동일 유형의 조회 누락 가능 → 페이지네이션 전체 순회 또는 이름 기반 단건 조회 개선을 별도 이슈로 검토 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
