### PR TITLE
feat(AIP-2241): project-controller 관측성 계측 추가

### DIFF
--- a/kubernetes/controller/project-controller/templates/deployment.yaml
+++ b/kubernetes/controller/project-controller/templates/deployment.yaml
@@ -30,6 +30,11 @@ spec:
         - name: project-controller
           image: project-controller:1.4.0
           imagePullPolicy: IfNotPresent
+          ports:
+            - name: webhook
+              containerPort: 8080
+            - name: metrics
+              containerPort: 8081
           envFrom:
             - configMapRef:
                 name: project-controller-envs

--- a/kubernetes/controller/project-controller/templates/service.yaml
+++ b/kubernetes/controller/project-controller/templates/service.yaml
@@ -2,12 +2,19 @@ apiVersion: v1
 kind: Service
 metadata:
   name: project-controller
+  labels:
+    app: project-controller
 spec:
   type: ClusterIP
   selector:
     app: project-controller
   ports:
-    - protocol: TCP
+    - name: webhook
+      protocol: TCP
       port: 8080
       targetPort: 8080
+    - name: metrics
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
 ---

--- a/pom.xml
+++ b/pom.xml
@@ -57,10 +57,15 @@
             <artifactId>client-java-extended</artifactId>
             <version>25.0.0</version>
         </dependency>
+
+        <!-- Observability dependencies -->
         <dependency>
-            <groupId>io.prometheus</groupId>
-            <artifactId>simpleclient</artifactId>
-            <version>0.16.0</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
 
         <!-- Etc dependencies -->

--- a/src/main/java/io/ten1010/aipub/projectcontroller/configuration/MetricsConfiguration.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/configuration/MetricsConfiguration.java
@@ -1,0 +1,107 @@
+package io.ten1010.aipub.projectcontroller.configuration;
+
+import io.kubernetes.client.common.KubernetesObject;
+import io.kubernetes.client.informer.SharedIndexInformer;
+import io.kubernetes.client.informer.SharedInformerFactory;
+import io.kubernetes.client.openapi.models.V1ClusterRole;
+import io.kubernetes.client.openapi.models.V1ClusterRoleBinding;
+import io.kubernetes.client.openapi.models.V1CronJob;
+import io.kubernetes.client.openapi.models.V1DaemonSet;
+import io.kubernetes.client.openapi.models.V1Deployment;
+import io.kubernetes.client.openapi.models.V1Job;
+import io.kubernetes.client.openapi.models.V1Namespace;
+import io.kubernetes.client.openapi.models.V1Node;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1ReplicaSet;
+import io.kubernetes.client.openapi.models.V1ResourceQuota;
+import io.kubernetes.client.openapi.models.V1Role;
+import io.kubernetes.client.openapi.models.V1RoleBinding;
+import io.kubernetes.client.openapi.models.V1Secret;
+import io.kubernetes.client.openapi.models.V1StatefulSet;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.ten1010.aipub.projectcontroller.controller.AbstractReconciler;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubUser;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubVolume;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ChainJob;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ImageBuild;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ImageHub;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1NodeGroup;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Operation;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Project;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ResourceSet;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1SftpServer;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1beta1Workspace;
+import jakarta.annotation.PostConstruct;
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 관측성(Micrometer/Prometheus) 계측 설정.
+ *
+ * <p>reconcile 지연은 {@link AbstractReconciler} 에 정적 주입한 MeterRegistry 로 기록하고, informer
+ * 캐시 크기는 리소스 타입별 Gauge 로 노출한다. admission webhook 지연은 actuator 의 {@code
+ * http.server.requests} 로 자동 계측된다. workqueue 깊이는 kubernetes-client 의 DefaultController
+ * 내부라 공개 접근 수단이 없어 이번 범위에서 제외한다(reconcile Timer 로 간접 관측).
+ */
+@Configuration
+public class MetricsConfiguration {
+
+  private static final String INFORMER_CACHE_SIZE_METRIC = "projectcontroller.informer.cache.size";
+
+  private static final List<Class<? extends KubernetesObject>> INFORMER_TYPES = List.of(
+      V1alpha1Project.class,
+      V1alpha1AipubUser.class,
+      V1alpha1NodeGroup.class,
+      V1alpha1ImageHub.class,
+      V1alpha1ResourceSet.class,
+      V1alpha1Operation.class,
+      V1beta1Workspace.class,
+      V1alpha1AipubVolume.class,
+      V1alpha1ChainJob.class,
+      V1alpha1SftpServer.class,
+      V1alpha1ImageBuild.class,
+      V1Namespace.class,
+      V1Node.class,
+      V1Pod.class,
+      V1Secret.class,
+      V1ResourceQuota.class,
+      V1ClusterRole.class,
+      V1ClusterRoleBinding.class,
+      V1Role.class,
+      V1RoleBinding.class,
+      V1CronJob.class,
+      V1DaemonSet.class,
+      V1Deployment.class,
+      V1Job.class,
+      V1ReplicaSet.class,
+      V1StatefulSet.class);
+
+  private final MeterRegistry meterRegistry;
+  private final SharedInformerFactory sharedInformerFactory;
+
+  public MetricsConfiguration(MeterRegistry meterRegistry,
+      SharedInformerFactory sharedInformerFactory) {
+    this.meterRegistry = meterRegistry;
+    this.sharedInformerFactory = sharedInformerFactory;
+  }
+
+  @PostConstruct
+  public void registerMetrics() {
+    AbstractReconciler.setMeterRegistry(this.meterRegistry);
+    INFORMER_TYPES.forEach(this::registerInformerCacheSizeGauge);
+  }
+
+  private <T extends KubernetesObject> void registerInformerCacheSizeGauge(Class<T> type) {
+    SharedIndexInformer<T> informer =
+        this.sharedInformerFactory.getExistingSharedIndexInformer(type);
+    if (informer == null) {
+      return;
+    }
+    Gauge.builder(INFORMER_CACHE_SIZE_METRIC, informer, i -> i.getIndexer().list().size())
+        .description("Number of objects held in the informer cache")
+        .tag("resource", type.getSimpleName())
+        .register(this.meterRegistry);
+  }
+
+}

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/AbstractReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/AbstractReconciler.java
@@ -4,6 +4,8 @@ import io.kubernetes.client.extended.controller.reconciler.Reconciler;
 import io.kubernetes.client.extended.controller.reconciler.Request;
 import io.kubernetes.client.extended.controller.reconciler.Result;
 import io.kubernetes.client.openapi.ApiException;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import java.net.HttpURLConnection;
 import java.time.Duration;
 import lombok.Getter;
@@ -12,6 +14,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class AbstractReconciler implements Reconciler {
+
+  private static final String RECONCILE_TIMER_NAME = "projectcontroller.reconcile.duration";
+
+  // Reconciler 는 *ControllerFactory 에서 new 로 생성되는 POJO 라 스프링 DI 대상이 아니다.
+  // MeterRegistry 는 기동 시 MetricsConfiguration 에서 1회 정적 주입한다(단일 인스턴스 컨트롤러).
+  private static MeterRegistry meterRegistry;
+
+  public static void setMeterRegistry(MeterRegistry meterRegistry) {
+    AbstractReconciler.meterRegistry = meterRegistry;
+  }
 
   private final Logger logger;
   @Getter
@@ -33,18 +45,37 @@ public abstract class AbstractReconciler implements Reconciler {
 
   @Override
   public Result reconcile(Request request) {
+    long startNanos = System.nanoTime();
+    String result = "success";
     try {
       return reconcileInternal(request);
     } catch (Exception e) {
       if (e instanceof ApiException apiException) {
         if (apiException.getCode() == HttpURLConnection.HTTP_CONFLICT) {
+          result = "conflict";
           this.logger.info(this.logMessageFactory.createMessage(request, e, true));
           return new Result(true, getApiConflictFailRequeueDuration());
         }
       }
+      result = "error";
       this.logger.error(this.logMessageFactory.createMessage(request, e, true));
       return new Result(true, getGeneralFailRequeueDuration());
+    } finally {
+      recordReconcileDuration(result, startNanos);
     }
+  }
+
+  private void recordReconcileDuration(String result, long startNanos) {
+    MeterRegistry registry = meterRegistry;
+    if (registry == null) {
+      return;
+    }
+    Timer.builder(RECONCILE_TIMER_NAME)
+        .description("Reconcile execution time per controller")
+        .tag("controller", getClass().getSimpleName())
+        .tag("result", result)
+        .register(registry)
+        .record(Duration.ofNanos(System.nanoTime() - startNanos));
   }
 
   protected abstract Result reconcileInternal(Request request) throws ApiException;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -38,3 +38,22 @@ app:
     reconcile-excluded-label-selectors:
       - "app.kubernetes.io/part-of=cilium"
       - "kubevirt.io"
+
+management:
+  server:
+    # webhook(메인 8080)은 TLS 이므로 actuator/prometheus 는 평문 포트로 분리한다.
+    port: 8081
+  endpoints:
+    web:
+      exposure:
+        include: "health,info,prometheus"
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  metrics:
+    tags:
+      application: ${spring.application.name}
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true


### PR DESCRIPTION
## 개요

성능 측정 연구에서 project-controller 가 성능 병목(직렬 reconcile, informer 전량 캐시, admission webhook)을 다수 보유하나 이를 관측할 계기가 없음이 확인되어 Micrometer/Prometheus 계측을 추가한다. aipub-backend(AIP-1246)와 계측 스택을 통일한다.

## 변경

- `pom.xml`: 미사용 `io.prometheus:simpleclient` 제거 → `spring-boot-starter-actuator` + `micrometer-registry-prometheus`
- `AbstractReconciler`: reconcile 진입점에 Timer(`controller`, `result` 태그) — 25개 컨트롤러 공통 계측. reconciler 는 `*ControllerFactory` 가 생성하는 POJO 라 MeterRegistry 를 기동 시 1회 정적 주입
- `MetricsConfiguration`(신규): MeterRegistry 정적 주입 + informer 26종 캐시 크기 Gauge(`resource` 태그)
- `application.yaml`: management 를 평문 `8081` 로 분리(메인 `8080` 은 webhook TLS), `health,info,prometheus` 노출, `http.server.requests` 히스토그램 on
- `service.yaml`/`deployment.yaml`: metrics 포트(8081) 노출

## 노출 메트릭

- `projectcontroller.reconcile.duration` — 컨트롤러별 reconcile 지연/결과(success/conflict/error)
- `projectcontroller.informer.cache.size` — 리소스별 informer 캐시 크기(메모리 지배 변수)
- `http.server.requests` — admission webhook 지연 p95/p99 + JVM/heap/GC 기본 메트릭

## 검증

- `./mvnw compile` BUILD SUCCESS
- `./mvnw test` 85개 전부 통과(회귀 없음)
- `kubectl kustomize` 빌드 성공

## 범위 제외 / 후속

- **workqueue 깊이**: kubernetes-client `DefaultController` 내부라 공개 접근 수단이 없어 이번 범위에서 제외(reconcile Timer 로 간접 관측)
- **수집(scrape)**: operator/ServiceMonitor CR 이 아니라 독립 Prometheus 스택의 정적 `scrape_config` 가 `/actuator/prometheus` 를 직접 긁는 플러그인 방식으로 운용. scrape 설정 편입은 별도 진행
- **런타임 확인**: `in_cluster` 전제라 `/actuator/prometheus` 실측은 클러스터 배포 후
