### PR TITLE
fix: log ImageHub-not-connected at WARN instead of throwing IllegalStateException

### DIFF
--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/ImageRegistryRobotReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/ImageRegistryRobotReconciler.java
@@ -11,17 +11,34 @@ import io.ten1010.aipub.projectcontroller.domain.aipubbackend.dto.ImageRegistryA
 import io.ten1010.aipub.projectcontroller.domain.aipubbackend.dto.ImageRegistryRobot;
 import io.ten1010.aipub.projectcontroller.domain.aipubbackend.dto.ImageRegistryRobotListOptions;
 import io.ten1010.aipub.projectcontroller.domain.aipubbackend.dto.ImageRegistryRobotPermission;
+import io.ten1010.aipub.projectcontroller.domain.aipubbackend.impl.AipubBackendResponseException;
 import io.ten1010.aipub.projectcontroller.domain.k8s.KeyResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ImageHub;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Project;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.ImageHubUtils;
+import io.ten1010.aipub.projectcontroller.domain.k8s.util.K8sObjectUtils;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.ProjectUtils;
+import io.ten1010.common.apiclient.ApiResponse;
+import java.net.HttpURLConnection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ImageRegistryRobotReconciler extends AbstractReconciler {
+
+  private static final Logger log = LoggerFactory.getLogger(ImageRegistryRobotReconciler.class);
+
+  // aipub 백엔드가 반환하는 IMAGEHUB_NOT_FOUND 응답 body 의 message 에서 ImageHub id 를 추출하기 위한 패턴.
+  // 예) {"type":"IMAGEHUB_NOT_FOUND","message":"ImageHub '32' not found"}
+  private static final Pattern IMAGE_HUB_NOT_FOUND_ID_PATTERN =
+      Pattern.compile("ImageHub '([^']+)' not found");
 
   private final ImageRegistryRobotService robotService;
   private final ImageRegistryRobotUsernameResolver usernameResolver;
@@ -76,7 +93,10 @@ public class ImageRegistryRobotReconciler extends AbstractReconciler {
       return new Result(false);
     }
 
-    List<ImageRegistryRobotPermission> reconciledPermissions = createPermissions(projectOpt.get());
+    List<V1alpha1ImageHub> boundImageHubs = resolveBoundImageHubs(projectOpt.get());
+    List<ImageRegistryRobotPermission> reconciledPermissions = boundImageHubs.stream()
+        .map(ImageRegistryRobotReconciler::createPermission)
+        .toList();
 
     if (robotOpt.isPresent()) {
       Objects.requireNonNull(robotOpt.get().getId());
@@ -91,14 +111,28 @@ public class ImageRegistryRobotReconciler extends AbstractReconciler {
       existing.setUsername(robotOpt.get().getUsername());
       existing.setSecret(robotOpt.get().getSecret());
       existing.setPermissions(reconciledPermissions);
-      this.robotService.updateImageRegistryRobot(robotOpt.get().getId(), existing);
+      try {
+        this.robotService.updateImageRegistryRobot(robotOpt.get().getId(), existing);
+      } catch (AipubBackendResponseException e) {
+        if (isImageHubNotFound(e)) {
+          return logImageHubNotFoundAndRequeue(e, request.getName(), boundImageHubs);
+        }
+        throw e;
+      }
     }
 
     if (!reconciledPermissions.isEmpty()) {
       ImageRegistryRobot newRobot = new ImageRegistryRobot();
       newRobot.setUsername(username);
       newRobot.setPermissions(reconciledPermissions);
-      this.robotService.createImageRegistryRobot(newRobot);
+      try {
+        this.robotService.createImageRegistryRobot(newRobot);
+      } catch (AipubBackendResponseException e) {
+        if (isImageHubNotFound(e)) {
+          return logImageHubNotFoundAndRequeue(e, request.getName(), boundImageHubs);
+        }
+        throw e;
+      }
       return new Result(false);
     }
 
@@ -116,12 +150,11 @@ public class ImageRegistryRobotReconciler extends AbstractReconciler {
         .findFirst();
   }
 
-  private List<ImageRegistryRobotPermission> createPermissions(V1alpha1Project project) {
+  private List<V1alpha1ImageHub> resolveBoundImageHubs(V1alpha1Project project) {
     return ProjectUtils.getSpecBindingImageHubs(project).stream()
         .map(e -> this.imageHubIndexer.getByKey(this.keyResolver.resolveKey(e)))
         .filter(Objects::nonNull)
         .filter(ImageRegistryRobotReconciler::hasSpecId)
-        .map(ImageRegistryRobotReconciler::createPermission)
         .toList();
   }
 
@@ -129,6 +162,61 @@ public class ImageRegistryRobotReconciler extends AbstractReconciler {
     return imageHub.getSpec() != null
         && imageHub.getSpec().getId() != null
         && !imageHub.getSpec().getId().isBlank();
+  }
+
+  private Result logImageHubNotFoundAndRequeue(
+      AipubBackendResponseException e, String projName, List<V1alpha1ImageHub> boundImageHubs) {
+    String missingId = extractMissingImageHubId(e).orElse(null);
+    log.warn(
+        "ImageHub CR {} 를 AIPub Backend 에서 찾을 수 없어 image registry robot reconcile 을 건너뜀 "
+            + "[project={}]. AIPub Backend 에 존재하지 않는 ImageHub 를 참조하고 있는지 확인 필요. "
+            + "backendMessage={}",
+        describeImageHub(missingId, boundImageHubs),
+        projName,
+        e.getResponse().getBodyAsString().orElse(null));
+    return new Result(true, getGeneralFailRequeueDuration());
+  }
+
+  /**
+   * IMAGEHUB_NOT_FOUND 로 지목된 ImageHub 를 사람이 읽을 수 있는 {@code [id=.., name=..]} 형태로 기술한다.
+   *
+   * <p>백엔드 message 에서 추출한 id 로 bound ImageHub CR 을 역추적해 CR 이름까지 함께 남긴다.
+   * id 를 특정하지 못하면 project 가 바인딩한 전체 ImageHub CR 목록을 남긴다.
+   */
+  private static String describeImageHub(
+      @Nullable String missingId, List<V1alpha1ImageHub> boundImageHubs) {
+    if (missingId != null) {
+      String crName = boundImageHubs.stream()
+          .filter(h -> missingId.equals(ImageHubUtils.getSpecId(h)))
+          .map(K8sObjectUtils::getName)
+          .findFirst()
+          .orElse("<unknown>");
+      return String.format("[id=%s, name=%s]", missingId, crName);
+    }
+    if (boundImageHubs.isEmpty()) {
+      return "[]";
+    }
+    return boundImageHubs.stream()
+        .map(h -> String.format("[id=%s, name=%s]", ImageHubUtils.getSpecId(h),
+            K8sObjectUtils.getName(h)))
+        .collect(Collectors.joining(", "));
+  }
+
+  private static boolean isImageHubNotFound(AipubBackendResponseException e) {
+    ApiResponse response = e.getResponse();
+    if (response.getStatusCode() != HttpURLConnection.HTTP_NOT_FOUND) {
+      return false;
+    }
+    return response.getBodyAsString()
+        .filter(body -> body.contains("IMAGEHUB_NOT_FOUND"))
+        .isPresent();
+  }
+
+  private static Optional<String> extractMissingImageHubId(AipubBackendResponseException e) {
+    return e.getResponse().getBodyAsString().flatMap(body -> {
+      Matcher matcher = IMAGE_HUB_NOT_FOUND_ID_PATTERN.matcher(body);
+      return matcher.find() ? Optional.of(matcher.group(1)) : Optional.empty();
+    });
   }
 
 }

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/namespaced/ImageRegistrySecretReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/namespaced/ImageRegistrySecretReconciler.java
@@ -12,6 +12,7 @@ import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1SecretBuilder;
 import io.ten1010.aipub.projectcontroller.controller.AbstractReconciler;
 import io.ten1010.aipub.projectcontroller.controller.RequestHelper;
+import io.ten1010.aipub.projectcontroller.domain.k8s.ImageHubNotConnectedException;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ImageRegistrySecretNameResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.K8sApiProvider;
 import io.ten1010.aipub.projectcontroller.domain.k8s.KeyResolver;
@@ -24,8 +25,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ImageRegistrySecretReconciler extends AbstractReconciler {
+
+  private static final Logger log = LoggerFactory.getLogger(ImageRegistrySecretReconciler.class);
 
   private final KeyResolver keyResolver;
   private final NamespaceNameResolver namespaceNameResolver;
@@ -98,15 +103,25 @@ public class ImageRegistrySecretReconciler extends AbstractReconciler {
         deleteSecret(secretOpt.get());
         return new Result(false);
       }
-      Map<String, byte[]> reconciledData = this.reconciliationService.reconcileImageRegistrySecretData(
-          projectOpt.get());
+      Map<String, byte[]> reconciledData;
+      try {
+        reconciledData = this.reconciliationService.reconcileImageRegistrySecretData(
+            projectOpt.get());
+      } catch (ImageHubNotConnectedException e) {
+        return logImageHubNotConnectedAndRequeue(projName);
+      }
       return reconcileExistingSecret(secretOpt.get(), reconciledReferences, reconciledType,
           reconciledData, reconciledLabels);
     }
 
     if (!K8sObjectUtils.isTerminating(projectOpt.get())) {
-      Map<String, byte[]> reconciledData = this.reconciliationService.reconcileImageRegistrySecretData(
-          projectOpt.get());
+      Map<String, byte[]> reconciledData;
+      try {
+        reconciledData = this.reconciliationService.reconcileImageRegistrySecretData(
+            projectOpt.get());
+      } catch (ImageHubNotConnectedException e) {
+        return logImageHubNotConnectedAndRequeue(projName);
+      }
       Map<String, String> reconciledLabels = this.reconciliationService.reconcileSecretLabels(
           namespaceOpt.get(), projectOpt.get());
       return reconcileNoExistingSecret(request.getNamespace(), request.getName(),
@@ -114,6 +129,12 @@ public class ImageRegistrySecretReconciler extends AbstractReconciler {
     }
 
     return new Result(false);
+  }
+
+  private Result logImageHubNotConnectedAndRequeue(String projName) {
+    log.warn("ImageHub is not connected to the project [name={}]. "
+        + "Skipping image registry secret reconciliation until it is connected.", projName);
+    return new Result(true, getGeneralFailRequeueDuration());
   }
 
   private Result reconcileNoExistingSecret(

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/aipubbackend/AipubDockerConfigJsonResolver.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/aipubbackend/AipubDockerConfigJsonResolver.java
@@ -4,6 +4,7 @@ import io.ten1010.aipub.projectcontroller.domain.aipubbackend.dto.ImageRegistryR
 import io.ten1010.aipub.projectcontroller.domain.aipubbackend.dto.ImageRegistryRobotListOptions;
 import io.ten1010.aipub.projectcontroller.domain.aipubbackend.dto.ImageRegistryRobotSecret;
 import io.ten1010.aipub.projectcontroller.domain.k8s.DockerConfigJsonResolver;
+import io.ten1010.aipub.projectcontroller.domain.k8s.ImageHubNotConnectedException;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Project;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.K8sObjectUtils;
 import java.util.Base64;
@@ -45,7 +46,8 @@ public class AipubDockerConfigJsonResolver implements DockerConfigJsonResolver {
         K8sObjectUtils.getName(project));
     Optional<ImageRegistryRobot> robotOpt = findByUsername(username);
     if (robotOpt.isEmpty()) {
-      throw new IllegalStateException("Could not find image registry robot for " + username);
+      throw new ImageHubNotConnectedException(
+          "Could not find image registry robot for " + username);
     }
     String password = getPassword(robotOpt.get());
 

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ImageHubNotConnectedException.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ImageHubNotConnectedException.java
@@ -1,0 +1,15 @@
+package io.ten1010.aipub.projectcontroller.domain.k8s;
+
+/**
+ * Project 에 ImageHub 가 연동되어 있지 않아 image registry 관련 리소스를 resolve 할 수 없을 때 발생한다.
+ *
+ * <p>이는 오류가 아니라 아직 ImageHub 가 연결되지 않은 정상적으로 발생 가능한 상태이므로,
+ * 리컨실러에서 잡아 경고 수준의 로그로 처리한다.
+ */
+public class ImageHubNotConnectedException extends RuntimeException {
+
+  public ImageHubNotConnectedException(String message) {
+    super(message);
+  }
+
+}


### PR DESCRIPTION
## 배경

Project 에 ImageHub 가 연동되지 않았거나, 참조하는 ImageHub 가 AIPub 백엔드에 존재하지 않는 경우, 리컨실 때마다 ERROR 스택트레이스가 로깅되었습니다. 이는 오류가 아니라 정상적으로 발생 가능한 상태이므로 WARN 수준으로 낮춥니다.

이 PR 은 관련된 두 리컨실러를 함께 다룹니다.

---

## 1. `ImageRegistrySecretReconciler` — ImageHub 미연동

Project 에 ImageHub 가 연동되지 않은 경우, image registry robot 을 찾지 못해 `AipubDockerConfigJsonResolver` 가 `IllegalStateException` 을 던졌고, 이것이 ERROR 스택트레이스로 로깅되었습니다.

```
ERROR i.t.a.p.c.n.ImageRegistrySecretReconciler - Exception occurred Processing reconcile request ...
java.lang.IllegalStateException: Could not find image registry robot for robot$project-aipub-ten1010-io-test-pr
    at io.ten1010.aipub.projectcontroller.domain.aipubbackend.AipubDockerConfigJsonResolver.resolve(...)
```

### 변경 사항

- **신규** `ImageHubNotConnectedException` (`domain.k8s`): ImageHub 미연동 상태를 나타내는 전용 예외
- `AipubDockerConfigJsonResolver`: robot 을 찾지 못하면 `IllegalStateException` 대신 `ImageHubNotConnectedException` 을 던짐
- `ImageRegistrySecretReconciler`: 해당 예외를 잡아 **WARN 로그**로 처리하고, 기존 requeue 동작은 유지하여 ImageHub 연동 후 자동으로 secret 이 리컨실되도록 함

변경 후 로그:

```
WARN  i.t.a.p.c.n.ImageRegistrySecretReconciler - ImageHub is not connected to the project [name=test-pr]. Skipping image registry secret reconciliation until it is connected.
```

---

## 2. `ImageRegistryRobotReconciler` — 존재하지 않는 ImageHub 참조

Project 가 바인딩한 ImageHub CR 의 `spec.id` 가 AIPub 백엔드에 존재하지 않는 경우, `createImageRegistryRobot` / `updateImageRegistryRobot` 호출이 `404 IMAGEHUB_NOT_FOUND` 를 반환하며 ERROR 스택트레이스로 로깅되었습니다.

```
ERROR i.t.a.p.c.ImageRegistryRobotReconciler - Exception occurred Processing reconcile request [namespace=null name=hyomin-test]
io.ten1010.aipub.projectcontroller.domain.aipubbackend.impl.AipubBackendResponseException: statusCode=404, ... body={"type":"IMAGEHUB_NOT_FOUND","message":"ImageHub '32' not found"}
    at ...createImageRegistryRobot(ImageRegistryRobotServiceImpl.java:40)
```

### 변경 사항

- `createImageRegistryRobot` / `updateImageRegistryRobot` 호출을 `try/catch` 로 감쌈
- `AipubBackendResponseException` 중 **404 + `IMAGEHUB_NOT_FOUND`** 인 경우만 **WARN** 처리, 그 외 예외는 그대로 재던져 기존 ERROR 동작 유지
- 백엔드 응답 message 에서 누락된 ImageHub id 를 추출 → project 가 바인딩한 ImageHub CR 목록에서 **CR 이름까지 역추적**해 로그에 남김 (로그만 보고 파악 가능)
- 기존 requeue 동작은 유지

변경 후 로그:

```
WARN  i.t.a.p.c.ImageRegistryRobotReconciler - ImageHub CR [id=32, name=hyomin-test-hub] 를 AIPub Backend 에서 찾을 수 없어 image registry robot reconcile 을 건너뜀 [project=hyomin-test]. AIPub Backend 에 존재하지 않는 ImageHub 를 참조하고 있는지 확인 필요. backendMessage={"type":"IMAGEHUB_NOT_FOUND","message":"ImageHub '32' not found"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)