### PR TITLE
fix(AIP-2241): simpleclient 런타임 의존성 복원

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,14 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
+        <!-- kubernetes-client-extended 의 DefaultController 가 workqueue 메트릭에 사용(런타임 필수).
+             소스에서 직접 import 하지 않지만 제거하면 io.prometheus.client.Gauge NoClassDefFoundError 로
+             기동에 실패한다. micrometer-registry-prometheus(io.prometheus.metrics 1.x)로는 대체 불가. -->
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>0.16.0</version>
+        </dependency>
 
         <!-- Etc dependencies -->
         <dependency>


### PR DESCRIPTION
## 문제

계측 이미지(1.7.5) 기동 시 `NoClassDefFoundError: io/prometheus/client/Gauge` 로 크래시.
`kubernetes-client-extended` 의 `DefaultController` 가 workqueue 메트릭에
`io.prometheus.client.Gauge`(simpleclient 0.x)를 런타임에 사용하는데, #72 에서
"미사용"으로 오판해 제거한 것이 원인.

## 수정

`io.prometheus:simpleclient:0.16.0` 을 direct 의존으로 복원(주석으로 재삭제 방지 명시).
`micrometer-registry-prometheus`(1.x, `io.prometheus.metrics`)는 구 `io.prometheus.client`
클래스를 제공하지 않아 대체 불가.

## 검증

`./mvnw compile` 성공, `dependency:tree` 에 `io.prometheus:simpleclient:0.16.0` 존재 확인.