### PR TITLE
Wire aipub-commons in as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "commons"]
+	path = commons
+	url = https://github.com/ten1010-io/aipub-commons.git

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 
     implementation 'com.google.code.gson:gson'
 
-    implementation project(':common-apiclient')
+    implementation project(':commons:common-apiclient')
     implementation project(':common-jsonpatch')
     implementation project(':common-exception-handler')
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 rootProject.name = 'project-controller'
 
-include 'common-apiclient'
+include 'commons:common-apiclient'
 include 'common-exception-handler'
 include 'common-jsonpatch'


### PR DESCRIPTION
Replaces the in-tree common-apiclient module with the shared aipub-commons/common-apiclient submodule. The old in-tree common-apiclient/ directory is left in place for now; removal is separate follow-up work.