### PR TITLE
fix(imagehub): stop rotating image registry robot secrets on every reconcile

### DIFF
--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/namespaced/ImageRegistrySecretReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/namespaced/ImageRegistrySecretReconciler.java
@@ -16,10 +16,12 @@ import io.ten1010.aipub.projectcontroller.domain.k8s.ImageHubNotConnectedExcepti
 import io.ten1010.aipub.projectcontroller.domain.k8s.ImageRegistrySecretNameResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.K8sApiProvider;
 import io.ten1010.aipub.projectcontroller.domain.k8s.KeyResolver;
+import io.ten1010.aipub.projectcontroller.domain.k8s.LabelConstants;
 import io.ten1010.aipub.projectcontroller.domain.k8s.NamespaceNameResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ReconciliationService;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Project;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.K8sObjectUtils;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -103,15 +105,36 @@ public class ImageRegistrySecretReconciler extends AbstractReconciler {
         deleteSecret(secretOpt.get());
         return new Result(false);
       }
-      Map<String, byte[]> reconciledData;
-      try {
-        reconciledData = this.reconciliationService.reconcileImageRegistrySecretData(
-            projectOpt.get());
-      } catch (ImageHubNotConnectedException e) {
+
+      Optional<String> currentRobotIdOpt = this.reconciliationService.resolveImageRegistryRobotId(
+          projectOpt.get());
+      if (currentRobotIdOpt.isEmpty()) {
         return logImageHubNotConnectedAndRequeue(projName);
       }
+      String currentRobotId = currentRobotIdOpt.get();
+      String existingRobotId = K8sObjectUtils.getAnnotations(secretOpt.get())
+          .get(LabelConstants.IMAGE_REGISTRY_ROBOT_ID_KEY);
+
+      Map<String, byte[]> reconciledData;
+      if (currentRobotId.equals(existingRobotId)) {
+        // robot 이 그대로면 비밀번호도 여전히 유효하다 — refreshSecret 을 또 부를 필요 없이
+        // 기존 Secret 데이터를 그대로 재사용한다. permission(bindingImageHubs) 변경은 robot
+        // 을 재생성하지 않으므로, 이 비교만으로 "재발급이 필요한가"를 판단할 수 있다.
+        reconciledData = secretOpt.get().getData();
+      } else {
+        try {
+          reconciledData = this.reconciliationService.reconcileImageRegistrySecretData(
+              projectOpt.get());
+        } catch (ImageHubNotConnectedException e) {
+          return logImageHubNotConnectedAndRequeue(projName);
+        }
+      }
+      Map<String, String> reconciledAnnotations = new HashMap<>(
+          K8sObjectUtils.getAnnotations(secretOpt.get()));
+      reconciledAnnotations.put(LabelConstants.IMAGE_REGISTRY_ROBOT_ID_KEY, currentRobotId);
+
       return reconcileExistingSecret(secretOpt.get(), reconciledReferences, reconciledType,
-          reconciledData, reconciledLabels);
+          reconciledData, reconciledLabels, reconciledAnnotations);
     }
 
     if (!K8sObjectUtils.isTerminating(projectOpt.get())) {
@@ -124,8 +147,13 @@ public class ImageRegistrySecretReconciler extends AbstractReconciler {
       }
       Map<String, String> reconciledLabels = this.reconciliationService.reconcileSecretLabels(
           namespaceOpt.get(), projectOpt.get());
+      Map<String, String> reconciledAnnotations = this.reconciliationService
+          .resolveImageRegistryRobotId(projectOpt.get())
+          .map(id -> Map.of(LabelConstants.IMAGE_REGISTRY_ROBOT_ID_KEY, id))
+          .orElse(Map.of());
       return reconcileNoExistingSecret(request.getNamespace(), request.getName(),
-          reconciledReferences, reconciledType, reconciledData, reconciledLabels);
+          reconciledReferences, reconciledType, reconciledData, reconciledLabels,
+          reconciledAnnotations);
     }
 
     return new Result(false);
@@ -143,13 +171,15 @@ public class ImageRegistrySecretReconciler extends AbstractReconciler {
       List<V1OwnerReference> reconciledReferences,
       String reconciledType,
       Map<String, byte[]> reconciledData,
-      Map<String, String> reconciledLabels) throws ApiException {
+      Map<String, String> reconciledLabels,
+      Map<String, String> reconciledAnnotations) throws ApiException {
     V1Secret secret = new V1SecretBuilder()
         .withNewMetadata()
         .withNamespace(namespace)
         .withName(objName)
         .withOwnerReferences(reconciledReferences)
         .withLabels(reconciledLabels)
+        .withAnnotations(reconciledAnnotations)
         .endMetadata()
         .withType(reconciledType)
         .withData(reconciledData)
@@ -164,17 +194,20 @@ public class ImageRegistrySecretReconciler extends AbstractReconciler {
       List<V1OwnerReference> reconciledReferences,
       String reconciledType,
       Map<String, byte[]> reconciledData,
-      Map<String, String> reconciledLabels) throws ApiException {
+      Map<String, String> reconciledLabels,
+      Map<String, String> reconciledAnnotations) throws ApiException {
     if (Set.copyOf(K8sObjectUtils.getOwnerReferences(existing))
         .equals(Set.copyOf(reconciledReferences)) &&
         Objects.equals(existing.getType(), reconciledType) &&
-        Objects.equals(existing.getData(), reconciledData)) {
+        Objects.equals(existing.getData(), reconciledData) &&
+        Objects.equals(K8sObjectUtils.getAnnotations(existing), reconciledAnnotations)) {
       return new Result(false);
     }
     V1Secret edited = new V1SecretBuilder(existing)
         .editMetadata()
         .withOwnerReferences(reconciledReferences)
         .withLabels(reconciledLabels)
+        .withAnnotations(reconciledAnnotations)
         .endMetadata()
         .withType(reconciledType)
         .withData(reconciledData)

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/aipubbackend/AipubDockerConfigJsonResolver.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/aipubbackend/AipubDockerConfigJsonResolver.java
@@ -65,6 +65,13 @@ public class AipubDockerConfigJsonResolver implements DockerConfigJsonResolver {
     return json;
   }
 
+  @Override
+  public Optional<String> resolveImageRegistryRobotId(V1alpha1Project project) {
+    String username = this.imageRegistryRobotUsernameResolver.resolve(
+        K8sObjectUtils.getName(project));
+    return findByUsername(username).map(ImageRegistryRobot::getId);
+  }
+
   private String getPassword(ImageRegistryRobot robot) {
     Objects.requireNonNull(robot.getId());
     ImageRegistryRobotSecret secret = this.imageRegistryRobotService.refreshSecret(robot.getId());

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/DefaultDockerConfigJsonResolver.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/DefaultDockerConfigJsonResolver.java
@@ -2,12 +2,18 @@ package io.ten1010.aipub.projectcontroller.domain.k8s;
 
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Project;
 import java.util.Map;
+import java.util.Optional;
 
 public class DefaultDockerConfigJsonResolver implements DockerConfigJsonResolver {
 
   @Override
   public Map<String, Object> resolve(V1alpha1Project project) {
     return Map.of();
+  }
+
+  @Override
+  public Optional<String> resolveImageRegistryRobotId(V1alpha1Project project) {
+    return Optional.empty();
   }
 
 }

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/DockerConfigJsonResolver.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/DockerConfigJsonResolver.java
@@ -2,9 +2,16 @@ package io.ten1010.aipub.projectcontroller.domain.k8s;
 
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Project;
 import java.util.Map;
+import java.util.Optional;
 
 public interface DockerConfigJsonResolver {
 
   Map<String, Object> resolve(V1alpha1Project project);
+
+  /**
+   * project 에 연결된 image registry robot 의 id 를 조회한다. secret 을 새로 발급받지 않고
+   * "지금 이 프로젝트의 robot 이 마지막으로 발급했던 robot 과 같은가"만 값싸게 확인하기 위한 용도.
+   */
+  Optional<String> resolveImageRegistryRobotId(V1alpha1Project project);
 
 }

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/LabelConstants.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/LabelConstants.java
@@ -16,6 +16,8 @@ public final class LabelConstants {
       ProjectApiConstants.AIPUB_GROUP + "/" + "workload-name";
   public static final String WORKLOAD_KIND_KEY =
       ProjectApiConstants.AIPUB_GROUP + "/" + "workload-kind";
+  public static final String IMAGE_REGISTRY_ROBOT_ID_KEY =
+      ProjectApiConstants.PROJECT_GROUP + "/" + "image-registry-robot-id";
 
   private LabelConstants() {
   }

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationService.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationService.java
@@ -914,6 +914,15 @@ public class ReconciliationService {
     }
   }
 
+  /**
+   * project 에 연결된 image registry robot 의 id 를 조회한다(secret 재발급 없이). 이미 반영된
+   * Secret 의 {@link LabelConstants#IMAGE_REGISTRY_ROBOT_ID_KEY} annotation 과 비교해서, robot
+   * 이 그대로인지(=비밀번호도 그대로 유효한지) 판단하는 용도로 쓰인다.
+   */
+  public Optional<String> resolveImageRegistryRobotId(V1alpha1Project project) {
+    return this.dockerConfigJsonResolver.resolveImageRegistryRobotId(project);
+  }
+
   public Map<String, String> reconcileNodeLabels(V1Node existing) {
     Map<String, String> existingLabels = K8sObjectUtils.getLabels(existing);
     Map<String, String> reconciled = new HashMap<>(existingLabels);


### PR DESCRIPTION
## Summary
`ImageRegistrySecretReconciler` called `refreshSecret()` (via `AipubDockerConfigJsonResolver`) **unconditionally** every time it reconciled a project's `.dockerconfigjson` Secret — not just at first creation. This fires on:
- every project-controller restart (informer resync re-lists all Projects, bypassing the update filter)
- any change to `spec.binding.imageHubs`, including adding a *second*, unrelated ImageHub to an already-connected project

Harbor robot permissions are updated independently of the robot's secret (`PUT /robots/{id}` vs `PUT /robots/{id}/refreshsecret`), so this rotation was never actually necessary once a working Secret already existed — it just invalidated whatever password was currently in use, with no warning.

**Confirmed live** on cluster12: created a project, connected one ImageHub, `docker login` with the resulting secret succeeded. Added a *second*, unrelated ImageHub binding to the same project (no restart, no crash) — the previously-working password immediately stopped authenticating, while the new one (silently rotated in) worked fine.

## Fix
Track which robot's secret is currently reflected in the K8s Secret via a new `project.aipub.ten1010.io/image-registry-robot-id` annotation. Only call `refreshSecret()` when:
- the Secret doesn't exist yet (first creation), or
- the project's *current* robot id differs from what's recorded on the existing Secret (i.e. the robot was actually deleted/recreated)

Otherwise, reuse the existing Secret's `.dockerconfigjson` data as-is — permission-only changes no longer touch the password at all.

## Note on rollout
Secrets created before this change won't have the annotation yet, so each will get one extra (harmless) rotation the first time it's reconciled after this ships. After that they settle into the new behavior permanently and stop rotating on unrelated changes.

## Follow-up (separate, cross-repo — not in this PR)
Even after this fix, first-time robot creation still costs two Harbor round-trips (create, then refresh-secret) because aipub-backend discards the plaintext secret Harbor already returns at creation time, at three layers (`backend-api`'s Harbor client call, the create gRPC response, and the gateway REST controller returning `Void`). Propagating that through would let project-controller seed the Secret directly from the create response. Tracked separately since it requires aipub-backend changes too — marking this PR as **draft** until that's scoped/decided, and this one is deliberately self-contained without a testing plan.

## Test plan
- [x] `./gradlew compileJava` / `./gradlew build -x test` pass
- [ ] Manually verify: connect ImageHub → login works → add second ImageHub → login with the *same* password still works (previously would have broken)
- [ ] Verify a pre-existing Secret (created before this PR) gets the one-time backfill rotation + annotation on its next reconcile, then stops rotating on subsequent unrelated changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)