### PR TITLE
feat: add namespace allowlist with runtime toleration injection (AIP-2389)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -219,6 +219,33 @@ kubectl logs -n project-controller deploy/project-controller -f --tail=200 \
 
 참고: 컨트롤러가 재기동하면 초기 동기화 과정에서 기존 소유 오브젝트 전체가 `Owned object created` 로 한 번씩 다시 출력됩니다(재기동 시점의 인벤토리이며, 오브젝트가 실제로 새로 생성된 것은 아닙니다).
 
+=== 네임스페이스 allowlist
+
+클러스터 애드온이나 인프라 오퍼레이터처럼 프로젝트 밖에서 동작하면서도 모든 노드(project managed 노드 포함)에 파드를 실행해야 하는 시스템 컴포넌트를 위해, 네임스페이스 단위 allowlist를 제공합니다.
+네임스페이스에 라벨을 붙이는 것만으로 동작하며, 컨트롤러 재시작 없이 즉시 반영됩니다.
+
+----
+# allowlist 지정
+kubectl label namespace <namespace> project.ten1010.io/allowlisted=true
+
+# allowlist 해제
+kubectl label namespace <namespace> project.ten1010.io/allowlisted-
+----
+
+allowlist 네임스페이스는 다음과 같이 처리됩니다.
+
+* *reconcile 제외* — 네임스페이스 라벨/ownerReference 정리, ResourceQuota, 이미지 레지스트리 Secret, RBAC 등 프로젝트 관리 동작을 수행하지 않습니다.
+* *eviction 제외* — strict isolation 노드 위에 있어도 해당 네임스페이스의 파드를 삭제하지 않습니다.
+* *toleration 주입* — 파드와 워크로드(Deployment 등)에 project managed taint를 허용하는 `Exists` toleration 쌍이 자동 주입되어, 어느 project managed 노드에나 스케줄링될 수 있습니다.
+* *webhook 제외* — 워크로드 라벨/사용자 소유권 주입 webhook이 해당 네임스페이스를 건드리지 않습니다.
+
+주의 사항:
+
+* 워크로드가 이미 배포된 네임스페이스를 allowlist하면 toleration 주입으로 인해 해당 워크로드들이 일괄 롤아웃됩니다. 가급적 컴포넌트 설치 전에 라벨을 먼저 붙이세요.
+* 파드의 toleration은 생성 후 변경할 수 없으므로, allowlist 이전에 생성된 파드는 재생성되어야 toleration을 받습니다.
+* allowlist를 해제하면 해당 네임스페이스는 즉시 일반 정책으로 돌아가며, strict isolation 노드 위의 파드는 eviction 대상이 됩니다.
+* 오브젝트 라벨 기반 제외(`app.aipub.reconcile-excluded-label-selectors`)는 "컨트롤러가 건드리지 않는" 용도이고, 네임스페이스 allowlist는 여기에 더해 "project managed 노드 접근을 허용하는" 용도입니다. 둘은 함께 사용할 수 있습니다.
+
 === 버그 리포팅 및 개선 사항, 질의
 
 버그를 발견하시거나 개선 사항, 질의가 있다면 link:https://github.com/ten1010-io/project-controller/issues[Github Issue]를 열어주세요.

--- a/kubernetes/controller/project-controller/templates/mutating-webhook-configuration.yaml
+++ b/kubernetes/controller/project-controller/templates/mutating-webhook-configuration.yaml
@@ -64,7 +64,7 @@ webhooks:
     rules:
       - apiGroups: [ "" ]
         apiVersions: [ "v1" ]
-        operations: [ "DELETE" ]
+        operations: [ "CREATE", "UPDATE", "DELETE" ]
         resources: [ "namespaces" ]
         scope: "*"
     sideEffects: None

--- a/src/main/java/io/ten1010/aipub/projectcontroller/configuration/AipubProperties.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/configuration/AipubProperties.java
@@ -28,8 +28,12 @@ public class AipubProperties {
   /**
    * project controller가 reconcile/mutating 대상에서 제외할 워크로드의 라벨 셀렉터 목록.
    * {@code "key=value"}(값 일치) 또는 {@code "key"}(존재만 확인) 형태를 지원하며, 하나라도
-   * 매칭되면 제외한다. virt-operator처럼 자체 워크로드를 직접 소유하는 인프라 오퍼레이터와의
-   * 소유권 충돌을 막기 위한 용도다.
+   * 매칭되면 제외한다. 자체 워크로드를 직접 소유하는 인프라 오퍼레이터와의 소유권 충돌을 막기
+   * 위한 용도다.
+   *
+   * <p>네임스페이스 전체를 제외하면서 그 파드를 project-managed 노드에도 올리려면, 이 셀렉터 대신
+   * 네임스페이스 라벨 기반 allowlist를 쓴다.
+   * {@link io.ten1010.aipub.projectcontroller.domain.k8s.NamespaceAllowlistResolver} 참고.
    */
   private List<String> reconcileExcludedLabelSelectors = new ArrayList<>();
 

--- a/src/main/java/io/ten1010/aipub/projectcontroller/configuration/DomainConfiguration.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/configuration/DomainConfiguration.java
@@ -1,10 +1,13 @@
 package io.ten1010.aipub.projectcontroller.configuration;
 
+import io.kubernetes.client.informer.SharedInformerFactory;
 import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.util.ClientBuilder;
 import io.kubernetes.client.util.KubeConfig;
 import io.ten1010.aipub.projectcontroller.domain.k8s.DockerConfigJsonResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.K8sApiProvider;
+import io.ten1010.aipub.projectcontroller.domain.k8s.NamespaceAllowlistResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ReconciliationService;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.WorkloadExclusionResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.SubjectResolver;
@@ -47,11 +50,21 @@ public class DomainConfiguration {
   }
 
   @Bean
+  public NamespaceAllowlistResolver namespaceAllowlistResolver(
+      SharedInformerFactory sharedInformerFactory) {
+    return new NamespaceAllowlistResolver(sharedInformerFactory
+        .getExistingSharedIndexInformer(V1Namespace.class)
+        .getIndexer());
+  }
+
+  @Bean
   public ReconciliationService reconciliationService(SubjectResolver subjectResolver,
-      DockerConfigJsonResolver dockerConfigJsonResolver, AipubProperties aipubProperties) {
+      DockerConfigJsonResolver dockerConfigJsonResolver, AipubProperties aipubProperties,
+      NamespaceAllowlistResolver namespaceAllowlistResolver) {
     return new ReconciliationService(subjectResolver, dockerConfigJsonResolver,
         aipubProperties.getReservedNamespace(),
-        new WorkloadExclusionResolver(aipubProperties.getReconcileExcludedLabelSelectors()));
+        new WorkloadExclusionResolver(aipubProperties.getReconcileExcludedLabelSelectors()),
+        namespaceAllowlistResolver);
   }
 
 }

--- a/src/main/java/io/ten1010/aipub/projectcontroller/configuration/MutatingConfiguration.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/configuration/MutatingConfiguration.java
@@ -7,6 +7,7 @@ import io.ten1010.aipub.projectcontroller.controller.workload.WorkloadController
 import io.ten1010.aipub.projectcontroller.domain.aipubbackend.ArtifactService;
 import io.ten1010.aipub.projectcontroller.domain.aipubbackend.ImageHubService;
 import io.ten1010.aipub.projectcontroller.domain.aipubbackend.RepositoryService;
+import io.ten1010.aipub.projectcontroller.domain.k8s.NamespaceAllowlistResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ReconciliationService;
 import io.ten1010.aipub.projectcontroller.domain.k8s.SubjectResolver;
 import io.ten1010.aipub.projectcontroller.mutating.AdmissionReviewController;
@@ -89,8 +90,10 @@ public class MutatingConfiguration {
 
   @Bean
   public ProjectReviewHandler projectReviewHandler(AipubProperties aipubProperties,
-      SubjectResolver subjectResolver, SharedInformerFactory sharedInformerFactory) {
-    return new ProjectReviewHandler(aipubProperties, subjectResolver, sharedInformerFactory);
+      SubjectResolver subjectResolver, SharedInformerFactory sharedInformerFactory,
+      NamespaceAllowlistResolver namespaceAllowlistResolver) {
+    return new ProjectReviewHandler(aipubProperties, subjectResolver, sharedInformerFactory,
+        namespaceAllowlistResolver);
   }
 
   @Bean
@@ -115,15 +118,16 @@ public class MutatingConfiguration {
   @Qualifier("aipubReviewHandlers")
   public List<ReviewHandler> aipubReviewHandlers(
       UserInfoAnalyzer userInfoAnalyzer, AipubProperties aipubProperties,
-      ApiResourceDiscovery apiResourceDiscovery, ApiClient apiClient) {
+      ApiResourceDiscovery apiResourceDiscovery, ApiClient apiClient,
+      NamespaceAllowlistResolver namespaceAllowlistResolver) {
     Set<String> exceptGvkSet = aipubProperties.getAddOwnerExceptGvkList().stream()
         .map(String::trim)
         .filter(s -> !s.isEmpty())
         .collect(Collectors.toSet());
     UserOwnerReviewHandler userOwnerReviewHandler = new UserOwnerReviewHandler(
-        userInfoAnalyzer, exceptGvkSet);
+        userInfoAnalyzer, exceptGvkSet, namespaceAllowlistResolver);
     UserLabelReviewHandler userLabelReviewHandler = new UserLabelReviewHandler(
-        userInfoAnalyzer, apiResourceDiscovery, apiClient);
+        userInfoAnalyzer, apiResourceDiscovery, apiClient, namespaceAllowlistResolver);
     return List.of(userOwnerReviewHandler, userLabelReviewHandler);
   }
 
@@ -135,8 +139,10 @@ public class MutatingConfiguration {
 
   @Bean
   public WorkloadLabelReviewHandler workloadLabelReviewHandler(
-      ApiResourceDiscovery apiResourceDiscovery, ApiClient apiClient) {
-    return new WorkloadLabelReviewHandler(apiResourceDiscovery, apiClient);
+      ApiResourceDiscovery apiResourceDiscovery, ApiClient apiClient,
+      NamespaceAllowlistResolver namespaceAllowlistResolver) {
+    return new WorkloadLabelReviewHandler(apiResourceDiscovery, apiClient,
+        namespaceAllowlistResolver);
   }
 
   @Bean

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/cluster/NamespaceReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/cluster/NamespaceReconciler.java
@@ -13,6 +13,7 @@ import io.ten1010.aipub.projectcontroller.controller.AbstractReconciler;
 import io.ten1010.aipub.projectcontroller.domain.k8s.K8sApiProvider;
 import io.ten1010.aipub.projectcontroller.domain.k8s.KeyResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.NamespaceNameResolver;
+import io.ten1010.aipub.projectcontroller.domain.k8s.NamespaceAllowlistResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ReconciliationService;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Project;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.K8sObjectUtils;
@@ -20,7 +21,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class NamespaceReconciler extends AbstractReconciler {
 
   private final KeyResolver keyResolver;
@@ -57,6 +60,16 @@ public class NamespaceReconciler extends AbstractReconciler {
         this.namespaceIndexer.getByKey(namespaceKey));
     Optional<V1alpha1Project> projectOpt = Optional.ofNullable(
         this.projectIndexer.getByKey(projKey));
+
+    // allowlist 네임스페이스는 라벨/ownerReference 정리 대상이 아니다. 동명의 project가 함께 있으면
+    // allowlist를 우선하고 경고 로그만 남긴다.
+    if (namespaceOpt.isPresent() && NamespaceAllowlistResolver.isAllowlisted(namespaceOpt.get())) {
+      if (projectOpt.isPresent()) {
+        log.warn("Namespace {} is allowlisted but a project with the same name exists;"
+            + " skipping reconciliation (allowlist takes precedence)", nsName);
+      }
+      return new Result(false);
+    }
 
     Map<String, String> reconciledLabels = this.reconciliationService.reconcileNamespaceLabels(
         namespaceOpt.orElse(null), projectOpt.orElse(null));

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/namespaced/ImageRegistrySecretReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/namespaced/ImageRegistrySecretReconciler.java
@@ -63,6 +63,9 @@ public class ImageRegistrySecretReconciler extends AbstractReconciler {
 
   @Override
   protected Result reconcileInternal(Request request) throws ApiException {
+    if (this.reconciliationService.isNamespaceAllowlisted(request.getNamespace())) {
+      return new Result(false);
+    }
     Optional<String> projNameOpt = this.secretNameResolver.resolveProjectName(request.getName());
     if (projNameOpt.isEmpty()) {
       return new Result(false);

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/namespaced/ResourceQuotaReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/namespaced/ResourceQuotaReconciler.java
@@ -53,6 +53,9 @@ public class ResourceQuotaReconciler extends AbstractReconciler {
 
   @Override
   protected Result reconcileInternal(Request request) throws ApiException {
+    if (this.reconciliationService.isNamespaceAllowlisted(request.getNamespace())) {
+      return new Result(false);
+    }
     Optional<String> projNameOpt = this.quotaNameResolver.resolveProjectName(request.getName());
     if (projNameOpt.isEmpty()) {
       return new Result(false);

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/aipub/AipubUserRoleBindingReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/aipub/AipubUserRoleBindingReconciler.java
@@ -64,6 +64,9 @@ public class AipubUserRoleBindingReconciler extends AbstractReconciler {
 
   @Override
   protected Result reconcileInternal(Request request) throws ApiException {
+    if (this.reconciliationService.isNamespaceAllowlisted(request.getNamespace())) {
+      return new Result(false);
+    }
     String roleKey = new RequestHelper(this.keyResolver).resolveKey(request);
     Optional<V1RoleBinding> roleBindingOpt = Optional.ofNullable(
         this.RoleBindingIndexer.getByKey(roleKey));

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/aipub/AipubUserRoleReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/aipub/AipubUserRoleReconciler.java
@@ -115,6 +115,9 @@ public class AipubUserRoleReconciler extends AbstractReconciler {
 
   @Override
   protected Result reconcileInternal(Request request) throws ApiException {
+    if (this.reconciliationService.isNamespaceAllowlisted(request.getNamespace())) {
+      return new Result(false);
+    }
     String roleKey = new RequestHelper(this.keyResolver).resolveKey(request);
     Optional<V1Role> roleOpt = Optional.ofNullable(this.roleIndexer.getByKey(roleKey));
     String projKey = this.keyResolver.resolveKey(

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/member/ClusterRoleBindingReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/member/ClusterRoleBindingReconciler.java
@@ -14,6 +14,7 @@ import io.kubernetes.client.openapi.models.V1RoleRef;
 import io.ten1010.aipub.projectcontroller.controller.AbstractReconciler;
 import io.ten1010.aipub.projectcontroller.controller.RequestHelper;
 import io.ten1010.aipub.projectcontroller.domain.k8s.K8sApiProvider;
+import io.ten1010.aipub.projectcontroller.domain.k8s.NamespaceNameResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.KeyResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ProjectNameAndRole;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ProjectRoleEnum;
@@ -60,6 +61,12 @@ public class ClusterRoleBindingReconciler extends AbstractReconciler {
     }
     String projName = projNameOpt.get().projectName();
     ProjectRoleEnum projRoleEnum = projNameOpt.get().projectRoleEnum();
+
+    // allowlist 네임스페이스와 이름이 같은 project는 관리하지 않는다(allowlist 우선).
+    if (this.reconciliationService.isNamespaceAllowlisted(
+        new NamespaceNameResolver().resolveNamespaceName(projName))) {
+      return new Result(false);
+    }
 
     String roleBindingKey = new RequestHelper(this.keyResolver).resolveKey(request);
     Optional<V1ClusterRoleBinding> roleBindingOpt = Optional.ofNullable(

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/member/ClusterRoleReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/member/ClusterRoleReconciler.java
@@ -17,6 +17,7 @@ import io.ten1010.aipub.projectcontroller.controller.BoundObjectResolver;
 import io.ten1010.aipub.projectcontroller.controller.RequestHelper;
 import io.ten1010.aipub.projectcontroller.domain.k8s.K8sApiProvider;
 import io.ten1010.aipub.projectcontroller.domain.k8s.KeyResolver;
+import io.ten1010.aipub.projectcontroller.domain.k8s.NamespaceNameResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ProjectNameAndRole;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ProjectRoleEnum;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ReconciliationService;
@@ -70,6 +71,12 @@ public class ClusterRoleReconciler extends AbstractReconciler {
     }
     String projName = projNameOpt.get().projectName();
     ProjectRoleEnum projRoleEnum = projNameOpt.get().projectRoleEnum();
+
+    // allowlist 네임스페이스와 이름이 같은 project는 관리하지 않는다(allowlist 우선).
+    if (this.reconciliationService.isNamespaceAllowlisted(
+        new NamespaceNameResolver().resolveNamespaceName(projName))) {
+      return new Result(false);
+    }
 
     String roleKey = new RequestHelper(this.keyResolver).resolveKey(request);
     Optional<V1ClusterRole> roleOpt = Optional.ofNullable(

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/member/RoleBindingReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/member/RoleBindingReconciler.java
@@ -56,6 +56,9 @@ public class RoleBindingReconciler extends AbstractReconciler {
 
   @Override
   protected Result reconcileInternal(Request request) throws ApiException {
+    if (this.reconciliationService.isNamespaceAllowlisted(request.getNamespace())) {
+      return new Result(false);
+    }
     Optional<ProjectNameAndRole> projNameOpt = this.roleNameResolver.resolveProjectName(
         request.getName());
     if (projNameOpt.isEmpty()) {

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/member/RoleReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/member/RoleReconciler.java
@@ -55,6 +55,9 @@ public class RoleReconciler extends AbstractReconciler {
 
   @Override
   protected Result reconcileInternal(Request request) throws ApiException {
+    if (this.reconciliationService.isNamespaceAllowlisted(request.getNamespace())) {
+      return new Result(false);
+    }
     Optional<ProjectNameAndRole> projNameOpt = this.roleNameResolver.resolveProjectName(
         request.getName());
     if (projNameOpt.isEmpty()) {

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/watch/OnUpdateFilterFactory.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/watch/OnUpdateFilterFactory.java
@@ -7,6 +7,7 @@ import io.kubernetes.client.openapi.models.V1CronJob;
 import io.kubernetes.client.openapi.models.V1DaemonSet;
 import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1Job;
+import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1Node;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1ReplicaSet;
@@ -16,6 +17,7 @@ import io.kubernetes.client.openapi.models.V1RoleBinding;
 import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1StatefulSet;
 import io.ten1010.aipub.projectcontroller.domain.k8s.AipubUserRoleNameResolver;
+import io.ten1010.aipub.projectcontroller.domain.k8s.LabelConstants;
 import io.ten1010.aipub.projectcontroller.domain.k8s.RoleNameResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1beta1Workspace;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubUser;
@@ -52,6 +54,12 @@ public class OnUpdateFilterFactory {
     return (oldObj, newObj) ->
         !K8sObjectUtils.getOwnerReferences(oldObj).equals(K8sObjectUtils.getOwnerReferences(newObj))
             || !K8sObjectUtils.getLabels(oldObj).equals(K8sObjectUtils.getLabels(newObj));
+  }
+
+  public BiPredicate<V1Namespace, V1Namespace> namespaceAllowlistLabelFilter() {
+    return (oldObj, newObj) -> !Objects.equals(
+        K8sObjectUtils.getLabels(oldObj).get(LabelConstants.ALLOWLISTED_KEY),
+        K8sObjectUtils.getLabels(newObj).get(LabelConstants.ALLOWLISTED_KEY));
   }
 
   public BiPredicate<V1alpha1Project, V1alpha1Project> projectSpecFieldFilter() {

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/watch/RequestBuilderFactory.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/watch/RequestBuilderFactory.java
@@ -177,6 +177,20 @@ public class RequestBuilderFactory {
     };
   }
 
+  public Function<V1Namespace, List<Request>> namespaceToNamespacedObjects(
+      Class<? extends KubernetesObject> objectClass) {
+    Indexer<? extends KubernetesObject> objectIndexer = this.sharedInformerFactory.getExistingSharedIndexInformer(
+        objectClass).getIndexer();
+    return namespace -> {
+      List<? extends KubernetesObject> objects = objectIndexer.byIndex(
+          IndexerConstants.NAMESPACE_TO_OBJECTS_INDEXER_NAME,
+          K8sObjectUtils.getName(namespace));
+      return objects.stream()
+          .map(e -> new Request(K8sObjectUtils.getNamespace(e), K8sObjectUtils.getName(e)))
+          .toList();
+    };
+  }
+
   public Function<V1alpha1AipubUser, List<Request>> aipubUserToClusterRoles() {
     return user -> {
       String userName = K8sObjectUtils.getName(user);

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/workload/PodControllerFactory.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/workload/PodControllerFactory.java
@@ -6,6 +6,7 @@ import io.kubernetes.client.extended.controller.builder.ControllerBuilder;
 import io.kubernetes.client.extended.controller.reconciler.Request;
 import io.kubernetes.client.extended.workqueue.WorkQueue;
 import io.kubernetes.client.informer.SharedInformerFactory;
+import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1Node;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.ten1010.aipub.projectcontroller.controller.ControllerFactory;
@@ -48,11 +49,14 @@ public class PodControllerFactory implements ControllerFactory {
             V1alpha1NodeGroup.class)::hasSynced)
         .withReadyFunc(
             this.sharedInformerFactory.getExistingSharedIndexInformer(V1Node.class)::hasSynced)
+        .withReadyFunc(
+            this.sharedInformerFactory.getExistingSharedIndexInformer(V1Namespace.class)::hasSynced)
         .watch(this::createPodWatch)
         .watch(this::createProjectWatch)
         .watch(this::createNodeGroupWatch)
         .watch(this::createNodeWatch)
         .watch(this::createBoundPodNodeWatch)
+        .watch(this::createNamespaceWatch)
         .withReconciler(new PodReconciler(
             this.sharedInformerFactory,
             this.k8sApiProvider,
@@ -93,6 +97,16 @@ public class PodControllerFactory implements ControllerFactory {
     DefaultControllerWatch<V1Node> watch = new DefaultControllerWatch<>(workQueue, V1Node.class);
     watch.setOnUpdateFilter(this.onUpdateFilterFactory.nodeFilter());
     watch.setRequestBuilder(this.requestBuilderFactory.nodeToBoundPods());
+    return watch;
+  }
+
+  // allowlist 라벨이 제거되면 해당 네임스페이스의 파드를 다시 평가해, 재시작 없이 런타임에
+  // eviction 정책이 반영되게 한다.
+  private ControllerWatch<V1Namespace> createNamespaceWatch(WorkQueue<Request> workQueue) {
+    DefaultControllerWatch<V1Namespace> watch = new DefaultControllerWatch<>(workQueue,
+        V1Namespace.class);
+    watch.setOnUpdateFilter(this.onUpdateFilterFactory.namespaceAllowlistLabelFilter());
+    watch.setRequestBuilder(this.requestBuilderFactory.namespaceToNamespacedObjects(V1Pod.class));
     return watch;
   }
 

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/workload/PodReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/workload/PodReconciler.java
@@ -6,6 +6,7 @@ import io.kubernetes.client.informer.SharedInformerFactory;
 import io.kubernetes.client.informer.cache.Indexer;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1Node;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.ten1010.aipub.projectcontroller.controller.AbstractReconciler;
@@ -13,6 +14,7 @@ import io.ten1010.aipub.projectcontroller.controller.RequestHelper;
 import io.ten1010.aipub.projectcontroller.domain.k8s.K8sApiProvider;
 import io.ten1010.aipub.projectcontroller.domain.k8s.KeyResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.NamespaceNameResolver;
+import io.ten1010.aipub.projectcontroller.domain.k8s.NamespaceAllowlistResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Project;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.K8sObjectUtils;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.NodeUtils;
@@ -31,6 +33,7 @@ public class PodReconciler extends AbstractReconciler {
   private final Indexer<V1alpha1Project> projectIndexer;
   private final CoreV1Api coreV1Api;
   private final PodNodesResolver podNodesResolver;
+  private final NamespaceAllowlistResolver namespaceAllowlistResolver;
 
   public PodReconciler(
       SharedInformerFactory sharedInformerFactory,
@@ -49,6 +52,9 @@ public class PodReconciler extends AbstractReconciler {
         .getIndexer();
     this.coreV1Api = new CoreV1Api(k8sApiProvider.getApiClient());
     this.podNodesResolver = podNodesResolver;
+    this.namespaceAllowlistResolver = new NamespaceAllowlistResolver(sharedInformerFactory
+        .getExistingSharedIndexInformer(V1Namespace.class)
+        .getIndexer());
   }
 
   @Override
@@ -59,6 +65,13 @@ public class PodReconciler extends AbstractReconciler {
       return new Result(false);
     }
     V1Pod pod = podOpt.get();
+
+    // allowlist 네임스페이스의 파드는 project-managed 노드에 있어도 절대 삭제하지 않는다. owner
+    // kind가 등록된 워크로드 타입이 아닐 때 파드를 삭제하는 UnsupportedControllerException 분기보다
+    // 먼저 검사해야 한다.
+    if (this.namespaceAllowlistResolver.isAllowlisted(K8sObjectUtils.getNamespace(pod))) {
+      return new Result(false);
+    }
 
     Optional<String> nodeNameOpt = WorkloadUtils.getNodeName(pod);
     if (nodeNameOpt.isEmpty()) {

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/workload/WorkloadControllerFactory.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/workload/WorkloadControllerFactory.java
@@ -2,12 +2,19 @@ package io.ten1010.aipub.projectcontroller.controller.workload;
 
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.extended.controller.Controller;
+import io.kubernetes.client.extended.controller.ControllerWatch;
 import io.kubernetes.client.extended.controller.builder.ControllerBuilder;
 import io.kubernetes.client.extended.controller.builder.DefaultControllerBuilder;
 import io.kubernetes.client.extended.controller.reconciler.Reconciler;
+import io.kubernetes.client.extended.controller.reconciler.Request;
+import io.kubernetes.client.extended.workqueue.WorkQueue;
 import io.kubernetes.client.informer.SharedInformerFactory;
+import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1PodTemplateSpec;
 import io.ten1010.aipub.projectcontroller.controller.ControllerFactory;
+import io.ten1010.aipub.projectcontroller.controller.watch.DefaultControllerWatch;
+import io.ten1010.aipub.projectcontroller.controller.watch.OnUpdateFilterFactory;
+import io.ten1010.aipub.projectcontroller.controller.watch.RequestBuilderFactory;
 import io.ten1010.aipub.projectcontroller.domain.k8s.K8sObjectType;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ReconciliationService;
 import java.util.function.Function;
@@ -32,8 +39,8 @@ public abstract class WorkloadControllerFactory<T extends KubernetesObject> impl
     configureControllerName();
     configureReadyFunc();
     configureWatch();
+    configureNamespaceAllowlistWatch();
     this.builder.withWorkerCount(1);
-    this.builder.withReconciler(createReconciler());
     this.builder.withReconciler(createReconciler());
 
     return this.builder.build();
@@ -52,6 +59,25 @@ public abstract class WorkloadControllerFactory<T extends KubernetesObject> impl
   protected abstract Function<KubernetesObject, V1PodTemplateSpec> getPodTemplateSpecResolver();
 
   protected abstract ControllerObjectReconciler getObjectReconciler();
+
+  /**
+   * 네임스페이스의 allowlist 라벨이 바뀌면 해당 네임스페이스의 워크로드를 다시 reconcile해, 재시작
+   * 없이 런타임에 toleration 주입/제거가 반영되게 한다.
+   */
+  private void configureNamespaceAllowlistWatch() {
+    this.builder.withReadyFunc(this.sharedInformerFactory
+        .getExistingSharedIndexInformer(V1Namespace.class)::hasSynced);
+    this.builder.watch(this::createNamespaceWatch);
+  }
+
+  private ControllerWatch<V1Namespace> createNamespaceWatch(WorkQueue<Request> workQueue) {
+    DefaultControllerWatch<V1Namespace> watch = new DefaultControllerWatch<>(workQueue,
+        V1Namespace.class);
+    watch.setOnUpdateFilter(new OnUpdateFilterFactory().namespaceAllowlistLabelFilter());
+    watch.setRequestBuilder(new RequestBuilderFactory(this.sharedInformerFactory)
+        .namespaceToNamespacedObjects(getObjectType().objClass()));
+    return watch;
+  }
 
   private Reconciler createReconciler() {
     return new WorkloadControllerReconciler(

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/workload/WorkloadControllerReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/workload/WorkloadControllerReconciler.java
@@ -72,10 +72,21 @@ public class WorkloadControllerReconciler extends AbstractReconciler {
     if (K8sObjectUtils.findControllerOwnerReference(controller).isPresent()) {
       return new Result(false);
     }
+
+    V1PodTemplateSpec templateSpec = this.podTemplateSpecResolver.apply(controller);
+
+    // allowlist 네임스페이스의 워크로드에는 project 소속과 무관하게 Exists toleration 쌍을 주입한다
+    // (project=null 경로는 affinity를 걷어내고 imagePullSecrets는 그대로 둔다).
+    if (this.reconciliationService.isNamespaceAllowlisted(request.getNamespace())) {
+      return this.controllerObjectReconciler.reconcileController(controller,
+          this.reconciliationService.reconcileTolerationsForAllowlistedNamespace(templateSpec),
+          this.reconciliationService.reconcileNodeSelectorTerms(templateSpec, null),
+          this.reconciliationService.reconcileImageRegistrySecrets(templateSpec, null));
+    }
+
     String projKey = this.keyResolver.resolveKey(request.getNamespace());
     V1alpha1Project project = this.projectIndexer.getByKey(projKey);
 
-    V1PodTemplateSpec templateSpec = this.podTemplateSpecResolver.apply(controller);
     List<V1Node> nodeObjects = this.workloadControllerNodesResolver.getNodes(controller);
     List<V1Toleration> reconciledTolerations = this.reconciliationService.reconcileTolerations(
         templateSpec, nodeObjects);

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/LabelConstants.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/LabelConstants.java
@@ -12,6 +12,8 @@ public final class LabelConstants {
       ProjectApiConstants.AIPUB_GROUP + "/" + "userid";
   public static final String PROJECT_LABEL_KEY =
       ProjectApiConstants.PROJECT_GROUP + "/" + "project";
+  public static final String ALLOWLISTED_KEY =
+      ProjectApiConstants.PROJECT_GROUP + "/" + "allowlisted";
   public static final String WORKLOAD_NAME_KEY =
       ProjectApiConstants.AIPUB_GROUP + "/" + "workload-name";
   public static final String WORKLOAD_KIND_KEY =

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/NamespaceAllowlistResolver.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/NamespaceAllowlistResolver.java
@@ -1,0 +1,51 @@
+package io.ten1010.aipub.projectcontroller.domain.k8s;
+
+import io.kubernetes.client.informer.cache.Indexer;
+import io.kubernetes.client.openapi.models.V1Namespace;
+import io.ten1010.aipub.projectcontroller.domain.k8s.util.K8sObjectUtils;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * 네임스페이스가 project controller 관리에서 allowlist되었는지 판정한다.
+ *
+ * <p>{@code project.ten1010.io/allowlisted: "true"} 라벨이 붙은 네임스페이스를 allowlist로 본다.
+ * project 네임스페이스 밖에서 동작하면서도 project-managed 노드에 파드를 올려야 하는 시스템
+ * 컴포넌트를 위한 것이다. allowlist 네임스페이스는 reconcile과 eviction에서 빠지고, 그 파드에는
+ * 어느 노드의 project-managed taint든 견디는 {@code Exists} toleration이 붙는다.
+ *
+ * <p>판정은 네임스페이스 informer 캐시를 직접 읽으므로 라벨 변경이 재시작 없이 런타임에 반영된다.
+ * 캐시에 없는 네임스페이스는 allowlist가 아닌 것으로 본다(fail-closed).
+ */
+public class NamespaceAllowlistResolver {
+
+  private final KeyResolver keyResolver;
+  private final Indexer<V1Namespace> namespaceIndexer;
+
+  public NamespaceAllowlistResolver(Indexer<V1Namespace> namespaceIndexer) {
+    this.keyResolver = new KeyResolver();
+    this.namespaceIndexer = namespaceIndexer;
+  }
+
+  public static boolean isAllowlisted(V1Namespace namespace) {
+    Map<String, String> labels = K8sObjectUtils.getLabels(namespace);
+    String value = labels.get(LabelConstants.ALLOWLISTED_KEY);
+    if (value == null) {
+      return false;
+    }
+    return value.equalsIgnoreCase(NamespaceAllowlistValueEnum.TRUE.getStr());
+  }
+
+  public boolean isAllowlisted(@Nullable String namespaceName) {
+    if (namespaceName == null || namespaceName.isBlank()) {
+      return false;
+    }
+    V1Namespace namespace = this.namespaceIndexer.getByKey(
+        this.keyResolver.resolveKey(namespaceName));
+    if (namespace == null) {
+      return false;
+    }
+    return isAllowlisted(namespace);
+  }
+
+}

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/NamespaceAllowlistValueEnum.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/NamespaceAllowlistValueEnum.java
@@ -1,0 +1,31 @@
+package io.ten1010.aipub.projectcontroller.domain.k8s;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum NamespaceAllowlistValueEnum {
+
+  TRUE("true"), FALSE("false");
+
+  private static final Map<String, NamespaceAllowlistValueEnum> STR_TO_ENUM;
+
+  static {
+    STR_TO_ENUM = new HashMap<>();
+    for (NamespaceAllowlistValueEnum e : NamespaceAllowlistValueEnum.values()) {
+      STR_TO_ENUM.put(e.getStr(), e);
+    }
+  }
+
+  private final String str;
+
+  public static Optional<NamespaceAllowlistValueEnum> getEnum(String str) {
+    NamespaceAllowlistValueEnum parsed = STR_TO_ENUM.get(str.toLowerCase());
+    return Optional.ofNullable(parsed);
+  }
+
+}

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationService.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationService.java
@@ -71,10 +71,12 @@ public class ReconciliationService {
   private final ObjectMapper mapper;
   private final List<String> reservedNamespaces;
   private final WorkloadExclusionResolver workloadExclusionResolver;
+  private final NamespaceAllowlistResolver namespaceAllowlistResolver;
 
   public ReconciliationService(SubjectResolver subjectResolver,
       DockerConfigJsonResolver dockerConfigJsonResolver, List<String> reservedNamespaces,
-      WorkloadExclusionResolver workloadExclusionResolver) {
+      WorkloadExclusionResolver workloadExclusionResolver,
+      NamespaceAllowlistResolver namespaceAllowlistResolver) {
     this.subjectResolver = subjectResolver;
     this.dockerConfigJsonResolver = dockerConfigJsonResolver;
     this.roleNameResolver = new RoleNameResolver();
@@ -84,15 +86,25 @@ public class ReconciliationService {
     this.mapper = new ObjectMapperFactory().createObjectMapper();
     this.reservedNamespaces = reservedNamespaces;
     this.workloadExclusionResolver = workloadExclusionResolver;
+    this.namespaceAllowlistResolver = namespaceAllowlistResolver;
   }
 
   /**
-   * 주어진 워크로드가 reconcile/mutating 대상에서 제외되어야 하는지 판정한다. virt-operator처럼
-   * 자체 워크로드를 직접 소유하는 인프라 오퍼레이터의 객체를 project controller가 건드리지 않도록
+   * 주어진 워크로드가 reconcile/mutating 대상에서 제외되어야 하는지 판정한다. 자체 워크로드를 직접
+   * 소유하는 인프라 오퍼레이터의 객체를 project controller가 건드리지 않도록
    * {@code app.aipub.reconcile-excluded-label-selectors} 설정으로 지정한다.
    */
   public boolean isExcludedFromReconciliation(KubernetesObject object) {
     return this.workloadExclusionResolver.isExcluded(object);
+  }
+
+  /**
+   * 주어진 네임스페이스가 allowlist인지 반환한다. allowlist 네임스페이스는 reconcile과 eviction에서
+   * 빠지고, 그 워크로드에는 project-managed 노드에 스케줄될 수 있도록 {@code Exists} toleration이
+   * 붙는다. {@link NamespaceAllowlistResolver} 참고.
+   */
+  public boolean isNamespaceAllowlisted(@Nullable String namespaceName) {
+    return this.namespaceAllowlistResolver.isAllowlisted(namespaceName);
   }
 
   private static List<V1OwnerReference> removeOwnerReferencesThatReferToProjectKind(
@@ -272,6 +284,38 @@ public class ReconciliationService {
         .withOperator("Equal")
         .build();
     return List.of(noSchedule, noExecute);
+  }
+
+  /**
+   * allowlist 네임스페이스의 워크로드에 주입할 toleration 쌍을 만든다. project-managed taint의 값은
+   * 노드 이름이므로, 모든 project-managed 노드에서 견딜 수 있도록 {@code Exists} operator를 쓴다.
+   */
+  private static List<V1Toleration> buildAllowlistedNamespaceTolerations() {
+    V1Toleration noSchedule = new V1TolerationBuilder()
+        .withKey(TaintConstants.PROJECT_MANAGED_KEY)
+        .withEffect(TaintConstants.NO_SCHEDULE_EFFECT)
+        .withOperator("Exists")
+        .build();
+    V1Toleration noExecute = new V1TolerationBuilder()
+        .withKey(TaintConstants.PROJECT_MANAGED_KEY)
+        .withEffect(TaintConstants.NO_EXECUTE_EFFECT)
+        .withOperator("Exists")
+        .build();
+    return List.of(noSchedule, noExecute);
+  }
+
+  /**
+   * allowlist 네임스페이스의 toleration을 reconcile한다. 일반 경로({@code reconcileTolerations})와
+   * 달리 {@code replaceAllKey*} 재작성은 적용하지 않는다. 워크로드가 스스로 붙인 catch-all
+   * toleration을 보존해야 하기 때문이다. project-managed toleration만 제거하고 {@code Exists} 쌍을
+   * 덧붙이므로 멱등하다.
+   */
+  private static List<V1Toleration> reconcileTolerationsForAllowlistedNamespace(
+      List<V1Toleration> existing) {
+    List<V1Toleration> reconciled = new ArrayList<>(removeProjectManagedTolerations(existing));
+    reconciled.addAll(buildAllowlistedNamespaceTolerations());
+
+    return reconciled;
   }
 
   private static V1NodeSelectorTerm buildProjectManagedNodeSelectorTerm() {
@@ -1074,6 +1118,17 @@ public class ReconciliationService {
       List<V1Node> allowedProjectNodes) {
     List<V1Toleration> existingTolerations = WorkloadUtils.getTolerations(existing);
     return reconcileTolerations(existingTolerations, allowedProjectNodes);
+  }
+
+  public List<V1Toleration> reconcileTolerationsForAllowlistedNamespace(V1Pod existing) {
+    List<V1Toleration> existingTolerations = WorkloadUtils.getTolerations(existing);
+    return reconcileTolerationsForAllowlistedNamespace(existingTolerations);
+  }
+
+  public List<V1Toleration> reconcileTolerationsForAllowlistedNamespace(
+      V1PodTemplateSpec existing) {
+    List<V1Toleration> existingTolerations = WorkloadUtils.getTolerations(existing);
+    return reconcileTolerationsForAllowlistedNamespace(existingTolerations);
   }
 
   public List<V1NodeSelectorTerm> reconcileNodeSelectorTerms(V1Pod existing,

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/util/WorkloadExclusionResolver.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/util/WorkloadExclusionResolver.java
@@ -14,10 +14,10 @@ import java.util.Map;
  *   <li>{@code "key"} : 라벨 {@code key} 가 존재하면(값 무관) 매칭</li>
  * </ul>
  *
- * <p>여러 셀렉터 중 하나라도 매칭되면 제외 대상으로 본다(OR). KubeVirt(virt-operator)처럼
- * 자체 컴포넌트를 직접 소유하는 인프라 오퍼레이터의 워크로드를 project controller가 건드리지
- * 않도록 하기 위한 용도다. 제외 대상 목록은 {@code app.aipub.reconcile-excluded-label-selectors}
- * 설정으로 주입되며, 책임과 관리 주체를 project controller로 일원화한다.
+ * <p>여러 셀렉터 중 하나라도 매칭되면 제외 대상으로 본다(OR). 자체 컴포넌트를 직접 소유하는
+ * 인프라 오퍼레이터의 워크로드를 project controller가 건드리지 않도록 하기 위한 용도다. 제외 대상
+ * 목록은 {@code app.aipub.reconcile-excluded-label-selectors} 설정으로 주입되며, 책임과 관리 주체를
+ * project controller로 일원화한다.
  */
 public class WorkloadExclusionResolver {
 

--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/DeploymentReviewHandler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/DeploymentReviewHandler.java
@@ -52,6 +52,20 @@ public class DeploymentReviewHandler extends AbstractReviewHandler<V1Deployment>
       return;
     }
 
+    if (this.reconciliationService.isNamespaceAllowlisted(review.getRequest().getNamespace())) {
+      List<V1Toleration> reconciledTolerations =
+          this.reconciliationService.reconcileTolerationsForAllowlistedNamespace(
+              WorkloadUtils.getPodTemplateSpec(deployment));
+      JsonPatchBuilder allowlistPatchBuilder = new JsonPatchBuilder();
+      allowlistPatchBuilder.addToOperations(new JsonPatchOperationBuilder()
+          .replace()
+          .setPath("/spec/template/spec/tolerations")
+          .setValue(createJsonNode(reconciledTolerations))
+          .build());
+      V1AdmissionReviewUtils.allow(review, allowlistPatchBuilder.build());
+      return;
+    }
+
     V1alpha1Project project = this.projectIndexer.getByKey(K8sObjectUtils.getNamespace(deployment));
 
     V1PodTemplateSpec podTemplateSpec = WorkloadUtils.getPodTemplateSpec(deployment);

--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/NamespaceReviewHandler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/NamespaceReviewHandler.java
@@ -7,22 +7,29 @@ import io.ten1010.aipub.projectcontroller.configuration.AipubProperties;
 import io.ten1010.aipub.projectcontroller.domain.k8s.K8sGroupConstants;
 import io.ten1010.aipub.projectcontroller.domain.k8s.K8sObjectTypeConstants;
 import io.ten1010.aipub.projectcontroller.domain.k8s.KeyResolver;
+import io.ten1010.aipub.projectcontroller.domain.k8s.NamespaceAllowlistResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.SubjectResolver;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Project;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.K8sObjectUtils;
 import io.ten1010.aipub.projectcontroller.mutating.V1AdmissionReviewUtils;
 import io.ten1010.aipub.projectcontroller.mutating.dto.V1AdmissionReview;
 import io.ten1010.aipub.projectcontroller.mutating.dto.V1UserInfo;
 import java.util.Objects;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 
 @Slf4j
 public class NamespaceReviewHandler extends AbstractReviewHandler<V1Namespace> {
 
+  private static final String OPERATION_CREATE = "CREATE";
+  private static final String OPERATION_UPDATE = "UPDATE";
+
   private final AipubProperties aipubProperties;
   private final KeyResolver keyResolver;
   private final SubjectResolver subjectResolver;
   private final Indexer<V1Namespace> namespaceIndexer;
+  private final Indexer<V1alpha1Project> projectIndexer;
 
   public NamespaceReviewHandler(AipubProperties aipubProperties, SubjectResolver subjectResolver,
       SharedInformerFactory sharedInformerFactory) {
@@ -33,6 +40,9 @@ public class NamespaceReviewHandler extends AbstractReviewHandler<V1Namespace> {
     this.namespaceIndexer = sharedInformerFactory
         .getExistingSharedIndexInformer(V1Namespace.class)
         .getIndexer();
+    this.projectIndexer = sharedInformerFactory
+        .getExistingSharedIndexInformer(V1alpha1Project.class)
+        .getIndexer();
   }
 
   @Override
@@ -40,6 +50,49 @@ public class NamespaceReviewHandler extends AbstractReviewHandler<V1Namespace> {
     Objects.requireNonNull(review.getRequest());
     Objects.requireNonNull(review.getRequest().getUserInfo());
 
+    String operation = review.getRequest().getOperation();
+    if (OPERATION_CREATE.equals(operation) || OPERATION_UPDATE.equals(operation)) {
+      handleAllowlistLabeling(review);
+      return;
+    }
+
+    handleReservedDeletion(review);
+  }
+
+  /**
+   * 동명의 project가 아직 있는(종료 중인 경우 포함) 네임스페이스에 allowlist 라벨을 붙이는 것을
+   * 거부한다. project 격리가 먼저 부여된 의미라 우선하며, allowlist 네임스페이스 이름으로 project를
+   * 만드는 것을 거부하는 {@code ProjectReviewHandler}와 대칭이다. system-admin 예외 없는 hard
+   * block이다. 종료 중인 project도 거부하는데, 그 네임스페이스는 project 소유(ownerReference)라
+   * project와 함께 garbage collection으로 지워지므로, allowlist를 붙여봐야 곧 사라질 네임스페이스에
+   * 라벨만 남기기 때문이다.
+   *
+   * <p>원하는 상태는 informer 캐시가 아니라 요청 객체에서 읽는다. UPDATE 시 캐시에는 patch 이전
+   * 네임스페이스가 남아 있어 새로 붙는 라벨을 놓치기 때문이다.
+   */
+  private void handleAllowlistLabeling(V1AdmissionReview review) {
+    V1Namespace desired = getRequestObject(review);
+    if (!NamespaceAllowlistResolver.isAllowlisted(desired)) {
+      V1AdmissionReviewUtils.allow(review);
+      return;
+    }
+
+    String namespaceName = K8sObjectUtils.getName(desired);
+    Optional<V1alpha1Project> projectOpt = Optional.ofNullable(
+        this.projectIndexer.getByKey(this.keyResolver.resolveKey(namespaceName)));
+    if (projectOpt.isPresent()) {
+      log.debug("Namespace {} cannot be allowlisted while a project with the same name exists",
+          namespaceName);
+      V1AdmissionReviewUtils.reject(review, HttpStatus.CONFLICT.value(),
+          String.format("%s still has a project of the same name; allowlisting is allowed only"
+              + " after that project is deleted and the namespace is released", namespaceName));
+      return;
+    }
+
+    V1AdmissionReviewUtils.allow(review);
+  }
+
+  private void handleReservedDeletion(V1AdmissionReview review) {
     V1Namespace namespace = this.namespaceIndexer.getByKey(
         this.keyResolver.resolveKey(getNamespaceName(review)));
     String namespaceName = K8sObjectUtils.getName(namespace);

--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/PodReviewHandler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/PodReviewHandler.java
@@ -47,6 +47,22 @@ public class PodReviewHandler extends AbstractReviewHandler<V1Pod> {
 
     V1Pod pod = getRequestObject(review);
 
+    // allowlist 네임스페이스는 라벨 제외 검사보다 먼저 처리한다. 파드의 toleration은 생성 후 바꿀 수
+    // 없으므로, 제외 라벨이 붙은 파드라도 project-managed 노드에 스케줄되려면 여기서 toleration을
+    // 주입해야 한다.
+    if (this.reconciliationService.isNamespaceAllowlisted(review.getRequest().getNamespace())) {
+      List<V1Toleration> reconciledTolerations =
+          this.reconciliationService.reconcileTolerationsForAllowlistedNamespace(pod);
+      JsonPatchBuilder allowlistPatchBuilder = new JsonPatchBuilder();
+      allowlistPatchBuilder.addToOperations(new JsonPatchOperationBuilder()
+          .replace()
+          .setPath("/spec/tolerations")
+          .setValue(createJsonNode(reconciledTolerations))
+          .build());
+      V1AdmissionReviewUtils.allow(review, allowlistPatchBuilder.build());
+      return;
+    }
+
     if (this.reconciliationService.isExcludedFromReconciliation(pod)) {
       V1AdmissionReviewUtils.allow(review);
       return;

--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/ProjectReviewHandler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/ProjectReviewHandler.java
@@ -7,6 +7,7 @@ import io.ten1010.aipub.projectcontroller.configuration.AipubProperties;
 import io.ten1010.aipub.projectcontroller.domain.k8s.K8sGroupConstants;
 import io.ten1010.aipub.projectcontroller.domain.k8s.K8sObjectTypeConstants;
 import io.ten1010.aipub.projectcontroller.domain.k8s.KeyResolver;
+import io.ten1010.aipub.projectcontroller.domain.k8s.NamespaceAllowlistResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ProjectRoleEnum;
 import io.ten1010.aipub.projectcontroller.domain.k8s.SubjectResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Project;
@@ -30,9 +31,11 @@ public class ProjectReviewHandler extends AbstractReviewHandler<V1alpha1Project>
   private final SubjectResolver subjectResolver;
   private final KeyResolver keyResolver;
   private final Indexer<V1alpha1Project> projectIndexer;
+  private final NamespaceAllowlistResolver namespaceAllowlistResolver;
 
   public ProjectReviewHandler(AipubProperties aipubProperties, SubjectResolver subjectResolver,
-      SharedInformerFactory sharedInformerFactory) {
+      SharedInformerFactory sharedInformerFactory,
+      NamespaceAllowlistResolver namespaceAllowlistResolver) {
     super(K8sObjectTypeConstants.PROJECT_V1ALPHA1);
     this.aipubProperties = aipubProperties;
     this.keyResolver = new KeyResolver();
@@ -40,6 +43,7 @@ public class ProjectReviewHandler extends AbstractReviewHandler<V1alpha1Project>
     this.projectIndexer = sharedInformerFactory
         .getExistingSharedIndexInformer(V1alpha1Project.class)
         .getIndexer();
+    this.namespaceAllowlistResolver = namespaceAllowlistResolver;
   }
 
   @Override
@@ -50,18 +54,23 @@ public class ProjectReviewHandler extends AbstractReviewHandler<V1alpha1Project>
     V1UserInfo userInfo = review.getRequest().getUserInfo();
     V1alpha1Project proj = getRequestObject(review);
     String projName = K8sObjectUtils.getName(proj);
+    // reserved 네임스페이스 이름으로 project를 만들면 project 관리(quota, RBAC, secret)가 인프라
+    // 네임스페이스로 새어 나간다. 그래서 아래에서 임의의 project 생성이 허용되는 system admin에게도
+    // 예외 없이 막는 hard block이다.
     if (isReservedName(projName)) {
-      if (userInfo.getGroups() != null &&
-          (userInfo.getGroups().contains(K8sGroupConstants.SYSTEM_MASTERS_GROUP_NAME) ||
-              userInfo.getGroups().contains(K8sGroupConstants.CLUSTER_ADMINS_GROUP_NAME)) &&
-          !userInfo.getGroups().contains(K8sGroupConstants.AIPUB_ADMIN_GROUP_NAME)) {
-        log.debug("Project name {} is reserved, but allowed for system admin", projName);
-        V1AdmissionReviewUtils.allow(review);
-        return;
-      }
       log.debug("Project name {} is reserved", projName);
       V1AdmissionReviewUtils.reject(review, HttpStatus.CONFLICT.value(),
           String.format("%s is reserved name", projName));
+      return;
+    }
+
+    // allowlist 네임스페이스 이름의 project는 관리하지 않으므로(allowlist 우선), 애매한 상태를 막기
+    // 위해 생성을 거부한다. allowlist가 먼저 부여된 의미라 우선하며, system-admin 예외 없는 hard
+    // block이다.
+    if (this.namespaceAllowlistResolver.isAllowlisted(projName)) {
+      log.debug("Project name {} matches allowlisted namespace", projName);
+      V1AdmissionReviewUtils.reject(review, HttpStatus.CONFLICT.value(),
+          String.format("%s is allowlisted namespace", projName));
       return;
     }
 

--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/UserLabelReviewHandler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/UserLabelReviewHandler.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kubernetes.client.openapi.ApiClient;
 import io.ten1010.aipub.projectcontroller.domain.k8s.LabelConstants;
+import io.ten1010.aipub.projectcontroller.domain.k8s.NamespaceAllowlistResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ObjectMapperFactory;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubUser;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.K8sObjectUtils;
@@ -35,13 +36,16 @@ public class UserLabelReviewHandler implements ReviewHandler {
   private final UserInfoAnalyzer userInfoAnalyzer;
   private final ApiResourceDiscovery apiResourceDiscovery;
   private final ApiClient k8sApiClient;
+  private final NamespaceAllowlistResolver namespaceAllowlistResolver;
   private final ObjectMapper mapper;
 
   public UserLabelReviewHandler(UserInfoAnalyzer userInfoAnalyzer,
-      ApiResourceDiscovery apiResourceDiscovery, ApiClient k8sApiClient) {
+      ApiResourceDiscovery apiResourceDiscovery, ApiClient k8sApiClient,
+      NamespaceAllowlistResolver namespaceAllowlistResolver) {
     this.userInfoAnalyzer = userInfoAnalyzer;
     this.apiResourceDiscovery = apiResourceDiscovery;
     this.k8sApiClient = k8sApiClient;
+    this.namespaceAllowlistResolver = namespaceAllowlistResolver;
     this.mapper = new ObjectMapperFactory().createObjectMapper();
   }
 
@@ -65,6 +69,11 @@ public class UserLabelReviewHandler implements ReviewHandler {
     Objects.requireNonNull(request.getUserInfo());
     Objects.requireNonNull(request.getObject());
     Objects.requireNonNull(request.getNamespace());
+
+    if (this.namespaceAllowlistResolver.isAllowlisted(request.getNamespace())) {
+      V1AdmissionReviewUtils.allowMerging(review);
+      return;
+    }
 
     log.debug("UserLabel handle: user={}, namespace={}, operation={}",
         request.getUserInfo().getUsername(), request.getNamespace(), request.getOperation());

--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/UserOwnerReviewHandler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/UserOwnerReviewHandler.java
@@ -3,6 +3,7 @@ package io.ten1010.aipub.projectcontroller.mutating.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kubernetes.client.openapi.models.V1OwnerReference;
+import io.ten1010.aipub.projectcontroller.domain.k8s.NamespaceAllowlistResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ObjectMapperFactory;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubUser;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.K8sObjectUtils;
@@ -23,11 +24,14 @@ public class UserOwnerReviewHandler implements ReviewHandler {
 
   private final UserInfoAnalyzer userInfoAnalyzer;
   private final Set<String> exceptGvkSet;
+  private final NamespaceAllowlistResolver namespaceAllowlistResolver;
   private final ObjectMapper mapper;
 
-  public UserOwnerReviewHandler(UserInfoAnalyzer userInfoAnalyzer, Set<String> exceptGvkSet) {
+  public UserOwnerReviewHandler(UserInfoAnalyzer userInfoAnalyzer, Set<String> exceptGvkSet,
+      NamespaceAllowlistResolver namespaceAllowlistResolver) {
     this.userInfoAnalyzer = userInfoAnalyzer;
     this.exceptGvkSet = exceptGvkSet;
+    this.namespaceAllowlistResolver = namespaceAllowlistResolver;
     this.mapper = new ObjectMapperFactory().createObjectMapper();
   }
 
@@ -52,6 +56,11 @@ public class UserOwnerReviewHandler implements ReviewHandler {
     Objects.requireNonNull(request.getKind().getKind());
     Objects.requireNonNull(request.getUserInfo());
     Objects.requireNonNull(request.getObject());
+
+    if (this.namespaceAllowlistResolver.isAllowlisted(request.getNamespace())) {
+      V1AdmissionReviewUtils.allowMerging(review);
+      return;
+    }
 
     String group = request.getKind().getGroup() != null ? request.getKind().getGroup() : "";
     String gvk = group + "/"

--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/WorkloadLabelReviewHandler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/WorkloadLabelReviewHandler.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kubernetes.client.openapi.ApiClient;
 import io.ten1010.aipub.projectcontroller.domain.k8s.LabelConstants;
+import io.ten1010.aipub.projectcontroller.domain.k8s.NamespaceAllowlistResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ObjectMapperFactory;
 import io.ten1010.aipub.projectcontroller.mutating.V1AdmissionReviewUtils;
 import io.ten1010.aipub.projectcontroller.mutating.dto.V1AdmissionReview;
@@ -36,13 +37,15 @@ public class WorkloadLabelReviewHandler implements ReviewHandler {
 
   private final ApiResourceDiscovery apiResourceDiscovery;
   private final ApiClient k8sApiClient;
+  private final NamespaceAllowlistResolver namespaceAllowlistResolver;
   private final ObjectMapper mapper;
 
   // Port of Python: __init__(self, owner_service)
   public WorkloadLabelReviewHandler(ApiResourceDiscovery apiResourceDiscovery,
-      ApiClient k8sApiClient) {
+      ApiClient k8sApiClient, NamespaceAllowlistResolver namespaceAllowlistResolver) {
     this.apiResourceDiscovery = apiResourceDiscovery;
     this.k8sApiClient = k8sApiClient;
+    this.namespaceAllowlistResolver = namespaceAllowlistResolver;
     this.mapper = new ObjectMapperFactory().createObjectMapper();
   }
 
@@ -66,6 +69,11 @@ public class WorkloadLabelReviewHandler implements ReviewHandler {
     V1AdmissionReviewRequest request = review.getRequest();
     Objects.requireNonNull(request.getObject());
     Objects.requireNonNull(request.getNamespace());
+
+    if (this.namespaceAllowlistResolver.isAllowlisted(request.getNamespace())) {
+      V1AdmissionReviewUtils.allowMerging(review);
+      return;
+    }
 
     log.debug("WorkloadLabel handle: namespace={}, operation={}",
         request.getNamespace(), request.getOperation());

--- a/src/test/java/io/ten1010/aipub/projectcontroller/domain/k8s/NamespaceAllowlistResolverTest.java
+++ b/src/test/java/io/ten1010/aipub/projectcontroller/domain/k8s/NamespaceAllowlistResolverTest.java
@@ -1,0 +1,85 @@
+package io.ten1010.aipub.projectcontroller.domain.k8s;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.kubernetes.client.informer.cache.Cache;
+import io.kubernetes.client.openapi.models.V1Namespace;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class NamespaceAllowlistResolverTest {
+
+  private static V1Namespace namespaceWithLabels(String name, Map<String, String> labels) {
+    return new V1Namespace().metadata(new V1ObjectMeta().name(name).labels(labels));
+  }
+
+  private static NamespaceAllowlistResolver resolverWith(V1Namespace... namespaces) {
+    Cache<V1Namespace> cache = new Cache<>();
+    for (V1Namespace namespace : namespaces) {
+      cache.add(namespace);
+    }
+    return new NamespaceAllowlistResolver(cache);
+  }
+
+  @Test
+  @DisplayName("allowlisted 라벨 값이 true면 allowlist로 판정한다(대소문자 무관)")
+  void givenAllowlistedLabelTrue_thenAllowlisted() {
+    NamespaceAllowlistResolver resolver = resolverWith(
+        namespaceWithLabels("kubevirt", Map.of(LabelConstants.ALLOWLISTED_KEY, "true")),
+        namespaceWithLabels("monitoring", Map.of(LabelConstants.ALLOWLISTED_KEY, "TRUE")));
+
+    assertThat(resolver.isAllowlisted("kubevirt")).isTrue();
+    assertThat(resolver.isAllowlisted("monitoring")).isTrue();
+  }
+
+  @Test
+  @DisplayName("allowlisted 라벨 값이 true가 아니면 allowlist가 아니다")
+  void givenAllowlistedLabelNotTrue_thenNotAllowlisted() {
+    NamespaceAllowlistResolver resolver = resolverWith(
+        namespaceWithLabels("ns-false", Map.of(LabelConstants.ALLOWLISTED_KEY, "false")),
+        namespaceWithLabels("ns-junk", Map.of(LabelConstants.ALLOWLISTED_KEY, "yes")));
+
+    assertThat(resolver.isAllowlisted("ns-false")).isFalse();
+    assertThat(resolver.isAllowlisted("ns-junk")).isFalse();
+  }
+
+  @Test
+  @DisplayName("allowlisted 라벨이 없으면 allowlist가 아니다")
+  void givenNoAllowlistedLabel_thenNotAllowlisted() {
+    NamespaceAllowlistResolver resolver = resolverWith(
+        namespaceWithLabels("plain", Map.of("other-label", "true")));
+
+    assertThat(resolver.isAllowlisted("plain")).isFalse();
+  }
+
+  @Test
+  @DisplayName("캐시에 없는 네임스페이스는 allowlist가 아니다(fail-closed)")
+  void givenNamespaceNotInCache_thenNotAllowlisted() {
+    NamespaceAllowlistResolver resolver = resolverWith();
+
+    assertThat(resolver.isAllowlisted("unknown")).isFalse();
+  }
+
+  @Test
+  @DisplayName("null이나 빈 이름은 allowlist가 아니다")
+  void givenNullOrBlankName_thenNotAllowlisted() {
+    NamespaceAllowlistResolver resolver = resolverWith(
+        namespaceWithLabels("kubevirt", Map.of(LabelConstants.ALLOWLISTED_KEY, "true")));
+
+    assertThat(resolver.isAllowlisted((String) null)).isFalse();
+    assertThat(resolver.isAllowlisted("")).isFalse();
+    assertThat(resolver.isAllowlisted("  ")).isFalse();
+  }
+
+  @Test
+  @DisplayName("static 오버로드는 네임스페이스 오브젝트의 라벨만으로 판정한다")
+  void givenNamespaceObject_thenStaticCheckWorks() {
+    assertThat(NamespaceAllowlistResolver.isAllowlisted(
+        namespaceWithLabels("a", Map.of(LabelConstants.ALLOWLISTED_KEY, "true")))).isTrue();
+    assertThat(NamespaceAllowlistResolver.isAllowlisted(
+        namespaceWithLabels("b", Map.of()))).isFalse();
+  }
+
+}

--- a/src/test/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationServiceOwnedRulesTest.java
+++ b/src/test/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationServiceOwnedRulesTest.java
@@ -39,7 +39,8 @@ class ReconciliationServiceOwnedRulesTest {
         subjectResolver,
         project -> java.util.Map.of(),
         List.of(),
-        new WorkloadExclusionResolver(List.of()));
+        new WorkloadExclusionResolver(List.of()),
+        new NamespaceAllowlistResolver(new io.kubernetes.client.informer.cache.Cache<>()));
 
     this.user = new V1alpha1AipubUser();
     V1ObjectMeta userMeta = new V1ObjectMeta();

--- a/src/test/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationServiceTest.java
+++ b/src/test/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationServiceTest.java
@@ -1,0 +1,103 @@
+package io.ten1010.aipub.projectcontroller.domain.k8s;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.kubernetes.client.informer.cache.Cache;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.kubernetes.client.openapi.models.V1PodTemplateSpec;
+import io.kubernetes.client.openapi.models.V1Toleration;
+import io.ten1010.aipub.projectcontroller.domain.k8s.util.WorkloadExclusionResolver;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ReconciliationServiceTest {
+
+  private static ReconciliationService createService() {
+    return new ReconciliationService(
+        mock(SubjectResolver.class),
+        mock(DockerConfigJsonResolver.class),
+        List.of(),
+        new WorkloadExclusionResolver(List.of()),
+        new NamespaceAllowlistResolver(new Cache<>()));
+  }
+
+  private static V1Pod podWithTolerations(List<V1Toleration> tolerations) {
+    return new V1Pod().spec(new V1PodSpec().tolerations(tolerations));
+  }
+
+  private static V1Toleration existsToleration(String effect) {
+    return new V1Toleration()
+        .key(TaintConstants.PROJECT_MANAGED_KEY)
+        .operator("Exists")
+        .effect(effect);
+  }
+
+  @Test
+  @DisplayName("allowlist reconcile은 project managed 키의 Exists toleration 쌍을 추가한다")
+  void givenNoTolerations_whenAllowlistReconcile_thenExistsPairAdded() {
+    ReconciliationService service = createService();
+
+    List<V1Toleration> reconciled = service.reconcileTolerationsForAllowlistedNamespace(
+        podWithTolerations(null));
+
+    assertThat(reconciled).containsExactly(
+        existsToleration(TaintConstants.NO_SCHEDULE_EFFECT),
+        existsToleration(TaintConstants.NO_EXECUTE_EFFECT));
+  }
+
+  @Test
+  @DisplayName("allowlist reconcile은 기존 toleration을 재작성 없이 그대로 보존한다(catch-all 포함)")
+  void givenExistingTolerations_whenAllowlistReconcile_thenPreservedVerbatim() {
+    ReconciliationService service = createService();
+    // 일반 경로의 replaceAllKeyAllEffectTolerations가 재작성해버릴 catch-all toleration(key/effect
+    // 없음)이, allowlist 경로에서는 그대로 보존되어야 한다.
+    V1Toleration catchAll = new V1Toleration().operator("Exists");
+    V1Toleration custom = new V1Toleration()
+        .key("kubevirt.io/drain").operator("Exists").effect(TaintConstants.NO_SCHEDULE_EFFECT);
+
+    List<V1Toleration> reconciled = service.reconcileTolerationsForAllowlistedNamespace(
+        podWithTolerations(new ArrayList<>(List.of(catchAll, custom))));
+
+    assertThat(reconciled).containsExactly(
+        catchAll,
+        custom,
+        existsToleration(TaintConstants.NO_SCHEDULE_EFFECT),
+        existsToleration(TaintConstants.NO_EXECUTE_EFFECT));
+  }
+
+  @Test
+  @DisplayName("allowlist reconcile은 기존 per-node Equal toleration을 제거하고 Exists 쌍으로 대체한다")
+  void givenPerNodeEqualTolerations_whenAllowlistReconcile_thenReplacedByExistsPair() {
+    ReconciliationService service = createService();
+    V1Toleration perNodeEqual = new V1Toleration()
+        .key(TaintConstants.PROJECT_MANAGED_KEY)
+        .operator("Equal")
+        .value("node-1")
+        .effect(TaintConstants.NO_SCHEDULE_EFFECT);
+
+    List<V1Toleration> reconciled = service.reconcileTolerationsForAllowlistedNamespace(
+        podWithTolerations(new ArrayList<>(List.of(perNodeEqual))));
+
+    assertThat(reconciled).containsExactly(
+        existsToleration(TaintConstants.NO_SCHEDULE_EFFECT),
+        existsToleration(TaintConstants.NO_EXECUTE_EFFECT));
+  }
+
+  @Test
+  @DisplayName("allowlist reconcile은 멱등이다(두 번 적용해도 쌍이 중복되지 않는다)")
+  void givenAlreadyReconciled_whenAllowlistReconcileAgain_thenIdempotent() {
+    ReconciliationService service = createService();
+    V1PodTemplateSpec templateSpec = new V1PodTemplateSpec().spec(new V1PodSpec());
+
+    List<V1Toleration> once = service.reconcileTolerationsForAllowlistedNamespace(templateSpec);
+    templateSpec.getSpec().tolerations(once);
+    List<V1Toleration> twice = service.reconcileTolerationsForAllowlistedNamespace(templateSpec);
+
+    assertThat(twice).isEqualTo(once);
+  }
+
+}

--- a/src/test/java/io/ten1010/aipub/projectcontroller/mutating/service/NamespaceReviewHandlerTest.java
+++ b/src/test/java/io/ten1010/aipub/projectcontroller/mutating/service/NamespaceReviewHandlerTest.java
@@ -1,0 +1,156 @@
+package io.ten1010.aipub.projectcontroller.mutating.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.kubernetes.client.common.KubernetesObject;
+import io.kubernetes.client.informer.SharedIndexInformer;
+import io.kubernetes.client.informer.SharedInformerFactory;
+import io.kubernetes.client.informer.cache.Indexer;
+import io.kubernetes.client.openapi.models.V1Namespace;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.ten1010.aipub.projectcontroller.configuration.AipubProperties;
+import io.ten1010.aipub.projectcontroller.domain.k8s.LabelConstants;
+import io.ten1010.aipub.projectcontroller.domain.k8s.ObjectMapperFactory;
+import io.ten1010.aipub.projectcontroller.domain.k8s.SubjectResolver;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Project;
+import io.ten1010.aipub.projectcontroller.mutating.dto.V1AdmissionReview;
+import io.ten1010.aipub.projectcontroller.mutating.dto.V1AdmissionReviewRequest;
+import io.ten1010.aipub.projectcontroller.mutating.dto.V1UserInfo;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class NamespaceReviewHandlerTest {
+
+  private NamespaceReviewHandler handler;
+  private Indexer<V1Namespace> mockNamespaceIndexer;
+  private Indexer<V1alpha1Project> mockProjectIndexer;
+  private ObjectMapper mapper;
+
+  @SuppressWarnings("unchecked")
+  @BeforeEach
+  void setUp() {
+    this.mockNamespaceIndexer = mock(Indexer.class);
+    this.mockProjectIndexer = mock(Indexer.class);
+
+    SharedInformerFactory factory = mock(SharedInformerFactory.class);
+    mockInformer(factory, V1Namespace.class, this.mockNamespaceIndexer);
+    mockInformer(factory, V1alpha1Project.class, this.mockProjectIndexer);
+
+    AipubProperties aipubProperties = new AipubProperties();
+    this.handler = new NamespaceReviewHandler(
+        aipubProperties, mock(SubjectResolver.class), factory);
+    this.mapper = new ObjectMapperFactory().createObjectMapper();
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T extends KubernetesObject> void mockInformer(SharedInformerFactory factory,
+      Class<T> clazz, Indexer<T> indexer) {
+    SharedIndexInformer<T> informer = mock(SharedIndexInformer.class);
+    when(informer.getIndexer()).thenReturn(indexer);
+    when(factory.getExistingSharedIndexInformer(clazz)).thenReturn(informer);
+  }
+
+  private V1Namespace namespace(String name, boolean allowlisted) {
+    V1ObjectMeta meta = new V1ObjectMeta().name(name);
+    if (allowlisted) {
+      meta.labels(Map.of(LabelConstants.ALLOWLISTED_KEY, "true"));
+    }
+    return new V1Namespace().metadata(meta);
+  }
+
+  private V1alpha1Project project(String name, boolean terminating) {
+    V1ObjectMeta meta = new V1ObjectMeta().name(name);
+    if (terminating) {
+      meta.deletionTimestamp(OffsetDateTime.now());
+    }
+    V1alpha1Project project = new V1alpha1Project();
+    project.setMetadata(meta);
+    return project;
+  }
+
+  private V1AdmissionReview createReview(String operation, V1Namespace desired) {
+    V1AdmissionReviewRequest request = new V1AdmissionReviewRequest();
+    request.setUid("test-uid");
+    request.setOperation(operation);
+    request.setName(desired.getMetadata().getName());
+    request.setUserInfo(new V1UserInfo());
+    request.setObject(this.mapper.valueToTree(desired));
+
+    V1AdmissionReview review = new V1AdmissionReview();
+    review.setApiVersion("admission.k8s.io/v1");
+    review.setKind("AdmissionReview");
+    review.setRequest(request);
+    return review;
+  }
+
+  @Test
+  @DisplayName("동명의 활성 project가 있으면 allowlist 라벨 부착(UPDATE)을 거부한다")
+  void update_allowlistLabelWithActiveProject_rejectsConflict() {
+    when(this.mockProjectIndexer.getByKey(anyString())).thenReturn(project("proj1", false));
+    V1AdmissionReview review = createReview("UPDATE", namespace("proj1", true));
+
+    this.handler.handle(review);
+
+    assertThat(review.getResponse()).isNotNull();
+    assertThat(review.getResponse().getAllowed()).isFalse();
+    assertThat(review.getResponse().getStatus().getCode()).isEqualTo(409);
+  }
+
+  @Test
+  @DisplayName("동명 project가 없으면 allowlist 라벨 부착을 허용한다")
+  void update_allowlistLabelWithoutProject_allows() {
+    V1AdmissionReview review = createReview("UPDATE", namespace("kubevirt", true));
+
+    this.handler.handle(review);
+
+    assertThat(review.getResponse()).isNotNull();
+    assertThat(review.getResponse().getAllowed()).isTrue();
+    assertThat(review.getResponse().getPatch()).isNull();
+  }
+
+  @Test
+  @DisplayName("동명 project가 종료 중이어도 allowlist 라벨 부착을 거부한다")
+  void update_allowlistLabelWithTerminatingProject_rejectsConflict() {
+    when(this.mockProjectIndexer.getByKey(anyString())).thenReturn(project("proj1", true));
+    V1AdmissionReview review = createReview("UPDATE", namespace("proj1", true));
+
+    this.handler.handle(review);
+
+    assertThat(review.getResponse()).isNotNull();
+    assertThat(review.getResponse().getAllowed()).isFalse();
+    assertThat(review.getResponse().getStatus().getCode()).isEqualTo(409);
+  }
+
+  @Test
+  @DisplayName("allowlist 라벨이 없으면 동명 project가 있어도 허용한다")
+  void update_withoutAllowlistLabel_allows() {
+    when(this.mockProjectIndexer.getByKey(anyString())).thenReturn(project("proj1", false));
+    V1AdmissionReview review = createReview("UPDATE", namespace("proj1", false));
+
+    this.handler.handle(review);
+
+    assertThat(review.getResponse()).isNotNull();
+    assertThat(review.getResponse().getAllowed()).isTrue();
+  }
+
+  @Test
+  @DisplayName("CREATE로 allowlist 라벨이 붙은 채 동명 활성 project가 있으면 거부한다")
+  void create_allowlistLabelWithActiveProject_rejectsConflict() {
+    when(this.mockProjectIndexer.getByKey(anyString())).thenReturn(project("proj1", false));
+    V1AdmissionReview review = createReview("CREATE", namespace("proj1", true));
+
+    this.handler.handle(review);
+
+    assertThat(review.getResponse()).isNotNull();
+    assertThat(review.getResponse().getAllowed()).isFalse();
+    assertThat(review.getResponse().getStatus().getCode()).isEqualTo(409);
+  }
+
+}

--- a/src/test/java/io/ten1010/aipub/projectcontroller/mutating/service/ProjectReviewHandlerTest.java
+++ b/src/test/java/io/ten1010/aipub/projectcontroller/mutating/service/ProjectReviewHandlerTest.java
@@ -1,0 +1,124 @@
+package io.ten1010.aipub.projectcontroller.mutating.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.kubernetes.client.common.KubernetesObject;
+import io.kubernetes.client.informer.SharedIndexInformer;
+import io.kubernetes.client.informer.SharedInformerFactory;
+import io.kubernetes.client.informer.cache.Cache;
+import io.kubernetes.client.informer.cache.Indexer;
+import io.kubernetes.client.openapi.models.V1Namespace;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.ten1010.aipub.projectcontroller.configuration.AipubProperties;
+import io.ten1010.aipub.projectcontroller.domain.k8s.K8sGroupConstants;
+import io.ten1010.aipub.projectcontroller.domain.k8s.LabelConstants;
+import io.ten1010.aipub.projectcontroller.domain.k8s.NamespaceAllowlistResolver;
+import io.ten1010.aipub.projectcontroller.domain.k8s.ObjectMapperFactory;
+import io.ten1010.aipub.projectcontroller.domain.k8s.SubjectResolver;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Project;
+import io.ten1010.aipub.projectcontroller.mutating.dto.V1AdmissionReview;
+import io.ten1010.aipub.projectcontroller.mutating.dto.V1AdmissionReviewRequest;
+import io.ten1010.aipub.projectcontroller.mutating.dto.V1UserInfo;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ProjectReviewHandlerTest {
+
+  private ProjectReviewHandler handler;
+  private ObjectMapper mapper;
+
+  @SuppressWarnings("unchecked")
+  @BeforeEach
+  void setUp() {
+    Indexer<V1alpha1Project> mockProjectIndexer = mock(Indexer.class);
+    SharedInformerFactory factory = mock(SharedInformerFactory.class);
+    mockInformer(factory, V1alpha1Project.class, mockProjectIndexer);
+
+    Cache<V1Namespace> namespaceCache = new Cache<>();
+    namespaceCache.add(new V1Namespace().metadata(new V1ObjectMeta()
+        .name("kubevirt")
+        .labels(Map.of(LabelConstants.ALLOWLISTED_KEY, "true"))));
+
+    AipubProperties aipubProperties = new AipubProperties();
+    aipubProperties.setReservedNamespace(List.of("aipub"));
+
+    this.handler = new ProjectReviewHandler(
+        aipubProperties, mock(SubjectResolver.class), factory,
+        new NamespaceAllowlistResolver(namespaceCache));
+    this.mapper = new ObjectMapperFactory().createObjectMapper();
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T extends KubernetesObject> void mockInformer(SharedInformerFactory factory,
+      Class<T> clazz, Indexer<T> indexer) {
+    SharedIndexInformer<T> informer = mock(SharedIndexInformer.class);
+    when(informer.getIndexer()).thenReturn(indexer);
+    when(factory.getExistingSharedIndexInformer(clazz)).thenReturn(informer);
+  }
+
+  private V1AdmissionReview createReview(String projectName, List<String> groups) {
+    V1alpha1Project project = new V1alpha1Project();
+    project.setMetadata(new V1ObjectMeta().name(projectName));
+
+    V1UserInfo userInfo = new V1UserInfo();
+    userInfo.setUsername("admin");
+    userInfo.setGroups(groups);
+
+    V1AdmissionReviewRequest request = new V1AdmissionReviewRequest();
+    request.setUid("test-uid");
+    request.setOperation("CREATE");
+    request.setUserInfo(userInfo);
+    request.setObject(this.mapper.valueToTree(project));
+
+    V1AdmissionReview review = new V1AdmissionReview();
+    review.setApiVersion("admission.k8s.io/v1");
+    review.setKind("AdmissionReview");
+    review.setRequest(request);
+    return review;
+  }
+
+  @Test
+  @DisplayName("system admin이라도 reserved 이름 project 생성은 거부한다")
+  void reservedName_systemAdmin_rejectsConflict() {
+    V1AdmissionReview review = createReview("aipub",
+        List.of(K8sGroupConstants.SYSTEM_MASTERS_GROUP_NAME));
+
+    this.handler.handle(review);
+
+    assertThat(review.getResponse()).isNotNull();
+    assertThat(review.getResponse().getAllowed()).isFalse();
+    assertThat(review.getResponse().getStatus().getCode()).isEqualTo(409);
+  }
+
+  @Test
+  @DisplayName("system admin이라도 allowlist 네임스페이스 이름 project 생성은 거부한다")
+  void allowlistedName_systemAdmin_rejectsConflict() {
+    V1AdmissionReview review = createReview("kubevirt",
+        List.of(K8sGroupConstants.SYSTEM_MASTERS_GROUP_NAME));
+
+    this.handler.handle(review);
+
+    assertThat(review.getResponse()).isNotNull();
+    assertThat(review.getResponse().getAllowed()).isFalse();
+    assertThat(review.getResponse().getStatus().getCode()).isEqualTo(409);
+  }
+
+  @Test
+  @DisplayName("reserved/allowlist가 아닌 이름은 system admin에게 허용한다")
+  void ordinaryName_systemAdmin_allows() {
+    V1AdmissionReview review = createReview("team-alpha",
+        List.of(K8sGroupConstants.SYSTEM_MASTERS_GROUP_NAME));
+
+    this.handler.handle(review);
+
+    assertThat(review.getResponse()).isNotNull();
+    assertThat(review.getResponse().getAllowed()).isTrue();
+  }
+
+}

--- a/src/test/java/io/ten1010/aipub/projectcontroller/mutating/service/UserLabelReviewHandlerTest.java
+++ b/src/test/java/io/ten1010/aipub/projectcontroller/mutating/service/UserLabelReviewHandlerTest.java
@@ -7,8 +7,10 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.kubernetes.client.informer.cache.Cache;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.ten1010.aipub.projectcontroller.domain.k8s.NamespaceAllowlistResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ObjectMapperFactory;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubUser;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubUserSpec;
@@ -31,7 +33,8 @@ class UserLabelReviewHandlerTest {
     this.mockAnalyzer = mock(UserInfoAnalyzer.class);
     ApiResourceDiscovery mockDiscovery = mock(ApiResourceDiscovery.class);
     ApiClient mockApiClient = mock(ApiClient.class);
-    this.handler = new UserLabelReviewHandler(this.mockAnalyzer, mockDiscovery, mockApiClient);
+    this.handler = new UserLabelReviewHandler(this.mockAnalyzer, mockDiscovery, mockApiClient,
+        new NamespaceAllowlistResolver(new Cache<>()));
     this.mapper = new ObjectMapperFactory().createObjectMapper();
   }
 

--- a/src/test/java/io/ten1010/aipub/projectcontroller/mutating/service/UserOwnerReviewHandlerTest.java
+++ b/src/test/java/io/ten1010/aipub/projectcontroller/mutating/service/UserOwnerReviewHandlerTest.java
@@ -7,7 +7,11 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.kubernetes.client.informer.cache.Cache;
+import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.ten1010.aipub.projectcontroller.domain.k8s.LabelConstants;
+import io.ten1010.aipub.projectcontroller.domain.k8s.NamespaceAllowlistResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ObjectMapperFactory;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubUser;
 import io.ten1010.aipub.projectcontroller.mutating.dto.V1AdmissionReview;
@@ -15,6 +19,7 @@ import io.ten1010.aipub.projectcontroller.mutating.dto.V1AdmissionReviewRequest;
 import io.ten1010.aipub.projectcontroller.mutating.dto.V1Kind;
 import io.ten1010.aipub.projectcontroller.mutating.dto.V1UserInfo;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,7 +35,8 @@ class UserOwnerReviewHandlerTest {
     this.mockAnalyzer = mock(UserInfoAnalyzer.class);
     this.handler = new UserOwnerReviewHandler(
         this.mockAnalyzer,
-        Set.of("aipub.ten1010.io/v1alpha1/Commit"));
+        Set.of("aipub.ten1010.io/v1alpha1/Commit"),
+        new NamespaceAllowlistResolver(new Cache<>()));
     this.mapper = new ObjectMapperFactory().createObjectMapper();
   }
 
@@ -153,6 +159,23 @@ class UserOwnerReviewHandlerTest {
     assertThat(review.getResponse().getAllowed()).isTrue();
     assertThat(review.getResponse().getPatch()).isNotNull();
     assertThat(review.getResponse().getPatchType()).isEqualTo("JSONPatch");
+  }
+
+  @Test
+  void handle_allowlistedNamespace_allowsWithoutPatch() {
+    Cache<V1Namespace> namespaceCache = new Cache<>();
+    namespaceCache.add(new V1Namespace().metadata(new V1ObjectMeta()
+        .name("kubevirt")
+        .labels(Map.of(LabelConstants.ALLOWLISTED_KEY, "true"))));
+    UserOwnerReviewHandler allowlistAwareHandler = new UserOwnerReviewHandler(
+        this.mockAnalyzer, Set.of(), new NamespaceAllowlistResolver(namespaceCache));
+    V1AdmissionReview review = createReview("CREATE", "kubevirt", "apps", "v1", "Deployment");
+
+    allowlistAwareHandler.handle(review);
+
+    assertThat(review.getResponse()).isNotNull();
+    assertThat(review.getResponse().getAllowed()).isTrue();
+    assertThat(review.getResponse().getPatch()).isNull();
   }
 
   @Test

--- a/src/test/java/io/ten1010/aipub/projectcontroller/mutating/service/WorkloadLabelReviewHandlerTest.java
+++ b/src/test/java/io/ten1010/aipub/projectcontroller/mutating/service/WorkloadLabelReviewHandlerTest.java
@@ -1,0 +1,82 @@
+package io.ten1010.aipub.projectcontroller.mutating.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.kubernetes.client.informer.cache.Cache;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.models.V1Namespace;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.ten1010.aipub.projectcontroller.domain.k8s.LabelConstants;
+import io.ten1010.aipub.projectcontroller.domain.k8s.NamespaceAllowlistResolver;
+import io.ten1010.aipub.projectcontroller.domain.k8s.ObjectMapperFactory;
+import io.ten1010.aipub.projectcontroller.mutating.dto.V1AdmissionReview;
+import io.ten1010.aipub.projectcontroller.mutating.dto.V1AdmissionReviewRequest;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class WorkloadLabelReviewHandlerTest {
+
+  private WorkloadLabelReviewHandler handler;
+  private ApiResourceDiscovery mockDiscovery;
+  private ApiClient mockApiClient;
+  private ObjectMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    this.mockDiscovery = mock(ApiResourceDiscovery.class);
+    this.mockApiClient = mock(ApiClient.class);
+    Cache<V1Namespace> namespaceCache = new Cache<>();
+    namespaceCache.add(new V1Namespace().metadata(new V1ObjectMeta()
+        .name("kubevirt")
+        .labels(Map.of(LabelConstants.ALLOWLISTED_KEY, "true"))));
+    this.handler = new WorkloadLabelReviewHandler(this.mockDiscovery, this.mockApiClient,
+        new NamespaceAllowlistResolver(namespaceCache));
+    this.mapper = new ObjectMapperFactory().createObjectMapper();
+  }
+
+  private V1AdmissionReview createReview(String namespace) {
+    V1AdmissionReviewRequest request = new V1AdmissionReviewRequest();
+    request.setUid("test-uid");
+    request.setOperation("CREATE");
+    request.setNamespace(namespace);
+    request.setObject(this.mapper.createObjectNode().putObject("metadata").objectNode());
+
+    V1AdmissionReview review = new V1AdmissionReview();
+    review.setApiVersion("admission.k8s.io/v1");
+    review.setKind("AdmissionReview");
+    review.setRequest(request);
+
+    return review;
+  }
+
+  @Test
+  @DisplayName("allowlist 네임스페이스의 요청은 owner 조회 없이 무패치 허용한다")
+  void handle_allowlistedNamespace_allowsWithoutPatch() {
+    V1AdmissionReview review = createReview("kubevirt");
+
+    this.handler.handle(review);
+
+    assertThat(review.getResponse()).isNotNull();
+    assertThat(review.getResponse().getAllowed()).isTrue();
+    assertThat(review.getResponse().getPatch()).isNull();
+    verifyNoInteractions(this.mockDiscovery, this.mockApiClient);
+  }
+
+  @Test
+  @DisplayName("allowlist가 아닌 네임스페이스에서 owner가 없으면 무패치 허용한다")
+  void handle_nonAllowlistedNamespaceWithoutOwner_allowsWithoutPatch() {
+    V1AdmissionReview review = createReview("default");
+
+    this.handler.handle(review);
+
+    assertThat(review.getResponse()).isNotNull();
+    assertThat(review.getResponse().getAllowed()).isTrue();
+    assertThat(review.getResponse().getPatch()).isNull();
+  }
+
+}


### PR DESCRIPTION
## 개요 (AIP-2389)

특정 네임스페이스를 project controller의 동작에서 예외처리(allowlist)하는 기능을 추가합니다. 네임스페이스 라벨 기반이라 **런타임에 즉시 추가/해제**되며 컨트롤러 재시작이 필요 없습니다.

```
kubectl label namespace kubevirt project.ten1010.io/allowlisted=true   # 지정
kubectl label namespace kubevirt project.ten1010.io/allowlisted-      # 해제
```

> ⚠️ 웹훅 operations 변경(namespaces `CREATE`/`UPDATE` 추가)이 있어 **aipub-installer#192 와 함께 배포**되어야 합니다.

## 배경

KubeVirt 같은 시스템 컴포넌트는 (1) project managed taint에 대한 toleration을 받지 못해 project managed 노드에 스케줄링될 수 없고, (2) strict isolation 노드에서는 owner가 미등록 타입(`VirtualMachineInstance`)이라 `PodReconciler`가 파드를 즉시 삭제합니다. 기존 `reconcile-excluded-label-selectors`는 웹훅이 건드리지 않게만 할 뿐 toleration 부여와 eviction 방지는 불가능합니다.

## 동작

allowlist 네임스페이스에 대해:

- **eviction 제외** — `PodReconciler`가 해당 네임스페이스 파드를 삭제하지 않음 (`UnsupportedControllerException` 분기보다 선행 가드)
- **toleration 능동 주입** — Pod/Deployment 웹훅과 6종 워크로드 reconciler가 `project.ten1010.io/project-managed` 키의 `Exists` toleration 쌍(NoSchedule+NoExecute)을 주입해 모든 project managed 노드에 스케줄링 가능. 기존 toleration은 재작성 없이 보존(add-only)
- **관리 reconcile 스킵** — Namespace 라벨/ownerRef 정리, ResourceQuota, 레지스트리 Secret, RBAC(member/aipub) 조기 반환
- **웹훅 스킵** — 워크로드 라벨/사용자 소유권 주입 웹훅 무패치 통과 (해당 웹훅 manifest는 수정 불필요)

## 이름 충돌 가드 (양방향 hard block)

allowlist("모두 허용")와 Project("격리")는 의미가 상충하므로, **먼저 부여된 의미를 우선**하도록 어드미션에서 양방향으로 봉쇄합니다. 세 경로 모두 system admin 예외 없이 hard block하고 kubectl 응답으로 사유를 반환합니다.

- **allowlist → Project**: allowlist 네임스페이스와 동명 Project 생성 거부 (`ProjectReviewHandler`)
- **Project → allowlist**: 동명 Project가 존재하는 네임스페이스에 allowlist 라벨 부착 거부 (`NamespaceReviewHandler`, namespaces 웹훅 `CREATE`/`UPDATE`). terminating Project도 거부 — namespace가 Project 소유(ownerReference)라 함께 GC 삭제되므로 라벨링이 무의미
- **reserved → Project**: reserved 이름 Project 생성의 system-admin escape hatch 제거. quota/RBAC/Secret 리컨실러엔 reserved 가드가 없어, 통과 시 인프라 네임스페이스(`aipub` 등)에 관리 리소스가 실제로 생성되는 것을 확인 → 어드미션이 유일 방어선이므로 구멍을 막음
- **런타임 backstop**: 웹훅 우회(컨트롤러 다운/informer 레이스)로 동명 Project + allowlist 상태가 생기면 `NamespaceReconciler`가 allowlist 우선 + warn 로그

## 런타임 전파

워크로드 팩토리 6종 + PodControllerFactory에 namespace watch를 추가해, allowlist 라벨 변경 시 해당 네임스페이스의 워크로드들이 재조정됩니다(템플릿 갱신 → 롤아웃).

## 판정 방식

- namespace informer 캐시 실시간 조회 (`NamespaceAllowlistResolver`)
- 캐시에 없는 네임스페이스는 allowlist 아님(fail-closed) — 격리 우회 방지
- namespaces 웹훅 `failurePolicy`는 `Ignore` 유지: 클러스터 전역 네임스페이스 웹훅이라 컨트롤러 다운 시 모든 네임스페이스 쓰기를 막으면 위험 → fail-open, 런타임 backstop이 보완

## 주의 사항

- 워크로드가 이미 있는 네임스페이스를 allowlist하면 toleration 주입으로 일괄 롤아웃 발생 → 컴포넌트 설치 전 라벨링 권장
- 파드 toleration은 불변이므로 allowlist 이전 파드는 재생성 필요
- allowlist 해제 시 strict 노드 위 파드는 즉시 eviction 대상
- 네임스페이스 라벨 권한 보유자는 project 노드 스케줄링 권한을 얻는 셈 (RBAC 참고)

## 테스트

- `NamespaceAllowlistResolverTest` (신규): 라벨 판정·fail-closed·null 안전성
- `ReconciliationServiceTest` (신규): Exists 쌍 주입, 기존 toleration 보존, per-node Equal 제거, 멱등성
- `NamespaceReviewHandlerTest` (신규): Project → allowlist 라벨 거부(CREATE/UPDATE, terminating 포함), 무충돌 허용
- `ProjectReviewHandlerTest` (신규): reserved/allowlist 이름 Project 생성이 system admin에게도 거부됨
- `WorkloadLabelReviewHandlerTest` (신규) + `UserOwnerReviewHandlerTest` 확장: allowlist 네임스페이스 무패치 통과
- `./gradlew :test` 전체 통과 (23개 클래스 132개 테스트)

수동 스모크 테스트(실클러스터)는 미수행: ① 라벨 부여 → Deployment에 Exists 쌍 주입·롤아웃 ② bare pod 생성 → 웹훅 주입 확인 ③ strict 노드 위 파드 미삭제 ④ 라벨 제거 → 원복 ⑤ 동명 Project 있는 ns에 라벨 → 거부
