### PR TITLE
feat(quota): add cpu/memory quota to Project spec and status

### DIFF
--- a/kubernetes/controller/project-controller/templates/crd.yaml
+++ b/kubernetes/controller/project-controller/templates/crd.yaml
@@ -56,10 +56,34 @@ spec:
                     pvcStorage:
                       type: string
                       pattern: '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                    hard:
+                      type: object
+                      properties:
+                        cpu:
+                          type: object
+                          properties:
+                            requests:
+                              type: string
+                              pattern: '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                            limits:
+                              type: string
+                              pattern: '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                        memory:
+                          type: object
+                          properties:
+                            requests:
+                              type: string
+                              pattern: '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                            limits:
+                              type: string
+                              pattern: '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
                     extendedResources:
                       type: object
                       additionalProperties:
                         type: string
+                      x-kubernetes-validations:
+                        - rule: "!('cpu' in self) && !('memory' in self)"
+                          message: "quota.extendedResources must not contain 'cpu' or 'memory'; use quota.hard.cpu / quota.hard.memory instead"
                 binding:
                   type: object
                   properties:
@@ -96,6 +120,43 @@ spec:
                           type: string
                         used:
                           type: string
+                    hard:
+                      type: object
+                      properties:
+                        cpu:
+                          type: object
+                          properties:
+                            requests:
+                              type: object
+                              properties:
+                                limit:
+                                  type: string
+                                used:
+                                  type: string
+                            limits:
+                              type: object
+                              properties:
+                                limit:
+                                  type: string
+                                used:
+                                  type: string
+                        memory:
+                          type: object
+                          properties:
+                            requests:
+                              type: object
+                              properties:
+                                limit:
+                                  type: string
+                                used:
+                                  type: string
+                            limits:
+                              type: object
+                              properties:
+                                limit:
+                                  type: string
+                                used:
+                                  type: string
                 allBoundNodeGroups:
                   type: array
                   default: [ ]

--- a/kubernetes/examples/proj1.yaml
+++ b/kubernetes/examples/proj1.yaml
@@ -10,6 +10,13 @@ spec:
       role: project-developer
   quota:
     pvcStorage: 500Gi
+    hard:
+      cpu:
+        requests: "16"
+        limits: "32"
+      memory:
+        requests: 64Gi
+        limits: 128Gi
   binding:
     nodes:
       - node1

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationService.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationService.java
@@ -38,7 +38,9 @@ import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1NodeGroupStatus
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Project;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ProjectStatus;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ProjectStatusQuota;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ProjectStatusQuotaHard;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ProjectStatusQuotaMetric;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ProjectStatusQuotaResource;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ResourceSet;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.K8sObjectUtils;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.NodeUtils;
@@ -54,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
@@ -62,7 +65,14 @@ import org.jspecify.annotations.Nullable;
 public class ReconciliationService {
 
   private static final String REQUESTS_STORAGE_QUOTA_RESOURCE_NAME = "requests.storage";
+  private static final String REQUESTS_CPU_QUOTA_RESOURCE_NAME = "requests.cpu";
+  private static final String LIMITS_CPU_QUOTA_RESOURCE_NAME = "limits.cpu";
+  private static final String REQUESTS_MEMORY_QUOTA_RESOURCE_NAME = "requests.memory";
+  private static final String LIMITS_MEMORY_QUOTA_RESOURCE_NAME = "limits.memory";
   private static final String EXTENDED_RESOURCE_HARD_PREFIX = "requests.";
+  // cpu / memory must be expressed via quota.hard, never via quota.extendedResources
+  // (which would collide with hard.cpu.requests / hard.memory.requests). Ignored if present.
+  private static final Set<String> RESERVED_EXTENDED_RESOURCE_KEYS = Set.of("cpu", "memory");
   private static final List<String> BASIC_VERBS = List.of("create", "get", "watch", "list");
   private static final List<String> UPDATABLE_VERBS = List.of("update", "patch", "delete");
   private final SubjectResolver subjectResolver;
@@ -299,25 +309,57 @@ public class ReconciliationService {
     }
 
     Map<String, Quantity> statusHard = ResourceQuotaUtils.getStatusHard(boundQuota);
-    Quantity hardQuantity = statusHard.get(REQUESTS_STORAGE_QUOTA_RESOURCE_NAME);
-    String metricLimit = Optional.ofNullable(hardQuantity)
-        .map(Quantity::toSuffixedString)
-        .orElse(null);
-
     Map<String, Quantity> statusUsed = ResourceQuotaUtils.getStatusUsed(boundQuota);
-    Quantity usedQuantity = statusUsed.get(REQUESTS_STORAGE_QUOTA_RESOURCE_NAME);
-    String metricUsed = Optional.ofNullable(usedQuantity)
-        .map(Quantity::toSuffixedString)
-        .orElse(null);
-
-    V1alpha1ProjectStatusQuotaMetric storageMetric = new V1alpha1ProjectStatusQuotaMetric();
-    storageMetric.setLimit(metricLimit);
-    storageMetric.setUsed(metricUsed);
 
     V1alpha1ProjectStatusQuota statusQuota = new V1alpha1ProjectStatusQuota();
-    statusQuota.setPvcStorage(storageMetric);
+    statusQuota.setPvcStorage(
+        buildQuotaMetric(statusHard, statusUsed, REQUESTS_STORAGE_QUOTA_RESOURCE_NAME));
+
+    V1alpha1ProjectStatusQuotaResource cpu = buildQuotaResource(statusHard, statusUsed,
+        REQUESTS_CPU_QUOTA_RESOURCE_NAME, LIMITS_CPU_QUOTA_RESOURCE_NAME);
+    V1alpha1ProjectStatusQuotaResource memory = buildQuotaResource(statusHard, statusUsed,
+        REQUESTS_MEMORY_QUOTA_RESOURCE_NAME, LIMITS_MEMORY_QUOTA_RESOURCE_NAME);
+    if (cpu != null || memory != null) {
+      V1alpha1ProjectStatusQuotaHard hard = new V1alpha1ProjectStatusQuotaHard();
+      hard.setCpu(cpu);
+      hard.setMemory(memory);
+      statusQuota.setHard(hard);
+    }
 
     return statusQuota;
+  }
+
+  @Nullable
+  private static V1alpha1ProjectStatusQuotaResource buildQuotaResource(
+      Map<String, Quantity> statusHard, Map<String, Quantity> statusUsed,
+      String requestsResourceName, String limitsResourceName) {
+    V1alpha1ProjectStatusQuotaMetric requestsMetric =
+        buildQuotaMetric(statusHard, statusUsed, requestsResourceName);
+    V1alpha1ProjectStatusQuotaMetric limitsMetric =
+        buildQuotaMetric(statusHard, statusUsed, limitsResourceName);
+    if (requestsMetric == null && limitsMetric == null) {
+      return null;
+    }
+
+    V1alpha1ProjectStatusQuotaResource resource = new V1alpha1ProjectStatusQuotaResource();
+    resource.setRequests(requestsMetric);
+    resource.setLimits(limitsMetric);
+    return resource;
+  }
+
+  @Nullable
+  private static V1alpha1ProjectStatusQuotaMetric buildQuotaMetric(
+      Map<String, Quantity> statusHard, Map<String, Quantity> statusUsed, String resourceName) {
+    Quantity hardQuantity = statusHard.get(resourceName);
+    Quantity usedQuantity = statusUsed.get(resourceName);
+    if (hardQuantity == null && usedQuantity == null) {
+      return null;
+    }
+
+    V1alpha1ProjectStatusQuotaMetric metric = new V1alpha1ProjectStatusQuotaMetric();
+    metric.setLimit(hardQuantity == null ? null : hardQuantity.toSuffixedString());
+    metric.setUsed(usedQuantity == null ? null : usedQuantity.toSuffixedString());
+    return metric;
   }
 
   public List<V1OwnerReference> reconcileOwnerReferences(@Nullable KubernetesObject existing,
@@ -892,12 +934,27 @@ public class ReconciliationService {
 
   public V1ResourceQuotaSpec reconcileQuotaSpec(V1alpha1Project project) {
     V1ResourceQuotaSpecBuilder builder = new V1ResourceQuotaSpecBuilder();
-    Optional<String> pvcStorageQuotaOpt = ProjectUtils.getSpecPvcStorageQuota(project);
-    pvcStorageQuotaOpt.ifPresent(quota -> builder.addToHard(REQUESTS_STORAGE_QUOTA_RESOURCE_NAME,
-        Quantity.fromString(quota)));
+
+    ProjectUtils.getSpecPvcStorageQuota(project).ifPresent(quota -> builder.addToHard(
+        REQUESTS_STORAGE_QUOTA_RESOURCE_NAME, Quantity.fromString(quota)));
+
+    ProjectUtils.getSpecCpuRequestsQuota(project).ifPresent(quota -> builder.addToHard(
+        REQUESTS_CPU_QUOTA_RESOURCE_NAME, Quantity.fromString(quota)));
+    ProjectUtils.getSpecCpuLimitsQuota(project).ifPresent(quota -> builder.addToHard(
+        LIMITS_CPU_QUOTA_RESOURCE_NAME, Quantity.fromString(quota)));
+    ProjectUtils.getSpecMemoryRequestsQuota(project).ifPresent(quota -> builder.addToHard(
+        REQUESTS_MEMORY_QUOTA_RESOURCE_NAME, Quantity.fromString(quota)));
+    ProjectUtils.getSpecMemoryLimitsQuota(project).ifPresent(quota -> builder.addToHard(
+        LIMITS_MEMORY_QUOTA_RESOURCE_NAME, Quantity.fromString(quota)));
+
     Map<String, String> extendedResourcesQuota = ProjectUtils.getSpecExtendedResourcesQuota(
         project);
     for (Map.Entry<String, String> e : extendedResourcesQuota.entrySet()) {
+      if (RESERVED_EXTENDED_RESOURCE_KEYS.contains(e.getKey())) {
+        log.warn("Ignoring reserved key '{}' in quota.extendedResources; use quota.hard.{} instead",
+            e.getKey(), e.getKey());
+        continue;
+      }
       builder.addToHard(EXTENDED_RESOURCE_HARD_PREFIX + e.getKey(),
           Quantity.fromString(e.getValue()));
     }

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/dto/V1alpha1ProjectSpecQuota.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/dto/V1alpha1ProjectSpecQuota.java
@@ -11,5 +11,7 @@ public class V1alpha1ProjectSpecQuota {
   private String pvcStorage;
   @Nullable
   private Map<String, String> extendedResources;
+  @Nullable
+  private V1alpha1ProjectSpecQuotaHard hard;
 
 }

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/dto/V1alpha1ProjectSpecQuotaHard.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/dto/V1alpha1ProjectSpecQuotaHard.java
@@ -1,0 +1,18 @@
+package io.ten1010.aipub.projectcontroller.domain.k8s.dto;
+
+import lombok.Data;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Compute resource caps, grouped under {@code hard} to mirror the native ResourceQuota
+ * {@code spec.hard}. Each entry wraps the {@code requests} / {@code limits} caps for a resource.
+ */
+@Data
+public class V1alpha1ProjectSpecQuotaHard {
+
+  @Nullable
+  private V1alpha1ProjectSpecQuotaResource cpu;
+  @Nullable
+  private V1alpha1ProjectSpecQuotaResource memory;
+
+}

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/dto/V1alpha1ProjectSpecQuotaResource.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/dto/V1alpha1ProjectSpecQuotaResource.java
@@ -1,0 +1,19 @@
+package io.ten1010.aipub.projectcontroller.domain.k8s.dto;
+
+import lombok.Data;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A compute resource quota entry wrapping the {@code requests} / {@code limits} caps for a single
+ * resource (e.g. cpu, memory). Mapped to the {@code requests.<name>} / {@code limits.<name>} keys
+ * of the managed ResourceQuota.
+ */
+@Data
+public class V1alpha1ProjectSpecQuotaResource {
+
+  @Nullable
+  private String requests;
+  @Nullable
+  private String limits;
+
+}

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/dto/V1alpha1ProjectStatusQuota.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/dto/V1alpha1ProjectStatusQuota.java
@@ -8,5 +8,7 @@ public class V1alpha1ProjectStatusQuota {
 
   @Nullable
   private V1alpha1ProjectStatusQuotaMetric pvcStorage;
+  @Nullable
+  private V1alpha1ProjectStatusQuotaHard hard;
 
 }

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/dto/V1alpha1ProjectStatusQuotaHard.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/dto/V1alpha1ProjectStatusQuotaHard.java
@@ -1,0 +1,18 @@
+package io.ten1010.aipub.projectcontroller.domain.k8s.dto;
+
+import lombok.Data;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Reported compute resource quota, grouped under {@code hard} to mirror the spec shape. Each entry
+ * wraps the {@code requests} / {@code limits} limit/used metrics for a resource.
+ */
+@Data
+public class V1alpha1ProjectStatusQuotaHard {
+
+  @Nullable
+  private V1alpha1ProjectStatusQuotaResource cpu;
+  @Nullable
+  private V1alpha1ProjectStatusQuotaResource memory;
+
+}

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/dto/V1alpha1ProjectStatusQuotaResource.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/dto/V1alpha1ProjectStatusQuotaResource.java
@@ -1,0 +1,18 @@
+package io.ten1010.aipub.projectcontroller.domain.k8s.dto;
+
+import lombok.Data;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Reported quota for a single compute resource, wrapping the {@code requests} / {@code limits}
+ * limit/used metrics (e.g. cpu, memory).
+ */
+@Data
+public class V1alpha1ProjectStatusQuotaResource {
+
+  @Nullable
+  private V1alpha1ProjectStatusQuotaMetric requests;
+  @Nullable
+  private V1alpha1ProjectStatusQuotaMetric limits;
+
+}

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/util/ProjectUtils.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/util/ProjectUtils.java
@@ -10,15 +10,20 @@ import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ProjectBinding;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ProjectMember;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ProjectSpec;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ProjectSpecQuota;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ProjectSpecQuotaHard;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ProjectSpecQuotaResource;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ProjectStatus;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ProjectStatusQuota;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ProjectStatusQuotaHard;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ProjectStatusQuotaMetric;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ProjectStatusQuotaResource;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 
 public abstract class ProjectUtils {
 
@@ -69,6 +74,34 @@ public abstract class ProjectUtils {
   public static Optional<String> getSpecPvcStorageQuota(V1alpha1Project object) {
     Optional<V1alpha1ProjectSpecQuota> quotaOpt = getSpecQuota(object);
     return quotaOpt.map(V1alpha1ProjectSpecQuota::getPvcStorage);
+  }
+
+  public static Optional<String> getSpecCpuRequestsQuota(V1alpha1Project object) {
+    return getSpecQuota(object)
+        .map(V1alpha1ProjectSpecQuota::getHard)
+        .map(V1alpha1ProjectSpecQuotaHard::getCpu)
+        .map(V1alpha1ProjectSpecQuotaResource::getRequests);
+  }
+
+  public static Optional<String> getSpecCpuLimitsQuota(V1alpha1Project object) {
+    return getSpecQuota(object)
+        .map(V1alpha1ProjectSpecQuota::getHard)
+        .map(V1alpha1ProjectSpecQuotaHard::getCpu)
+        .map(V1alpha1ProjectSpecQuotaResource::getLimits);
+  }
+
+  public static Optional<String> getSpecMemoryRequestsQuota(V1alpha1Project object) {
+    return getSpecQuota(object)
+        .map(V1alpha1ProjectSpecQuota::getHard)
+        .map(V1alpha1ProjectSpecQuotaHard::getMemory)
+        .map(V1alpha1ProjectSpecQuotaResource::getRequests);
+  }
+
+  public static Optional<String> getSpecMemoryLimitsQuota(V1alpha1Project object) {
+    return getSpecQuota(object)
+        .map(V1alpha1ProjectSpecQuota::getHard)
+        .map(V1alpha1ProjectSpecQuotaHard::getMemory)
+        .map(V1alpha1ProjectSpecQuotaResource::getLimits);
   }
 
   public static Map<String, String> getSpecExtendedResourcesQuota(V1alpha1Project object) {
@@ -149,6 +182,10 @@ public abstract class ProjectUtils {
     if (spec.getQuota() != null) {
       V1alpha1ProjectSpecQuota quota = new V1alpha1ProjectSpecQuota();
       quota.setPvcStorage(spec.getQuota().getPvcStorage());
+      if (spec.getQuota().getExtendedResources() != null) {
+        quota.setExtendedResources(new HashMap<>(spec.getQuota().getExtendedResources()));
+      }
+      quota.setHard(cloneSpecQuotaHard(spec.getQuota().getHard()));
       clone.setQuota(quota);
     }
     if (spec.getBinding() != null) {
@@ -174,13 +211,10 @@ public abstract class ProjectUtils {
       clone.setAllBoundAipubUsers(new ArrayList<>(status.getAllBoundAipubUsers()));
     }
     if (status.getQuota() != null) {
+      V1alpha1ProjectStatusQuota source = status.getQuota();
       V1alpha1ProjectStatusQuota quota = new V1alpha1ProjectStatusQuota();
-      if (status.getQuota().getPvcStorage() != null) {
-        V1alpha1ProjectStatusQuotaMetric pvcStorage = new V1alpha1ProjectStatusQuotaMetric();
-        pvcStorage.setLimit(status.getQuota().getPvcStorage().getLimit());
-        pvcStorage.setUsed(status.getQuota().getPvcStorage().getUsed());
-        quota.setPvcStorage(pvcStorage);
-      }
+      quota.setPvcStorage(cloneMetric(source.getPvcStorage()));
+      quota.setHard(cloneStatusQuotaHard(source.getHard()));
       clone.setQuota(quota);
     }
     if (status.getAllBoundNodeGroups() != null) {
@@ -193,6 +227,66 @@ public abstract class ProjectUtils {
       clone.setAllBoundImageHubs(new ArrayList<>(status.getAllBoundImageHubs()));
     }
 
+    return clone;
+  }
+
+  @Nullable
+  private static V1alpha1ProjectStatusQuotaMetric cloneMetric(
+      @Nullable V1alpha1ProjectStatusQuotaMetric metric) {
+    if (metric == null) {
+      return null;
+    }
+    V1alpha1ProjectStatusQuotaMetric clone = new V1alpha1ProjectStatusQuotaMetric();
+    clone.setLimit(metric.getLimit());
+    clone.setUsed(metric.getUsed());
+    return clone;
+  }
+
+  @Nullable
+  private static V1alpha1ProjectSpecQuotaHard cloneSpecQuotaHard(
+      @Nullable V1alpha1ProjectSpecQuotaHard hard) {
+    if (hard == null) {
+      return null;
+    }
+    V1alpha1ProjectSpecQuotaHard clone = new V1alpha1ProjectSpecQuotaHard();
+    clone.setCpu(cloneSpecResource(hard.getCpu()));
+    clone.setMemory(cloneSpecResource(hard.getMemory()));
+    return clone;
+  }
+
+  @Nullable
+  private static V1alpha1ProjectStatusQuotaHard cloneStatusQuotaHard(
+      @Nullable V1alpha1ProjectStatusQuotaHard hard) {
+    if (hard == null) {
+      return null;
+    }
+    V1alpha1ProjectStatusQuotaHard clone = new V1alpha1ProjectStatusQuotaHard();
+    clone.setCpu(cloneStatusResource(hard.getCpu()));
+    clone.setMemory(cloneStatusResource(hard.getMemory()));
+    return clone;
+  }
+
+  @Nullable
+  private static V1alpha1ProjectSpecQuotaResource cloneSpecResource(
+      @Nullable V1alpha1ProjectSpecQuotaResource resource) {
+    if (resource == null) {
+      return null;
+    }
+    V1alpha1ProjectSpecQuotaResource clone = new V1alpha1ProjectSpecQuotaResource();
+    clone.setRequests(resource.getRequests());
+    clone.setLimits(resource.getLimits());
+    return clone;
+  }
+
+  @Nullable
+  private static V1alpha1ProjectStatusQuotaResource cloneStatusResource(
+      @Nullable V1alpha1ProjectStatusQuotaResource resource) {
+    if (resource == null) {
+      return null;
+    }
+    V1alpha1ProjectStatusQuotaResource clone = new V1alpha1ProjectStatusQuotaResource();
+    clone.setRequests(cloneMetric(resource.getRequests()));
+    clone.setLimits(cloneMetric(resource.getLimits()));
     return clone;
   }
 


### PR DESCRIPTION
## 개요 (AIP-2303)

Project CRD의 `spec.quota`에 **cpu / memory quota** 를 추가한다. 네이티브 ResourceQuota `spec.hard`를 미러링해 **`hard` 래퍼** 아래에 구조화된 cpu/memory를 둔다. `pvcStorage`/`extendedResources`는 quota 직속 그대로 유지한다.

## spec.quota
```yaml
spec:
  quota:
    pvcStorage: 500Gi          # 유지 -> requests.storage
    extendedResources: {...}   # 유지 -> requests.<key> (cpu/memory 금지, 아래 참조)
    hard:
      cpu:
        requests: "16"         # -> requests.cpu
        limits: "32"           # -> limits.cpu
      memory:
        requests: 64Gi         # -> requests.memory
        limits: 128Gi          # -> limits.memory
```

## status.quota
```yaml
status:
  quota:
    pvcStorage: { limit, used }
    hard:
      cpu:
        requests: { limit, used }
        limits:   { limit, used }
      memory:
        requests: { limit, used }
        limits:   { limit, used }
```

## extendedResources 에서 cpu / memory 금지

cpu / memory 는 **오직 `quota.hard`** 로만 표현한다. `quota.extendedResources` 에는 `cpu` / `memory` 키를 넣지 못하도록 두 층위로 막는다.

- **CRD (거절)**: `extendedResources` 에 CEL 검증(`x-kubernetes-validations`) 추가 — `cpu` / `memory` 키가 있으면 admission 에서 거절.
  ```yaml
  x-kubernetes-validations:
    - rule: \"!('cpu' in self) && !('memory' in self)\"
      message: \"quota.extendedResources must not contain 'cpu' or 'memory'; use quota.hard.cpu / quota.hard.memory instead\"
  ```
  (CEL 은 k8s >= 1.25 필요)
- **컨트롤러 (무시)**: 혹시 들어오더라도 `reconcileQuotaSpec` 이 `cpu` / `memory` 키를 skip + warn 로그. 구버전 클러스터/CEL 비활성 시 백업.

### Concern — 왜 막는가
`extendedResources` 는 각 키에 `requests.` 접두어만 붙이는 구조라, 여기에 cpu/memory 를 넣으면:
- **requests / limits 를 따로 설정할 수 없다** — `limits.cpu` / `limits.memory` 를 표현할 방법이 없다(항상 `requests.*` 로만 매핑됨).
- **status 에서 used 를 파악할 수 없다** — 컨트롤러가 extendedResources 에 대한 `status.quota` 를 채우지 않는다.

즉 cpu/memory 를 extendedResources 로 넣으면 request/limit 분리와 사용량(used) 조회가 불가능하므로, 반드시 `quota.hard` 로만 표현하도록 강제한다.

## 코드
- 신규 DTO `V1alpha1ProjectSpecQuotaHard` / `V1alpha1ProjectStatusQuotaHard` (`{cpu, memory}`), `*QuotaResource` (`{requests, limits}`)
- `V1alpha1ProjectSpecQuota` / `V1alpha1ProjectStatusQuota`: `hard` 필드 (pvcStorage/extendedResources는 top-level 유지)
- `ReconciliationService`: spec `hard.cpu/memory` -> ResourceQuota `hard` 매핑; extendedResources 의 reserved cpu/memory 키 무시; status 는 `buildQuotaResource` 헬퍼로 구성
- `ProjectUtils`: 중첩 getter; `clone` 보정 — **기존 버그 수정**(clone 시 extendedResources 누락으로 terminating 경로 `update(clone)`에서 유실될 수 있었음)
- `crd.yaml`: spec/status `quota.hard.cpu/memory` 스키마 + extendedResources CEL 규칙
- `examples/proj1.yaml`: `quota.hard` 예시

## 배포 시 주의
- cpu/memory에 quota를 걸면 그 네임스페이스의 모든 Pod가 request/limit을 명시해야 하며(미기재 시 admission 거절), 필요 시 **LimitRange(non-zero 기본값)** 를 함께 배포해야 한다. 이 컨트롤러는 LimitRange를 생성하지 않는다.
- extendedResources CEL 규칙은 k8s >= 1.25 에서만 강제된다(미만은 컨트롤러의 무시 로직이 백업).

## 테스트
- `./mvnw -o test` 전체 통과 (85 tests).

관련 PR: ten1010-io/aipub-installer#167