### PR TITLE
chore(deps): bump kubernetes client-java from 26.0.0 to 27.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,8 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     // Kubernetes client dependencies
-    implementation 'io.kubernetes:client-java:26.0.0'
-    implementation 'io.kubernetes:client-java-extended:26.0.0'
+    implementation 'io.kubernetes:client-java:27.0.0'
+    implementation 'io.kubernetes:client-java-extended:27.0.0'
 
     // Observability dependencies
     implementation 'org.springframework.boot:spring-boot-starter-actuator'


### PR DESCRIPTION
## 개요

Jira: AIP-2320

kubernetes client-java를 26.0.0 → 27.0.0으로 업데이트하여 aipub-backend의 `kubernetesClientVersion`(27.0.0)과 정렬.

## 변경 사항

- `io.kubernetes:client-java` / `client-java-extended` 26.0.0 → 27.0.0 (build.gradle)

## 검증

- `./gradlew clean build` (테스트 포함) 통과
- 로컬에서 컨트롤러 동작 검증 완료