### PR TITLE
fix(AIP-2241): management 커넥터 평문화 (8082 http)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -43,6 +43,9 @@ management:
   server:
     # webhook(메인 8080)은 TLS 라 actuator 를 평문 포트로 분리. backend Java 서비스(8082)와 통일.
     port: 8082
+    ssl:
+      # webhook 의 server.ssl 을 management 커넥터가 상속하지 않도록 평문(http)으로 강제한다.
+      enabled: false
   endpoints:
     web:
       exposure:


### PR DESCRIPTION
webhook(8080) TLS 상속으로 management(8082)가 https 로 떠 backend Java(http 8082)와 scheme 이 불일치했다. `management.server.ssl.enabled: false` 로 8082 를 평문화 → backend 와 scheme 통일, 자립 Prometheus 스택이 전 타겟을 http 로 스크레이프. #74 후속.