### PR TITLE
fix(AIP-2241): management 포트를 backend 와 통일 (8082)

### DIFF
--- a/kubernetes/controller/project-controller/templates/deployment.yaml
+++ b/kubernetes/controller/project-controller/templates/deployment.yaml
@@ -33,8 +33,8 @@ spec:
           ports:
             - name: webhook
               containerPort: 8080
-            - name: metrics
-              containerPort: 8081
+            - name: management
+              containerPort: 8082
           envFrom:
             - configMapRef:
                 name: project-controller-envs

--- a/kubernetes/controller/project-controller/templates/service.yaml
+++ b/kubernetes/controller/project-controller/templates/service.yaml
@@ -13,8 +13,8 @@ spec:
       protocol: TCP
       port: 8080
       targetPort: 8080
-    - name: metrics
+    - name: management
       protocol: TCP
-      port: 8081
-      targetPort: 8081
+      port: 8082
+      targetPort: 8082
 ---

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,8 +41,8 @@ app:
 
 management:
   server:
-    # webhook(메인 8080)은 TLS 이므로 actuator/prometheus 는 평문 포트로 분리한다.
-    port: 8081
+    # webhook(메인 8080)은 TLS 라 actuator 를 평문 포트로 분리. backend Java 서비스(8082)와 통일.
+    port: 8082
   endpoints:
     web:
       exposure:


### PR DESCRIPTION
## 개요

PR #72 에서 project-controller 에 actuator/prometheus 를 노출하며 management 포트를 8081 로 두었으나, 클러스터의 backend Java 서비스(api·gateway 등)가 management 를 **8082**(name: `management`)로 통일 사용하므로 project-controller 도 동일 포트/이름으로 맞춘다.

## 변경

- `application.yaml`: `management.server.port` 8081 → 8082
- `service.yaml` / `deployment.yaml`: 포트 `name: metrics`(8081) → `name: management`(8082)

## 연계

- PR #72 (계측 도입, 머지됨)
- installer PR #157 (helm 차트 8082 반영 + 기배포 Service 보정용 `patch-metrics-svc.sh`)