### PR TITLE
chore(deps): upgrade to Java 25 and align dependency versions with aipub-backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM eclipse-temurin:21-jre
+FROM eclipse-temurin:25-jre
 COPY target/*.jar /app.jar
 ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.1</version>
+        <version>4.0.6</version>
     </parent>
 
     <groupId>io.ten1010.aipub</groupId>
@@ -16,7 +16,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -50,12 +50,12 @@
         <dependency>
             <groupId>io.kubernetes</groupId>
             <artifactId>client-java</artifactId>
-            <version>25.0.0</version>
+            <version>26.0.0</version>
         </dependency>
         <dependency>
             <groupId>io.kubernetes</groupId>
             <artifactId>client-java-extended</artifactId>
-            <version>25.0.0</version>
+            <version>26.0.0</version>
         </dependency>
 
         <!-- Observability dependencies -->
@@ -120,6 +120,16 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- JDK 23+ 는 classpath 기반 implicit annotation processing 을 기본
+                         비활성화하므로(Lombok, spring-boot-configuration-processor 미동작)
+                         명시적으로 활성화한다. -->
+                    <proc>full</proc>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/WorkloadResourceResolver.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/WorkloadResourceResolver.java
@@ -5,7 +5,7 @@ import io.kubernetes.client.openapi.models.V1CronJob;
 import io.kubernetes.client.openapi.models.V1Job;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ImageBuild;
 import java.util.Optional;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public class WorkloadResourceResolver {
 


### PR DESCRIPTION
## 개요

Jira: AIP-2240

Java 25 업그레이드 및 aipub-backend와 의존성 버전 정렬.

## 변경 사항

- `java.version` 21 → 25, Dockerfile `eclipse-temurin:21-jre` → `25-jre`
- `spring-boot-starter-parent` 4.0.1 → 4.0.6 (aipub-backend `springBootVersion`과 동일)
- `io.kubernetes` client-java / client-java-extended 25.0.0 → 26.0.0 (aipub-backend `kubernetesClientVersion`과 동일)
- `WorkloadResourceResolver`: `javax.annotation.Nullable` → `org.jspecify.annotations.Nullable`
  (client-java 26부터 javax.annotation을 전이 의존성으로 제공하지 않음; jspecify가 코드베이스 관례)
- `maven-compiler-plugin`에 `proc=full` 추가: JDK 23+는 classpath 기반 암묵적 annotation processing을 기본 비활성화하여 Lombok과 spring-boot-configuration-processor가 조용히 스킵되는 문제 방지
- common-apiclient / common-jsonpatch / common-exception-handler는 0.1.0-SNAPSHOT 유지

## 검증

- 로컬에서 빌드 및 컨트롤러 동작 검증 완료