### PR TITLE
feat: reflect creator-owned CR permissions in RBAC for arbitrary CRDs (AIP-2388)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ harbor/.env
 /image_push.sh
 /_workspace
 /_workspace_prev_*
+target/

--- a/README.adoc
+++ b/README.adoc
@@ -196,6 +196,32 @@ spec:
 Project Controller는 리소스가 만들어지거나 바뀌는 시점에 admission webhook을 통해 프로젝트 경계를 지킵니다.
 새로 만들어지는 리소스에는 어느 프로젝트와 사용자에 속하는지를 표시해 소유 관계를 분명히 하고, 사용자가 요청한 작업이 그가 가진 권한 범위 안에 있는지 확인합니다.
 
+=== 소유권 이벤트 로그 조회
+
+컨트롤러는 CRD 감지와 소유 오브젝트(CR·네이티브 리소스) 변화를 INFO 레벨로 기록합니다.
+
+* `Detected CRD` / `Removed CRD` — CRD 등록·삭제 감지
+* `Started owned-object informer` / `Stopped owned-object informer` — 타입별 추적 시작·중지
+* `Owned object created` / `Owned object ownership changed` / `Owned object deleted` — 소유 오브젝트 생성·소유권 변경·삭제
+
+[source,bash]
+----
+# CRD 감지/제거 로그
+kubectl logs -n project-controller deploy/project-controller | grep -E "Detected CRD|Removed CRD"
+
+# 소유 오브젝트 생성/변경/삭제 로그
+kubectl logs -n project-controller deploy/project-controller | grep "Owned object"
+
+# 특정 사용자의 소유 오브젝트 이벤트만
+kubectl logs -n project-controller deploy/project-controller | grep "Owned object" | grep "owner=<aipub사용자명>"
+
+# 실시간 스트리밍
+kubectl logs -n project-controller deploy/project-controller -f --tail=200 \
+  | grep --line-buffered -E "Detected CRD|Removed CRD|Owned object|owned-object informer"
+----
+
+참고: 컨트롤러가 재기동하면 초기 동기화 과정에서 기존 소유 오브젝트 전체가 `Owned object created` 로 한 번씩 다시 출력됩니다(재기동 시점의 인벤토리이며, 오브젝트가 실제로 새로 생성된 것은 아닙니다).
+
 === 버그 리포팅 및 개선 사항, 질의
 
 버그를 발견하시거나 개선 사항, 질의가 있다면 link:https://github.com/ten1010-io/project-controller/issues[Github Issue]를 열어주세요.

--- a/kubernetes/controller/project-controller/templates/mutating-webhook-user-v2.yaml
+++ b/kubernetes/controller/project-controller/templates/mutating-webhook-user-v2.yaml
@@ -36,6 +36,9 @@ webhooks:
             - aipub-efk
     objectSelector: { }
     reinvocationPolicy: IfNeeded
+    # rules 는 부트스트랩 값이다. 기동 후에는 user-label-webhook-configuration-controller 가
+    # CRD 목록에 맞춰 rules 를 리컨실한다(CRD 그룹마다 scope "*" CREATE rule 추가).
+    # base rules 를 바꿀 때는 UserLabelWebhookConfigurationReconciler.baseRules() 도 함께 수정할 것.
     rules:
       - apiGroups: [ "" ]
         apiVersions: [ "*" ]

--- a/kubernetes/controller/project-controller/templates/mutating-webhook-user-v2.yaml
+++ b/kubernetes/controller/project-controller/templates/mutating-webhook-user-v2.yaml
@@ -43,12 +43,22 @@ webhooks:
       - apiGroups: [ "" ]
         apiVersions: [ "*" ]
         operations: [ "CREATE" ]
-        resources: [ "pods", "replicationcontrollers", "services", "configmaps", "secrets", "persistentvolumeclaims" ]
+        resources: [ "pods", "replicationcontrollers", "services", "configmaps", "secrets", "persistentvolumeclaims", "serviceaccounts", "limitranges" ]
         scope: "Namespaced"
       - apiGroups: [ "networking.k8s.io" ]
         apiVersions: [ "*" ]
         operations: [ "CREATE" ]
         resources: [ "ingresses" ]
+        scope: "Namespaced"
+      - apiGroups: [ "autoscaling" ]
+        apiVersions: [ "*" ]
+        operations: [ "CREATE" ]
+        resources: [ "horizontalpodautoscalers" ]
+        scope: "Namespaced"
+      - apiGroups: [ "policy" ]
+        apiVersions: [ "*" ]
+        operations: [ "CREATE" ]
+        resources: [ "poddisruptionbudgets" ]
         scope: "Namespaced"
       - apiGroups: [ "batch" ]
         apiVersions: [ "*" ]

--- a/src/main/java/io/ten1010/aipub/projectcontroller/configuration/ControllerConfiguration.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/configuration/ControllerConfiguration.java
@@ -24,6 +24,7 @@ import io.ten1010.aipub.projectcontroller.controller.rbac.member.ClusterRoleBind
 import io.ten1010.aipub.projectcontroller.controller.rbac.member.ClusterRoleControllerFactory;
 import io.ten1010.aipub.projectcontroller.controller.rbac.member.RoleBindingControllerFactory;
 import io.ten1010.aipub.projectcontroller.controller.rbac.member.RoleControllerFactory;
+import io.ten1010.aipub.projectcontroller.controller.webhook.UserLabelWebhookConfigurationControllerFactory;
 import io.ten1010.aipub.projectcontroller.controller.workload.CompositeWorkloadControllerNodesResolver;
 import io.ten1010.aipub.projectcontroller.controller.workload.CronJobInformerRegistrar;
 import io.ten1010.aipub.projectcontroller.controller.workload.CronJobWorkloadControllerFactory;
@@ -46,6 +47,7 @@ import io.ten1010.aipub.projectcontroller.domain.k8s.K8sApiProvider;
 import io.ten1010.aipub.projectcontroller.domain.k8s.K8sObjectType;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ReconciliationService;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Project;
+import io.ten1010.aipub.projectcontroller.informer.dynamic.DynamicCrInformerManager;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -106,9 +108,10 @@ public class ControllerConfiguration {
   @Bean
   public Controller aipubUserClusterRoleController(SharedInformerFactory sharedInformerFactory,
       K8sApiProvider k8sApiProvider,
-      ReconciliationService reconciliationService) {
+      ReconciliationService reconciliationService,
+      DynamicCrInformerManager dynamicCrInformerManager) {
     return new AipubUserClusterRoleControllerFactory(sharedInformerFactory, k8sApiProvider,
-        reconciliationService)
+        reconciliationService, dynamicCrInformerManager)
         .createController();
   }
 
@@ -125,9 +128,19 @@ public class ControllerConfiguration {
   @Bean
   public Controller aipubUserRoleController(SharedInformerFactory sharedInformerFactory,
       K8sApiProvider k8sApiProvider,
-      ReconciliationService reconciliationService) {
+      ReconciliationService reconciliationService,
+      DynamicCrInformerManager dynamicCrInformerManager) {
     return new AipubUserRoleControllerFactory(sharedInformerFactory, k8sApiProvider,
-        reconciliationService)
+        reconciliationService, dynamicCrInformerManager)
+        .createController();
+  }
+
+  @Bean
+  public Controller userLabelWebhookConfigurationController(
+      SharedInformerFactory sharedInformerFactory,
+      K8sApiProvider k8sApiProvider) {
+    return new UserLabelWebhookConfigurationControllerFactory(sharedInformerFactory,
+        k8sApiProvider)
         .createController();
   }
 

--- a/src/main/java/io/ten1010/aipub/projectcontroller/configuration/ControllerConfiguration.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/configuration/ControllerConfiguration.java
@@ -62,12 +62,17 @@ public class ControllerConfiguration {
   @Bean
   public ControllerManager controllerManager(
       SharedInformerFactory sharedInformerFactory, List<Controller> controllers,
-      List<WorkloadControllerFactory<?>> workloadControllerFactories) {
+      List<WorkloadControllerFactory<?>> workloadControllerFactories,
+      DynamicCrInformerManager dynamicCrInformerManager) {
     ControllerManagerBuilder builder = ControllerBuilder.controllerManagerBuilder(
         sharedInformerFactory);
     controllers.forEach(builder::addController);
     workloadControllerFactories.forEach(f -> builder.addController(f.createController()));
     ControllerManager controllerManager = builder.build();
+
+    // 모든 컨트롤러 빌드가 끝나 개인 Role/ClusterRole 워크큐가 매니저에 등록된 뒤에
+    // 네이티브 소유권 인포머를 시작해야 초기 onAdd 이벤트가 유실되지 않는다
+    dynamicCrInformerManager.start();
 
     ExecutorService executor = Executors.newSingleThreadExecutor();
     executor.execute(controllerManager);

--- a/src/main/java/io/ten1010/aipub/projectcontroller/configuration/InformerConfiguration.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/configuration/InformerConfiguration.java
@@ -4,6 +4,7 @@ import io.kubernetes.client.informer.SharedInformerFactory;
 import io.ten1010.aipub.projectcontroller.domain.k8s.K8sApiProvider;
 import io.ten1010.aipub.projectcontroller.informer.InformerRegistrar;
 import io.ten1010.aipub.projectcontroller.informer.SharedInformerFactoryProvider;
+import io.ten1010.aipub.projectcontroller.informer.dynamic.DynamicCrInformerManager;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,6 +17,12 @@ public class InformerConfiguration {
       List<InformerRegistrar> registrars) {
     return new SharedInformerFactoryProvider(k8sApiProvider,
         registrars).createSharedInformerFactory();
+  }
+
+  @Bean
+  public DynamicCrInformerManager dynamicCrInformerManager(
+      K8sApiProvider k8sApiProvider, SharedInformerFactory sharedInformerFactory) {
+    return new DynamicCrInformerManager(k8sApiProvider.getApiClient(), sharedInformerFactory);
   }
 
 }

--- a/src/main/java/io/ten1010/aipub/projectcontroller/configuration/InformerConfiguration.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/configuration/InformerConfiguration.java
@@ -5,6 +5,7 @@ import io.ten1010.aipub.projectcontroller.domain.k8s.K8sApiProvider;
 import io.ten1010.aipub.projectcontroller.informer.InformerRegistrar;
 import io.ten1010.aipub.projectcontroller.informer.SharedInformerFactoryProvider;
 import io.ten1010.aipub.projectcontroller.informer.dynamic.DynamicCrInformerManager;
+import io.ten1010.aipub.projectcontroller.informer.dynamic.OwnedObjectRoleResweeper;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,6 +24,12 @@ public class InformerConfiguration {
   public DynamicCrInformerManager dynamicCrInformerManager(
       K8sApiProvider k8sApiProvider, SharedInformerFactory sharedInformerFactory) {
     return new DynamicCrInformerManager(k8sApiProvider.getApiClient(), sharedInformerFactory);
+  }
+
+  @Bean
+  public OwnedObjectRoleResweeper ownedObjectRoleResweeper(
+      DynamicCrInformerManager dynamicCrInformerManager) {
+    return new OwnedObjectRoleResweeper(dynamicCrInformerManager);
   }
 
 }

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/aipub/AipubUserClusterRoleControllerFactory.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/aipub/AipubUserClusterRoleControllerFactory.java
@@ -15,6 +15,7 @@ import io.ten1010.aipub.projectcontroller.domain.k8s.K8sApiProvider;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ReconciliationService;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubUser;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Project;
+import io.ten1010.aipub.projectcontroller.informer.dynamic.DynamicCrInformerManager;
 
 public class AipubUserClusterRoleControllerFactory implements ControllerFactory {
 
@@ -23,16 +24,19 @@ public class AipubUserClusterRoleControllerFactory implements ControllerFactory 
   private final RequestBuilderFactory requestBuilderFactory;
   private final K8sApiProvider k8sApiProvider;
   private final ReconciliationService reconciliationService;
+  private final DynamicCrInformerManager dynamicCrInformerManager;
 
   public AipubUserClusterRoleControllerFactory(
       SharedInformerFactory sharedInformerFactory,
       K8sApiProvider k8sApiProvider,
-      ReconciliationService reconciliationService) {
+      ReconciliationService reconciliationService,
+      DynamicCrInformerManager dynamicCrInformerManager) {
     this.sharedInformerFactory = sharedInformerFactory;
     this.onUpdateFilterFactory = new OnUpdateFilterFactory();
     this.requestBuilderFactory = new RequestBuilderFactory(sharedInformerFactory);
     this.k8sApiProvider = k8sApiProvider;
     this.reconciliationService = reconciliationService;
+    this.dynamicCrInformerManager = dynamicCrInformerManager;
   }
 
   @Override
@@ -48,11 +52,13 @@ public class AipubUserClusterRoleControllerFactory implements ControllerFactory 
         .watch(this::createAipubUserWatch)
         .withReconciler(
             new AipubUserClusterRoleReconciler(this.sharedInformerFactory, this.k8sApiProvider,
-                this.reconciliationService))
+                this.reconciliationService, this.dynamicCrInformerManager))
         .build();
   }
 
   private ControllerWatch<V1ClusterRole> createClusterRoleWatch(WorkQueue<Request> workQueue) {
+    // 클러스터 스코프 동적 CR 이벤트가 이 컨트롤러의 큐로 직접 enqueue 되도록 큐를 등록한다
+    this.dynamicCrInformerManager.setAipubUserClusterRoleWorkQueue(workQueue);
     DefaultControllerWatch<V1ClusterRole> watch = new DefaultControllerWatch<>(workQueue,
         V1ClusterRole.class);
     watch.setOnUpdateFilter(this.onUpdateFilterFactory.aipubUserClusterRoleFilter());

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/aipub/AipubUserClusterRoleReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/aipub/AipubUserClusterRoleReconciler.java
@@ -16,10 +16,12 @@ import io.ten1010.aipub.projectcontroller.controller.RequestHelper;
 import io.ten1010.aipub.projectcontroller.domain.k8s.AipubUserRoleNameResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.K8sApiProvider;
 import io.ten1010.aipub.projectcontroller.domain.k8s.KeyResolver;
+import io.ten1010.aipub.projectcontroller.domain.k8s.OwnedCrObject;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ReconciliationService;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubUser;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.K8sObjectUtils;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.RoleUtils;
+import io.ten1010.aipub.projectcontroller.informer.dynamic.DynamicCrInformerManager;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -35,14 +37,17 @@ public class AipubUserClusterRoleReconciler extends AbstractReconciler {
   private final Indexer<V1ClusterRole> clusterRoleIndexer;
   private final Indexer<V1alpha1AipubUser> userIndexer;
   private final RbacAuthorizationV1Api rbacAuthorizationV1Api;
+  private final DynamicCrInformerManager dynamicCrInformerManager;
 
   public AipubUserClusterRoleReconciler(
       SharedInformerFactory sharedInformerFactory,
       K8sApiProvider k8sApiProvider,
-      ReconciliationService reconciliationService) {
+      ReconciliationService reconciliationService,
+      DynamicCrInformerManager dynamicCrInformerManager) {
     this.keyResolver = new KeyResolver();
     this.roleNameResolver = new AipubUserRoleNameResolver();
     this.reconciliationService = reconciliationService;
+    this.dynamicCrInformerManager = dynamicCrInformerManager;
     this.clusterRoleIndexer = sharedInformerFactory
         .getExistingSharedIndexInformer(V1ClusterRole.class)
         .getIndexer();
@@ -77,8 +82,10 @@ public class AipubUserClusterRoleReconciler extends AbstractReconciler {
 
     List<V1OwnerReference> reconciledReferences = this.reconciliationService.reconcileOwnerReferences(
         roleOpt.orElse(null), userOpt.get());
+    List<OwnedCrObject> ownedCrObjects = this.dynamicCrInformerManager
+        .getClusterOwnedObjects(userName);
     List<V1PolicyRule> reconciledRules = this.reconciliationService.reconcileClusterRoleRules(
-        userOpt.get());
+        userOpt.get(), ownedCrObjects);
     V1AggregationRule reconciledAggregationRule = this.reconciliationService.reconcileClusterRoleAggregationRule(
         userOpt.get());
 

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/aipub/AipubUserRoleControllerFactory.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/aipub/AipubUserRoleControllerFactory.java
@@ -23,9 +23,8 @@ import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ImageBuild;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Operation;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Project;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1SftpServer;
-import lombok.AllArgsConstructor;
+import io.ten1010.aipub.projectcontroller.informer.dynamic.DynamicCrInformerManager;
 
-@AllArgsConstructor
 public class AipubUserRoleControllerFactory implements ControllerFactory {
 
   private final SharedInformerFactory sharedInformerFactory;
@@ -33,16 +32,19 @@ public class AipubUserRoleControllerFactory implements ControllerFactory {
   private final RequestBuilderFactory requestBuilderFactory;
   private final K8sApiProvider k8sApiProvider;
   private final ReconciliationService reconciliationService;
+  private final DynamicCrInformerManager dynamicCrInformerManager;
 
   public AipubUserRoleControllerFactory(
       SharedInformerFactory sharedInformerFactory,
       K8sApiProvider k8sApiProvider,
-      ReconciliationService reconciliationService) {
+      ReconciliationService reconciliationService,
+      DynamicCrInformerManager dynamicCrInformerManager) {
     this.sharedInformerFactory = sharedInformerFactory;
     this.onUpdateFilterFactory = new OnUpdateFilterFactory();
     this.requestBuilderFactory = new RequestBuilderFactory(sharedInformerFactory);
     this.k8sApiProvider = k8sApiProvider;
     this.reconciliationService = reconciliationService;
+    this.dynamicCrInformerManager = dynamicCrInformerManager;
   }
 
   @Override
@@ -84,11 +86,13 @@ public class AipubUserRoleControllerFactory implements ControllerFactory {
         .watch(this::createSftpServerWatch)
         .watch(this::createImageBuildWatch)
         .withReconciler(new AipubUserRoleReconciler(this.sharedInformerFactory, this.k8sApiProvider,
-            this.reconciliationService))
+            this.reconciliationService, this.dynamicCrInformerManager))
         .build();
   }
 
   private ControllerWatch<V1Role> createRoleWatch(WorkQueue<Request> workQueue) {
+    // 동적 CR 이벤트(소유 CR 생성/삭제)가 이 컨트롤러의 큐로 직접 enqueue 되도록 큐를 등록한다
+    this.dynamicCrInformerManager.setAipubUserRoleWorkQueue(workQueue);
     DefaultControllerWatch<V1Role> watch = new DefaultControllerWatch<>(workQueue, V1Role.class);
     watch.setOnUpdateFilter(this.onUpdateFilterFactory.aipubUserRoleFilter());
 

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/aipub/AipubUserRoleReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/rbac/aipub/AipubUserRoleReconciler.java
@@ -20,6 +20,7 @@ import io.ten1010.aipub.projectcontroller.domain.k8s.AipubUserRoleNameResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.K8sApiProvider;
 import io.ten1010.aipub.projectcontroller.domain.k8s.KeyResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.NamespaceNameResolver;
+import io.ten1010.aipub.projectcontroller.domain.k8s.OwnedCrObject;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ReconciliationService;
 import io.ten1010.aipub.projectcontroller.domain.k8s.RoleNameResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1beta1Workspace;
@@ -33,6 +34,7 @@ import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1SftpServer;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.K8sObjectUtils;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.ProjectUtils;
 import io.ten1010.aipub.projectcontroller.informer.IndexerConstants;
+import io.ten1010.aipub.projectcontroller.informer.dynamic.DynamicCrInformerManager;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -60,11 +62,13 @@ public class AipubUserRoleReconciler extends AbstractReconciler {
   private final Indexer<V1alpha1ImageBuild> imageBuildIndexer;
   private final BoundObjectResolver boundObjectResolver;
   private final RbacAuthorizationV1Api rbacAuthorizationV1Api;
+  private final DynamicCrInformerManager dynamicCrInformerManager;
 
   public AipubUserRoleReconciler(
       SharedInformerFactory sharedInformerFactory,
       K8sApiProvider k8sApiProvider,
-      ReconciliationService reconciliationService
+      ReconciliationService reconciliationService,
+      DynamicCrInformerManager dynamicCrInformerManager
   ) {
     this.keyResolver = new KeyResolver();
     this.namespaceNameResolver = new NamespaceNameResolver();
@@ -105,6 +109,7 @@ public class AipubUserRoleReconciler extends AbstractReconciler {
         .getExistingSharedIndexInformer(V1alpha1ImageBuild.class)
         .getIndexer();
     this.boundObjectResolver = new BoundObjectResolver(sharedInformerFactory);
+    this.dynamicCrInformerManager = dynamicCrInformerManager;
     this.rbacAuthorizationV1Api = new RbacAuthorizationV1Api(k8sApiProvider.getApiClient());
   }
 
@@ -170,8 +175,10 @@ public class AipubUserRoleReconciler extends AbstractReconciler {
 
     List<V1OwnerReference> reconciledReferences = this.reconciliationService.reconcileOwnerReferences(
         roleOpt.orElse(null), userOpt.get());
+    List<OwnedCrObject> ownedCrObjects = this.dynamicCrInformerManager
+        .getNamespacedOwnedObjects(request.getNamespace(), username);
     List<V1PolicyRule> reconciledRules = this.reconciliationService.reconcileAipubUserRoleRules(
-        userOpt.get(), projectOpt.get(), workloads);
+        userOpt.get(), projectOpt.get(), workloads, ownedCrObjects);
 
     if (roleOpt.isPresent()) {
       String projNameFromRoleName = K8sObjectUtils.getName(projectOpt.get());

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/webhook/UserLabelWebhookConfigurationControllerFactory.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/webhook/UserLabelWebhookConfigurationControllerFactory.java
@@ -1,0 +1,58 @@
+package io.ten1010.aipub.projectcontroller.controller.webhook;
+
+import io.kubernetes.client.extended.controller.Controller;
+import io.kubernetes.client.extended.controller.ControllerWatch;
+import io.kubernetes.client.extended.controller.builder.ControllerBuilder;
+import io.kubernetes.client.extended.controller.reconciler.Request;
+import io.kubernetes.client.extended.workqueue.WorkQueue;
+import io.kubernetes.client.informer.SharedInformerFactory;
+import io.kubernetes.client.openapi.models.V1CustomResourceDefinition;
+import io.kubernetes.client.openapi.models.V1MutatingWebhookConfiguration;
+import io.ten1010.aipub.projectcontroller.controller.ControllerFactory;
+import io.ten1010.aipub.projectcontroller.controller.watch.DefaultControllerWatch;
+import io.ten1010.aipub.projectcontroller.domain.k8s.K8sApiProvider;
+import java.util.List;
+
+public class UserLabelWebhookConfigurationControllerFactory implements ControllerFactory {
+
+  private final SharedInformerFactory sharedInformerFactory;
+  private final K8sApiProvider k8sApiProvider;
+
+  public UserLabelWebhookConfigurationControllerFactory(
+      SharedInformerFactory sharedInformerFactory,
+      K8sApiProvider k8sApiProvider) {
+    this.sharedInformerFactory = sharedInformerFactory;
+    this.k8sApiProvider = k8sApiProvider;
+  }
+
+  @Override
+  public Controller createController() {
+    return ControllerBuilder.defaultBuilder(this.sharedInformerFactory)
+        .withName("user-label-webhook-configuration-controller")
+        .withWorkerCount(1)
+        .withReadyFunc(this.sharedInformerFactory.getExistingSharedIndexInformer(
+            V1MutatingWebhookConfiguration.class)::hasSynced)
+        .withReadyFunc(this.sharedInformerFactory.getExistingSharedIndexInformer(
+            V1CustomResourceDefinition.class)::hasSynced)
+        .watch(this::createWebhookConfigurationWatch)
+        .watch(this::createCustomResourceDefinitionWatch)
+        .withReconciler(new UserLabelWebhookConfigurationReconciler(this.sharedInformerFactory,
+            this.k8sApiProvider))
+        .build();
+  }
+
+  private ControllerWatch<V1MutatingWebhookConfiguration> createWebhookConfigurationWatch(
+      WorkQueue<Request> workQueue) {
+    return new DefaultControllerWatch<>(workQueue, V1MutatingWebhookConfiguration.class);
+  }
+
+  private ControllerWatch<V1CustomResourceDefinition> createCustomResourceDefinitionWatch(
+      WorkQueue<Request> workQueue) {
+    DefaultControllerWatch<V1CustomResourceDefinition> watch = new DefaultControllerWatch<>(
+        workQueue, V1CustomResourceDefinition.class);
+    watch.setRequestBuilder(obj -> List.of(
+        new Request(UserLabelWebhookConfigurationReconciler.WEBHOOK_CONFIGURATION_NAME)));
+    return watch;
+  }
+
+}

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/webhook/UserLabelWebhookConfigurationReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/webhook/UserLabelWebhookConfigurationReconciler.java
@@ -102,7 +102,7 @@ public class UserLabelWebhookConfigurationReconciler extends AbstractReconciler 
             .withApiVersions("*")
             .withOperations("CREATE")
             .withResources("pods", "replicationcontrollers", "services", "configmaps", "secrets",
-                "persistentvolumeclaims")
+                "persistentvolumeclaims", "serviceaccounts", "limitranges")
             .withScope("Namespaced")
             .build(),
         new V1RuleWithOperationsBuilder()
@@ -110,6 +110,20 @@ public class UserLabelWebhookConfigurationReconciler extends AbstractReconciler 
             .withApiVersions("*")
             .withOperations("CREATE")
             .withResources("ingresses")
+            .withScope("Namespaced")
+            .build(),
+        new V1RuleWithOperationsBuilder()
+            .withApiGroups("autoscaling")
+            .withApiVersions("*")
+            .withOperations("CREATE")
+            .withResources("horizontalpodautoscalers")
+            .withScope("Namespaced")
+            .build(),
+        new V1RuleWithOperationsBuilder()
+            .withApiGroups("policy")
+            .withApiVersions("*")
+            .withOperations("CREATE")
+            .withResources("poddisruptionbudgets")
             .withScope("Namespaced")
             .build(),
         new V1RuleWithOperationsBuilder()

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/webhook/UserLabelWebhookConfigurationReconciler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/webhook/UserLabelWebhookConfigurationReconciler.java
@@ -1,0 +1,138 @@
+package io.ten1010.aipub.projectcontroller.controller.webhook;
+
+import io.kubernetes.client.extended.controller.reconciler.Request;
+import io.kubernetes.client.extended.controller.reconciler.Result;
+import io.kubernetes.client.informer.SharedInformerFactory;
+import io.kubernetes.client.informer.cache.Indexer;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.AdmissionregistrationV1Api;
+import io.kubernetes.client.openapi.models.V1CustomResourceDefinition;
+import io.kubernetes.client.openapi.models.V1MutatingWebhookConfiguration;
+import io.kubernetes.client.openapi.models.V1MutatingWebhookConfigurationBuilder;
+import io.kubernetes.client.openapi.models.V1RuleWithOperations;
+import io.kubernetes.client.openapi.models.V1RuleWithOperationsBuilder;
+import io.ten1010.aipub.projectcontroller.controller.AbstractReconciler;
+import io.ten1010.aipub.projectcontroller.domain.k8s.DynamicCrConstants;
+import io.ten1010.aipub.projectcontroller.domain.k8s.K8sApiProvider;
+import io.ten1010.aipub.projectcontroller.domain.k8s.ProjectApiConstants;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * user-label 낙인 웹훅(MutatingWebhookConfiguration)의 rules 를 CRD 목록에 맞춰 유지한다.
+ * 고정 base rules(네이티브 리소스 + aipub 그룹)에 더해, 존재하는 CRD 그룹마다
+ * scope "*" 의 CREATE 인터셉트 rule 을 생성하여 임의 CR(클러스터 스코프 포함) 생성 시
+ * 소유자 레이블이 찍히도록 한다. 와일드카드로 전 그룹을 여는 대신 CRD 그룹만 정확히
+ * 인터셉트하여, failurePolicy Fail 상태에서도 네이티브 클러스터 리소스(Node 등록 등)에
+ * 영향을 주지 않는다.
+ */
+public class UserLabelWebhookConfigurationReconciler extends AbstractReconciler {
+
+  public static final String WEBHOOK_CONFIGURATION_NAME =
+      "userrelationship-v2.project-controller.project.aipub.ten1010.io";
+
+  private final Indexer<V1MutatingWebhookConfiguration> webhookConfigurationIndexer;
+  private final Indexer<V1CustomResourceDefinition> crdIndexer;
+  private final AdmissionregistrationV1Api admissionregistrationV1Api;
+
+  public UserLabelWebhookConfigurationReconciler(
+      SharedInformerFactory sharedInformerFactory,
+      K8sApiProvider k8sApiProvider) {
+    this.webhookConfigurationIndexer = sharedInformerFactory
+        .getExistingSharedIndexInformer(V1MutatingWebhookConfiguration.class)
+        .getIndexer();
+    this.crdIndexer = sharedInformerFactory
+        .getExistingSharedIndexInformer(V1CustomResourceDefinition.class)
+        .getIndexer();
+    this.admissionregistrationV1Api = new AdmissionregistrationV1Api(
+        k8sApiProvider.getApiClient());
+  }
+
+  @Override
+  protected Result reconcileInternal(Request request) throws ApiException {
+    if (!WEBHOOK_CONFIGURATION_NAME.equals(request.getName())) {
+      return new Result(false);
+    }
+    V1MutatingWebhookConfiguration config = this.webhookConfigurationIndexer
+        .getByKey(WEBHOOK_CONFIGURATION_NAME);
+    if (config == null || config.getWebhooks() == null || config.getWebhooks().isEmpty()) {
+      return new Result(false);
+    }
+    List<V1RuleWithOperations> reconciledRules = buildDesiredRules(this.crdIndexer.list());
+    if (reconciledRules.equals(config.getWebhooks().get(0).getRules())) {
+      return new Result(false);
+    }
+    V1MutatingWebhookConfiguration edited = new V1MutatingWebhookConfigurationBuilder(config)
+        .editFirstWebhook()
+        .withRules(reconciledRules)
+        .endWebhook()
+        .build();
+    this.admissionregistrationV1Api
+        .replaceMutatingWebhookConfiguration(WEBHOOK_CONFIGURATION_NAME, edited)
+        .execute();
+    return new Result(false);
+  }
+
+  static List<V1RuleWithOperations> buildDesiredRules(List<V1CustomResourceDefinition> crds) {
+    List<V1RuleWithOperations> rules = new ArrayList<>(baseRules());
+    crds.stream()
+        .map(crd -> crd.getSpec() == null ? null : crd.getSpec().getGroup())
+        .filter(Objects::nonNull)
+        .filter(group -> !DynamicCrConstants.EXCLUDED_GROUPS.contains(group))
+        .distinct()
+        .sorted()
+        .forEach(group -> rules.add(new V1RuleWithOperationsBuilder()
+            .withApiGroups(group)
+            .withApiVersions("*")
+            .withOperations("CREATE")
+            .withResources("*")
+            .withScope("*")
+            .build()));
+    return rules;
+  }
+
+  /**
+   * templates/mutating-webhook-user-v2.yaml 의 부트스트랩 rules 와 동일해야 한다.
+   */
+  private static List<V1RuleWithOperations> baseRules() {
+    return List.of(
+        new V1RuleWithOperationsBuilder()
+            .withApiGroups("")
+            .withApiVersions("*")
+            .withOperations("CREATE")
+            .withResources("pods", "replicationcontrollers", "services", "configmaps", "secrets",
+                "persistentvolumeclaims")
+            .withScope("Namespaced")
+            .build(),
+        new V1RuleWithOperationsBuilder()
+            .withApiGroups("networking.k8s.io")
+            .withApiVersions("*")
+            .withOperations("CREATE")
+            .withResources("ingresses")
+            .withScope("Namespaced")
+            .build(),
+        new V1RuleWithOperationsBuilder()
+            .withApiGroups("batch")
+            .withApiVersions("*")
+            .withOperations("CREATE")
+            .withResources("*")
+            .withScope("Namespaced")
+            .build(),
+        new V1RuleWithOperationsBuilder()
+            .withApiGroups("apps")
+            .withApiVersions("*")
+            .withOperations("CREATE")
+            .withResources("*")
+            .withScope("Namespaced")
+            .build(),
+        new V1RuleWithOperationsBuilder()
+            .withApiGroups(ProjectApiConstants.AIPUB_GROUP)
+            .withApiVersions("*")
+            .withOperations("CREATE")
+            .withResources("*")
+            .withScope("Namespaced")
+            .build());
+  }
+
+}

--- a/src/main/java/io/ten1010/aipub/projectcontroller/controller/webhook/package-info.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/controller/webhook/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * 웹훅 설정(admissionregistration) 오브젝트를 리컨실하는 컨트롤러 패키지.
+ */
+package io.ten1010.aipub.projectcontroller.controller.webhook;

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/DynamicCrConstants.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/DynamicCrConstants.java
@@ -1,5 +1,6 @@
 package io.ten1010.aipub.projectcontroller.domain.k8s;
 
+import java.util.List;
 import java.util.Set;
 
 public final class DynamicCrConstants {
@@ -14,6 +15,23 @@ public final class DynamicCrConstants {
       ProjectApiConstants.PROJECT_GROUP,
       ProjectApiConstants.AIPUB_GROUP,
       ProjectApiConstants.COASTER_GROUP);
+
+  /**
+   * CRD 와 동일한 소유권 메커니즘을 적용하는 네이티브 네임스페이스 리소스.
+   * 낙인 웹훅이 이미 CREATE 를 인터셉트하는 타입만 넣는다(레이블이 없으면 추적이 무의미).
+   * pods/replicasets 는 상위 워크로드가 만들어내는 파생 오브젝트라 제외(개인 Role 비대 방지,
+   * 삭제는 부모 삭제로 캐스케이드). jobs/cronjobs 는 기존 정적 경로가 담당한다.
+   */
+  public static final List<ResourceTarget> NATIVE_OWNED_TARGETS = List.of(
+      new ResourceTarget("", "v1", "configmaps", true),
+      new ResourceTarget("", "v1", "secrets", true),
+      new ResourceTarget("", "v1", "services", true),
+      new ResourceTarget("", "v1", "persistentvolumeclaims", true),
+      new ResourceTarget("", "v1", "replicationcontrollers", true),
+      new ResourceTarget("apps", "v1", "deployments", true),
+      new ResourceTarget("apps", "v1", "statefulsets", true),
+      new ResourceTarget("apps", "v1", "daemonsets", true),
+      new ResourceTarget("networking.k8s.io", "v1", "ingresses", true));
 
   private DynamicCrConstants() {
   }

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/DynamicCrConstants.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/DynamicCrConstants.java
@@ -1,0 +1,21 @@
+package io.ten1010.aipub.projectcontroller.domain.k8s;
+
+import java.util.Set;
+
+public final class DynamicCrConstants {
+
+  /**
+   * 동적 CR 소유권 처리(레이블 낙인 웹훅 rules, 개인 Role/ClusterRole 규칙 생성)에서 제외하는
+   * 플랫폼 컨트롤 플레인 그룹. aipub.ten1010.io 의 워크로드 타입은 기존 정적 경로
+   * (WorkloadResourceResolver + AipubUserRoleReconciler)가 담당하며, 나머지 타입(검증·리뷰류)은
+   * 생성 즉시 GC 되는 일시 오브젝트라 소유권 규칙 대상이 아니다.
+   */
+  public static final Set<String> EXCLUDED_GROUPS = Set.of(
+      ProjectApiConstants.PROJECT_GROUP,
+      ProjectApiConstants.AIPUB_GROUP,
+      ProjectApiConstants.COASTER_GROUP);
+
+  private DynamicCrConstants() {
+  }
+
+}

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/DynamicCrConstants.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/DynamicCrConstants.java
@@ -18,9 +18,14 @@ public final class DynamicCrConstants {
 
   /**
    * CRD 와 동일한 소유권 메커니즘을 적용하는 네이티브 네임스페이스 리소스.
-   * 낙인 웹훅이 이미 CREATE 를 인터셉트하는 타입만 넣는다(레이블이 없으면 추적이 무의미).
-   * pods/replicasets 는 상위 워크로드가 만들어내는 파생 오브젝트라 제외(개인 Role 비대 방지,
-   * 삭제는 부모 삭제로 캐스케이드). jobs/cronjobs 는 기존 정적 경로가 담당한다.
+   * 선정 기준: (1) 멤버 Role 이 create 를 허용하고 (2) 사용자가 직접 관리하는 오브젝트이며
+   * (3) 낙인 웹훅이 CREATE 를 인터셉트하는 타입. 이 기준에 따라
+   * 시스템 파생물(events/endpoints/endpointslices/leases/controllerrevisions)과
+   * 워크로드 파생물(pods/replicasets — 개인 Role 비대 방지, 삭제는 부모 삭제로 캐스케이드),
+   * 멤버가 생성 불가한 타입(networkpolicies/resourcequotas/roles 등)은 제외한다.
+   * jobs/cronjobs 는 기존 정적 경로가 담당한다.
+   * 목록 추가 시 낙인 웹훅 rules(UserLabelWebhookConfigurationReconciler.baseRules,
+   * mutating-webhook-user-v2.yaml)가 해당 타입을 커버하는지 함께 확인할 것.
    */
   public static final List<ResourceTarget> NATIVE_OWNED_TARGETS = List.of(
       new ResourceTarget("", "v1", "configmaps", true),
@@ -28,10 +33,14 @@ public final class DynamicCrConstants {
       new ResourceTarget("", "v1", "services", true),
       new ResourceTarget("", "v1", "persistentvolumeclaims", true),
       new ResourceTarget("", "v1", "replicationcontrollers", true),
+      new ResourceTarget("", "v1", "serviceaccounts", true),
+      new ResourceTarget("", "v1", "limitranges", true),
       new ResourceTarget("apps", "v1", "deployments", true),
       new ResourceTarget("apps", "v1", "statefulsets", true),
       new ResourceTarget("apps", "v1", "daemonsets", true),
-      new ResourceTarget("networking.k8s.io", "v1", "ingresses", true));
+      new ResourceTarget("networking.k8s.io", "v1", "ingresses", true),
+      new ResourceTarget("autoscaling", "v2", "horizontalpodautoscalers", true),
+      new ResourceTarget("policy", "v1", "poddisruptionbudgets", true));
 
   private DynamicCrConstants() {
   }

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/OwnedCrObject.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/OwnedCrObject.java
@@ -1,0 +1,7 @@
+package io.ten1010.aipub.projectcontroller.domain.k8s;
+
+/**
+ * 사용자 소유(username 레이블) CR 오브젝트의 개인 Role/ClusterRole 규칙 생성용 식별자.
+ */
+public record OwnedCrObject(String group, String resource, String name) {
+}

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationService.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationService.java
@@ -62,6 +62,8 @@ public class ReconciliationService {
 
   private static final List<String> BASIC_VERBS = List.of("create", "get", "watch", "list");
   private static final List<String> UPDATABLE_VERBS = List.of("update", "patch", "delete");
+  // 임의 CRD 의 소유 CR 은 멤버 Role 에 조회 권한이 없으므로 get 까지 개인 규칙에 포함한다
+  private static final List<String> OWNED_CR_VERBS = List.of("get", "update", "patch", "delete");
   private final SubjectResolver subjectResolver;
   private final DockerConfigJsonResolver dockerConfigJsonResolver;
   private final RoleNameResolver roleNameResolver;
@@ -565,6 +567,15 @@ public class ReconciliationService {
         userWorkspaceReclaims);
   }
 
+  public List<V1PolicyRule> reconcileClusterRoleRules(V1alpha1AipubUser aipubUser,
+      List<OwnedCrObject> ownedCrObjects) {
+    List<V1PolicyRule> reconciled = new ArrayList<>(reconcileClusterRoleRules(aipubUser));
+    for (OwnedCrObject ownedCrObject : ownedCrObjects) {
+      reconciled.add(buildOwnedCrRoleRule(ownedCrObject));
+    }
+    return reconciled;
+  }
+
   @Nullable
   public V1AggregationRule reconcileClusterRoleAggregationRule(V1alpha1Project project,
       ProjectRoleEnum projectRoleEnum) {
@@ -828,6 +839,19 @@ public class ReconciliationService {
 
     ArrayList<V1PolicyRule> reconciledRules = new ArrayList<>();
     reconciledRules.addAll(workloadRules);
+    return reconciledRules;
+  }
+
+  public List<V1PolicyRule> reconcileAipubUserRoleRules(
+      V1alpha1AipubUser aipubUser,
+      V1alpha1Project project,
+      List<KubernetesObject> workloads,
+      List<OwnedCrObject> ownedCrObjects) {
+    List<V1PolicyRule> reconciledRules = new ArrayList<>(
+        reconcileAipubUserRoleRules(aipubUser, project, workloads));
+    for (OwnedCrObject ownedCrObject : ownedCrObjects) {
+      reconciledRules.add(buildOwnedCrRoleRule(ownedCrObject));
+    }
     return reconciledRules;
   }
 
@@ -1150,6 +1174,14 @@ public class ReconciliationService {
         .withResources(resource)
         .withVerbs(UPDATABLE_VERBS)
         .withResourceNames(resourceName)
+        .build();
+  }
+
+  private V1PolicyRule buildOwnedCrRoleRule(OwnedCrObject ownedCrObject) {
+    return new V1PolicyRuleBuilder().withApiGroups(ownedCrObject.group())
+        .withResources(ownedCrObject.resource())
+        .withVerbs(OWNED_CR_VERBS)
+        .withResourceNames(ownedCrObject.name())
         .build();
   }
 

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ResourceTarget.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ResourceTarget.java
@@ -1,0 +1,8 @@
+package io.ten1010.aipub.projectcontroller.domain.k8s;
+
+/**
+ * 소유권 추적 대상 리소스 타입 식별자 (CRD 유래 또는 네이티브 고정 목록).
+ * group 이 빈 문자열이면 core API 그룹.
+ */
+public record ResourceTarget(String group, String version, String plural, boolean namespaced) {
+}

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/dto/V1PartialObject.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/dto/V1PartialObject.java
@@ -1,0 +1,22 @@
+package io.ten1010.aipub.projectcontroller.domain.k8s.dto;
+
+import io.kubernetes.client.common.KubernetesObject;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import lombok.Data;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * 임의 CR 을 타입 정의 없이 메타데이터만으로 다루기 위한 부분 오브젝트.
+ * spec/status 등 나머지 필드는 역직렬화 시 무시된다.
+ */
+@Data
+public class V1PartialObject implements KubernetesObject {
+
+  @Nullable
+  private String apiVersion;
+  @Nullable
+  private String kind;
+  @Nullable
+  private V1ObjectMeta metadata;
+
+}

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/dto/V1PartialObjectList.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/dto/V1PartialObjectList.java
@@ -1,0 +1,21 @@
+package io.ten1010.aipub.projectcontroller.domain.k8s.dto;
+
+import io.kubernetes.client.common.KubernetesListObject;
+import io.kubernetes.client.openapi.models.V1ListMeta;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Data;
+import org.jspecify.annotations.Nullable;
+
+@Data
+public class V1PartialObjectList implements KubernetesListObject {
+
+  @Nullable
+  private String apiVersion;
+  @Nullable
+  private String kind;
+  @Nullable
+  private V1ListMeta metadata;
+  private List<V1PartialObject> items = new ArrayList<>();
+
+}

--- a/src/main/java/io/ten1010/aipub/projectcontroller/informer/SharedInformerFactoryProvider.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/informer/SharedInformerFactoryProvider.java
@@ -3,6 +3,8 @@ package io.ten1010.aipub.projectcontroller.informer;
 import io.kubernetes.client.informer.SharedIndexInformer;
 import io.kubernetes.client.informer.SharedInformerFactory;
 import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.apis.AdmissionregistrationV1Api;
+import io.kubernetes.client.openapi.apis.ApiextensionsV1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.apis.RbacAuthorizationV1Api;
 import io.kubernetes.client.openapi.models.V1ClusterRole;
@@ -10,6 +12,10 @@ import io.kubernetes.client.openapi.models.V1ClusterRoleBinding;
 import io.kubernetes.client.openapi.models.V1ClusterRoleBindingList;
 import io.kubernetes.client.openapi.models.RbacV1Subject;
 import io.kubernetes.client.openapi.models.V1ClusterRoleList;
+import io.kubernetes.client.openapi.models.V1CustomResourceDefinition;
+import io.kubernetes.client.openapi.models.V1CustomResourceDefinitionList;
+import io.kubernetes.client.openapi.models.V1MutatingWebhookConfiguration;
+import io.kubernetes.client.openapi.models.V1MutatingWebhookConfigurationList;
 import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1NamespaceList;
 import io.kubernetes.client.openapi.models.V1Node;
@@ -87,6 +93,8 @@ public class SharedInformerFactoryProvider {
     registerSftpServerInformer(informerFactory);
     registerImageBuildInformer(informerFactory);
     registerPodInformer(informerFactory);
+    registerCustomResourceDefinitionInformer(informerFactory);
+    registerMutatingWebhookConfigurationInformer(informerFactory);
     this.registrars.forEach(e -> e.registerInformer(informerFactory));
 
     return informerFactory;
@@ -369,6 +377,33 @@ public class SharedInformerFactoryProvider {
     informer.addIndexers(Map.of(
         IndexerConstants.NAMESPACE_TO_OBJECTS_INDEXER_NAME,
         obj -> List.of(K8sObjectUtils.getNamespace(obj))));
+  }
+
+  private void registerCustomResourceDefinitionInformer(SharedInformerFactory informerFactory) {
+    ApiClient apiClient = this.k8sApiProvider.getApiClient();
+    informerFactory.sharedIndexInformerFor(
+        (CallGeneratorParams params) -> new ApiextensionsV1Api(
+            apiClient).listCustomResourceDefinition()
+            .resourceVersion(params.resourceVersion)
+            .watch(params.watch)
+            .timeoutSeconds(params.timeoutSeconds)
+            .buildCall(null),
+        V1CustomResourceDefinition.class,
+        V1CustomResourceDefinitionList.class);
+  }
+
+  private void registerMutatingWebhookConfigurationInformer(
+      SharedInformerFactory informerFactory) {
+    ApiClient apiClient = this.k8sApiProvider.getApiClient();
+    informerFactory.sharedIndexInformerFor(
+        (CallGeneratorParams params) -> new AdmissionregistrationV1Api(
+            apiClient).listMutatingWebhookConfiguration()
+            .resourceVersion(params.resourceVersion)
+            .watch(params.watch)
+            .timeoutSeconds(params.timeoutSeconds)
+            .buildCall(null),
+        V1MutatingWebhookConfiguration.class,
+        V1MutatingWebhookConfigurationList.class);
   }
 
   private void registerPodInformer(SharedInformerFactory informerFactory) {

--- a/src/main/java/io/ten1010/aipub/projectcontroller/informer/dynamic/DynamicCrInformerManager.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/informer/dynamic/DynamicCrInformerManager.java
@@ -1,0 +1,294 @@
+package io.ten1010.aipub.projectcontroller.informer.dynamic;
+
+import io.kubernetes.client.extended.controller.reconciler.Request;
+import io.kubernetes.client.extended.workqueue.WorkQueue;
+import io.kubernetes.client.informer.ResourceEventHandler;
+import io.kubernetes.client.informer.SharedIndexInformer;
+import io.kubernetes.client.informer.SharedInformerFactory;
+import io.kubernetes.client.informer.cache.Indexer;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.apis.CustomObjectsApi;
+import io.kubernetes.client.openapi.models.V1ClusterRole;
+import io.kubernetes.client.openapi.models.V1CustomResourceDefinition;
+import io.kubernetes.client.openapi.models.V1CustomResourceDefinitionSpec;
+import io.kubernetes.client.openapi.models.V1CustomResourceDefinitionVersion;
+import io.kubernetes.client.openapi.models.V1Role;
+import io.kubernetes.client.util.CallGeneratorParams;
+import io.ten1010.aipub.projectcontroller.domain.k8s.AipubUserRoleNameResolver;
+import io.ten1010.aipub.projectcontroller.domain.k8s.DynamicCrConstants;
+import io.ten1010.aipub.projectcontroller.domain.k8s.LabelConstants;
+import io.ten1010.aipub.projectcontroller.domain.k8s.OwnedCrObject;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1PartialObject;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1PartialObjectList;
+import io.ten1010.aipub.projectcontroller.domain.k8s.util.K8sObjectUtils;
+import io.ten1010.aipub.projectcontroller.domain.k8s.util.UsernameUtils;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * CRD 를 워치하여 CRD 마다 username 레이블 셀렉터가 걸린 메타데이터 전용 동적 인포머를 기동/중지하고,
+ * 소유 CR 변화를 개인 Role/ClusterRole 리컨실 큐로 라우팅한다. 리컨실러는 이 매니저를 통해
+ * 사용자별 소유 CR 목록을 조회하여 resourceNames 기반 RBAC 규칙을 생성한다.
+ */
+@Slf4j
+public class DynamicCrInformerManager {
+
+  record CrdTarget(String group, String version, String plural, boolean namespaced) {
+  }
+
+  private record TrackedCrd(CrdTarget target, SharedInformerFactory informerFactory,
+      SharedIndexInformer<V1PartialObject> informer) {
+  }
+
+  private final ApiClient apiClient;
+  private final AipubUserRoleNameResolver roleNameResolver;
+  private final Indexer<V1Role> roleIndexer;
+  private final Indexer<V1ClusterRole> clusterRoleIndexer;
+  private final Map<String, TrackedCrd> trackedCrds;
+
+  @Setter
+  private volatile WorkQueue<Request> aipubUserRoleWorkQueue;
+  @Setter
+  private volatile WorkQueue<Request> aipubUserClusterRoleWorkQueue;
+
+  public DynamicCrInformerManager(ApiClient apiClient,
+      SharedInformerFactory sharedInformerFactory) {
+    this.apiClient = apiClient;
+    this.roleNameResolver = new AipubUserRoleNameResolver();
+    this.roleIndexer = sharedInformerFactory
+        .getExistingSharedIndexInformer(V1Role.class)
+        .getIndexer();
+    this.clusterRoleIndexer = sharedInformerFactory
+        .getExistingSharedIndexInformer(V1ClusterRole.class)
+        .getIndexer();
+    this.trackedCrds = new ConcurrentHashMap<>();
+    sharedInformerFactory.getExistingSharedIndexInformer(V1CustomResourceDefinition.class)
+        .addEventHandler(new ResourceEventHandler<>() {
+
+          @Override
+          public void onAdd(V1CustomResourceDefinition obj) {
+            track(obj);
+          }
+
+          @Override
+          public void onUpdate(V1CustomResourceDefinition oldObj,
+              V1CustomResourceDefinition newObj) {
+            track(newObj);
+          }
+
+          @Override
+          public void onDelete(V1CustomResourceDefinition obj, boolean deletedFinalStateUnknown) {
+            untrack(obj);
+          }
+
+        });
+  }
+
+  public List<OwnedCrObject> getNamespacedOwnedObjects(String namespace, String aipubUserName) {
+    return getOwnedObjects(true, obj -> namespace.equals(resolveNamespace(obj)), aipubUserName);
+  }
+
+  public List<OwnedCrObject> getClusterOwnedObjects(String aipubUserName) {
+    return getOwnedObjects(false, obj -> true, aipubUserName);
+  }
+
+  private List<OwnedCrObject> getOwnedObjects(boolean namespaced,
+      Predicate<V1PartialObject> filter, String aipubUserName) {
+    List<OwnedCrObject> owned = new ArrayList<>();
+    for (TrackedCrd tracked : this.trackedCrds.values()) {
+      if (tracked.target().namespaced() != namespaced) {
+        continue;
+      }
+      for (V1PartialObject obj : tracked.informer().getIndexer().list()) {
+        if (!filter.test(obj)) {
+          continue;
+        }
+        if (UsernameUtils.getUsername(obj).filter(aipubUserName::equals).isEmpty()) {
+          continue;
+        }
+        owned.add(new OwnedCrObject(tracked.target().group(), tracked.target().plural(),
+            K8sObjectUtils.getName(obj)));
+      }
+    }
+    // reconcileExistingRole 이 규칙 리스트를 equals 로 비교하므로 순서가 결정적이어야 한다
+    owned.sort(Comparator.comparing(OwnedCrObject::group)
+        .thenComparing(OwnedCrObject::resource)
+        .thenComparing(OwnedCrObject::name));
+    return owned;
+  }
+
+  static Optional<CrdTarget> resolveTarget(V1CustomResourceDefinition crd) {
+    V1CustomResourceDefinitionSpec spec = crd.getSpec();
+    if (spec == null || spec.getGroup() == null || spec.getNames() == null
+        || spec.getNames().getPlural() == null) {
+      return Optional.empty();
+    }
+    if (DynamicCrConstants.EXCLUDED_GROUPS.contains(spec.getGroup())) {
+      return Optional.empty();
+    }
+    List<V1CustomResourceDefinitionVersion> versions =
+        spec.getVersions() == null ? List.of() : spec.getVersions();
+    Optional<String> versionOpt = versions.stream()
+        .filter(v -> Boolean.TRUE.equals(v.getStorage()))
+        .map(V1CustomResourceDefinitionVersion::getName)
+        .findFirst()
+        .or(() -> versions.stream()
+            .filter(v -> Boolean.TRUE.equals(v.getServed()))
+            .map(V1CustomResourceDefinitionVersion::getName)
+            .findFirst());
+    return versionOpt.map(version -> new CrdTarget(
+        spec.getGroup(),
+        version,
+        spec.getNames().getPlural(),
+        "Namespaced".equals(spec.getScope())));
+  }
+
+  private static String trackingKey(String group, String plural) {
+    return group + "/" + plural;
+  }
+
+  private synchronized void track(V1CustomResourceDefinition crd) {
+    Optional<CrdTarget> targetOpt = resolveTarget(crd);
+    if (targetOpt.isEmpty()) {
+      return;
+    }
+    CrdTarget target = targetOpt.get();
+    String key = trackingKey(target.group(), target.plural());
+    TrackedCrd existing = this.trackedCrds.get(key);
+    if (existing != null) {
+      if (existing.target().equals(target)) {
+        return;
+      }
+      stopTracking(key, existing);
+    }
+    startTracking(key, target);
+  }
+
+  private synchronized void untrack(V1CustomResourceDefinition crd) {
+    V1CustomResourceDefinitionSpec spec = crd.getSpec();
+    if (spec == null || spec.getGroup() == null || spec.getNames() == null
+        || spec.getNames().getPlural() == null) {
+      return;
+    }
+    String key = trackingKey(spec.getGroup(), spec.getNames().getPlural());
+    TrackedCrd tracked = this.trackedCrds.get(key);
+    if (tracked == null) {
+      return;
+    }
+    stopTracking(key, tracked);
+  }
+
+  private void startTracking(String key, CrdTarget target) {
+    SharedInformerFactory informerFactory = new SharedInformerFactory(this.apiClient);
+    SharedIndexInformer<V1PartialObject> informer = informerFactory.sharedIndexInformerFor(
+        (CallGeneratorParams params) -> new CustomObjectsApi(this.apiClient)
+            .listClusterCustomObject(target.group(), target.version(), target.plural())
+            .labelSelector(LabelConstants.OBJECT_OWN_USERNAME_KEY)
+            .resourceVersion(params.resourceVersion)
+            .watch(params.watch)
+            .timeoutSeconds(params.timeoutSeconds)
+            .buildCall(null),
+        V1PartialObject.class,
+        V1PartialObjectList.class);
+    informer.addEventHandler(new ResourceEventHandler<>() {
+
+      @Override
+      public void onAdd(V1PartialObject obj) {
+        enqueueOwnerRole(target, obj);
+      }
+
+      @Override
+      public void onUpdate(V1PartialObject oldObj, V1PartialObject newObj) {
+        enqueueOwnerRole(target, oldObj);
+        enqueueOwnerRole(target, newObj);
+      }
+
+      @Override
+      public void onDelete(V1PartialObject obj, boolean deletedFinalStateUnknown) {
+        enqueueOwnerRole(target, obj);
+      }
+
+    });
+    this.trackedCrds.put(key, new TrackedCrd(target, informerFactory, informer));
+    informerFactory.startAllRegisteredInformers();
+    log.info("Started dynamic CR informer: group={}, version={}, plural={}, namespaced={}",
+        target.group(), target.version(), target.plural(), target.namespaced());
+  }
+
+  private void stopTracking(String key, TrackedCrd tracked) {
+    this.trackedCrds.remove(key);
+    tracked.informerFactory().stopAllRegisteredInformers();
+    enqueueAllPersonalRoles(tracked.target().namespaced());
+    log.info("Stopped dynamic CR informer: {}", key);
+  }
+
+  private void enqueueOwnerRole(CrdTarget target, V1PartialObject obj) {
+    Optional<String> usernameOpt = UsernameUtils.getUsername(obj);
+    if (usernameOpt.isEmpty()) {
+      return;
+    }
+    String roleName;
+    try {
+      roleName = this.roleNameResolver.resolveRoleName(usernameOpt.get());
+    } catch (IllegalArgumentException e) {
+      log.warn("Invalid username label value: {}", usernameOpt.get());
+      return;
+    }
+    if (target.namespaced()) {
+      WorkQueue<Request> queue = this.aipubUserRoleWorkQueue;
+      String namespace = resolveNamespace(obj);
+      if (queue == null || namespace == null) {
+        return;
+      }
+      queue.add(new Request(namespace, roleName));
+    } else {
+      WorkQueue<Request> queue = this.aipubUserClusterRoleWorkQueue;
+      if (queue == null) {
+        return;
+      }
+      queue.add(new Request(roleName));
+    }
+  }
+
+  private void enqueueAllPersonalRoles(boolean namespaced) {
+    if (namespaced) {
+      WorkQueue<Request> queue = this.aipubUserRoleWorkQueue;
+      if (queue == null) {
+        return;
+      }
+      for (V1Role role : this.roleIndexer.list()) {
+        String name = K8sObjectUtils.getName(role);
+        if (this.roleNameResolver.resolveAipubUserName(name).isEmpty()) {
+          continue;
+        }
+        queue.add(new Request(K8sObjectUtils.getNamespace(role), name));
+      }
+    } else {
+      WorkQueue<Request> queue = this.aipubUserClusterRoleWorkQueue;
+      if (queue == null) {
+        return;
+      }
+      for (V1ClusterRole role : this.clusterRoleIndexer.list()) {
+        String name = K8sObjectUtils.getName(role);
+        if (this.roleNameResolver.resolveAipubUserName(name).isEmpty()) {
+          continue;
+        }
+        queue.add(new Request(name));
+      }
+    }
+  }
+
+  @Nullable
+  private static String resolveNamespace(V1PartialObject obj) {
+    return obj.getMetadata() == null ? null : obj.getMetadata().getNamespace();
+  }
+
+}

--- a/src/main/java/io/ten1010/aipub/projectcontroller/informer/dynamic/DynamicCrInformerManager.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/informer/dynamic/DynamicCrInformerManager.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Predicate;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Call;
@@ -45,6 +44,13 @@ import org.jspecify.annotations.Nullable;
  */
 @Slf4j
 public class DynamicCrInformerManager {
+
+  /**
+   * 소유자 → 오브젝트 인덱스. 네임스페이스 타입은 "{namespace}/{username}",
+   * 클러스터 타입은 "{username}" 을 키로 사용한다. 이벤트 한 건이 트리거하는 리컨실이
+   * 전체 캐시 풀스캔 없이 해당 소유자의 오브젝트만 O(1) 로 조회하기 위한 것이다.
+   */
+  private static final String OWNER_TO_OBJECTS_INDEXER_NAME = "OWNER_TO_OBJECTS";
 
   private record TrackedTarget(ResourceTarget target, SharedInformerFactory informerFactory,
       SharedIndexInformer<V1PartialObject> informer) {
@@ -72,9 +78,6 @@ public class DynamicCrInformerManager {
         .getExistingSharedIndexInformer(V1ClusterRole.class)
         .getIndexer();
     this.trackedTargets = new ConcurrentHashMap<>();
-    for (ResourceTarget nativeTarget : DynamicCrConstants.NATIVE_OWNED_TARGETS) {
-      startTracking(trackingKey(nativeTarget.group(), nativeTarget.plural()), nativeTarget);
-    }
     sharedInformerFactory.getExistingSharedIndexInformer(V1CustomResourceDefinition.class)
         .addEventHandler(new ResourceEventHandler<>() {
 
@@ -97,28 +100,46 @@ public class DynamicCrInformerManager {
         });
   }
 
+  /**
+   * 네이티브 대상 추적을 시작한다. 인포머의 초기 onAdd 이벤트가 유실되지 않도록
+   * 개인 Role/ClusterRole 컨트롤러의 워크큐 등록이 끝난 뒤에 호출해야 한다
+   * (생성자에서 시작하면 큐 등록 전 이벤트가 버려져, 기동 초기 리컨실이 지운 규칙을
+   * 되살릴 트리거가 사라진다).
+   */
+  public synchronized void start() {
+    for (ResourceTarget nativeTarget : DynamicCrConstants.NATIVE_OWNED_TARGETS) {
+      String key = trackingKey(nativeTarget.group(), nativeTarget.plural());
+      if (!this.trackedTargets.containsKey(key)) {
+        startTracking(key, nativeTarget);
+      }
+    }
+  }
+
+  /**
+   * 모든 개인 Role/ClusterRole 을 재큐잉하는 주기 백스톱. 이벤트 경로가 어떤 이유로든
+   * 유실되어도(기동 레이스, 예기치 못한 드리프트) 다음 주기에 수렴을 보장한다.
+   */
+  public void resweepPersonalRoles() {
+    enqueueAllPersonalRoles(true);
+    enqueueAllPersonalRoles(false);
+  }
+
   public List<OwnedCrObject> getNamespacedOwnedObjects(String namespace, String aipubUserName) {
-    return getOwnedObjects(true, obj -> namespace.equals(resolveNamespace(obj)), aipubUserName);
+    return getOwnedObjects(true, ownerIndexKey(namespace, aipubUserName));
   }
 
   public List<OwnedCrObject> getClusterOwnedObjects(String aipubUserName) {
-    return getOwnedObjects(false, obj -> true, aipubUserName);
+    return getOwnedObjects(false, aipubUserName);
   }
 
-  private List<OwnedCrObject> getOwnedObjects(boolean namespaced,
-      Predicate<V1PartialObject> filter, String aipubUserName) {
+  private List<OwnedCrObject> getOwnedObjects(boolean namespaced, String ownerIndexKey) {
     List<OwnedCrObject> owned = new ArrayList<>();
     for (TrackedTarget tracked : this.trackedTargets.values()) {
       if (tracked.target().namespaced() != namespaced) {
         continue;
       }
-      for (V1PartialObject obj : tracked.informer().getIndexer().list()) {
-        if (!filter.test(obj)) {
-          continue;
-        }
-        if (UsernameUtils.getUsername(obj).filter(aipubUserName::equals).isEmpty()) {
-          continue;
-        }
+      for (V1PartialObject obj : tracked.informer().getIndexer()
+          .byIndex(OWNER_TO_OBJECTS_INDEXER_NAME, ownerIndexKey)) {
         owned.add(new OwnedCrObject(tracked.target().group(), tracked.target().plural(),
             K8sObjectUtils.getName(obj)));
       }
@@ -128,6 +149,10 @@ public class DynamicCrInformerManager {
         .thenComparing(OwnedCrObject::resource)
         .thenComparing(OwnedCrObject::name));
     return owned;
+  }
+
+  private static String ownerIndexKey(String namespace, String aipubUserName) {
+    return namespace + "/" + aipubUserName;
   }
 
   static Optional<ResourceTarget> resolveTarget(V1CustomResourceDefinition crd) {
@@ -197,6 +222,19 @@ public class DynamicCrInformerManager {
         (CallGeneratorParams params) -> buildListCall(target, params),
         V1PartialObject.class,
         V1PartialObjectList.class);
+    informer.addIndexers(Map.of(
+        OWNER_TO_OBJECTS_INDEXER_NAME,
+        obj -> UsernameUtils.getUsername(obj)
+            .map(username -> {
+              if (!target.namespaced()) {
+                return List.of(username);
+              }
+              String namespace = resolveNamespace(obj);
+              return namespace == null
+                  ? List.<String>of()
+                  : List.of(ownerIndexKey(namespace, username));
+            })
+            .orElse(List.of())));
     informer.addEventHandler(new ResourceEventHandler<>() {
 
       @Override
@@ -206,6 +244,11 @@ public class DynamicCrInformerManager {
 
       @Override
       public void onUpdate(V1PartialObject oldObj, V1PartialObject newObj) {
+        // 소유권 규칙은 (소유자, 오브젝트 이름)에만 의존하므로, username 레이블이
+        // 안 바뀐 update(status 갱신 등)는 리컨실을 트리거할 이유가 없다
+        if (UsernameUtils.getUsername(oldObj).equals(UsernameUtils.getUsername(newObj))) {
+          return;
+        }
         enqueueOwnerRole(target, oldObj);
         enqueueOwnerRole(target, newObj);
       }

--- a/src/main/java/io/ten1010/aipub/projectcontroller/informer/dynamic/DynamicCrInformerManager.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/informer/dynamic/DynamicCrInformerManager.java
@@ -199,6 +199,9 @@ public class DynamicCrInformerManager {
       }
       stopTracking(key, existing);
     }
+    log.info("Detected CRD: name={}, group={}, version={}, plural={}, namespaced={}",
+        K8sObjectUtils.getName(crd), target.group(), target.version(), target.plural(),
+        target.namespaced());
     startTracking(key, target);
   }
 
@@ -213,6 +216,7 @@ public class DynamicCrInformerManager {
     if (tracked == null) {
       return;
     }
+    log.info("Removed CRD: name={}, key={}", K8sObjectUtils.getName(crd), key);
     stopTracking(key, tracked);
   }
 
@@ -239,6 +243,9 @@ public class DynamicCrInformerManager {
 
       @Override
       public void onAdd(V1PartialObject obj) {
+        log.info("Owned object created: group={}, resource={}, namespace={}, name={}, owner={}",
+            target.group(), target.plural(), resolveNamespace(obj), K8sObjectUtils.getName(obj),
+            UsernameUtils.getUsername(obj).orElse(""));
         enqueueOwnerRole(target, obj);
       }
 
@@ -249,12 +256,21 @@ public class DynamicCrInformerManager {
         if (UsernameUtils.getUsername(oldObj).equals(UsernameUtils.getUsername(newObj))) {
           return;
         }
+        log.info("Owned object ownership changed: group={}, resource={}, namespace={}, name={}, "
+                + "previousOwner={}, owner={}",
+            target.group(), target.plural(), resolveNamespace(newObj),
+            K8sObjectUtils.getName(newObj),
+            UsernameUtils.getUsername(oldObj).orElse(""),
+            UsernameUtils.getUsername(newObj).orElse(""));
         enqueueOwnerRole(target, oldObj);
         enqueueOwnerRole(target, newObj);
       }
 
       @Override
       public void onDelete(V1PartialObject obj, boolean deletedFinalStateUnknown) {
+        log.info("Owned object deleted: group={}, resource={}, namespace={}, name={}, owner={}",
+            target.group(), target.plural(), resolveNamespace(obj), K8sObjectUtils.getName(obj),
+            UsernameUtils.getUsername(obj).orElse(""));
         enqueueOwnerRole(target, obj);
       }
 

--- a/src/main/java/io/ten1010/aipub/projectcontroller/informer/dynamic/DynamicCrInformerManager.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/informer/dynamic/DynamicCrInformerManager.java
@@ -7,7 +7,7 @@ import io.kubernetes.client.informer.SharedIndexInformer;
 import io.kubernetes.client.informer.SharedInformerFactory;
 import io.kubernetes.client.informer.cache.Indexer;
 import io.kubernetes.client.openapi.ApiClient;
-import io.kubernetes.client.openapi.apis.CustomObjectsApi;
+import io.kubernetes.client.openapi.Pair;
 import io.kubernetes.client.openapi.models.V1ClusterRole;
 import io.kubernetes.client.openapi.models.V1CustomResourceDefinition;
 import io.kubernetes.client.openapi.models.V1CustomResourceDefinitionSpec;
@@ -18,6 +18,7 @@ import io.ten1010.aipub.projectcontroller.domain.k8s.AipubUserRoleNameResolver;
 import io.ten1010.aipub.projectcontroller.domain.k8s.DynamicCrConstants;
 import io.ten1010.aipub.projectcontroller.domain.k8s.LabelConstants;
 import io.ten1010.aipub.projectcontroller.domain.k8s.OwnedCrObject;
+import io.ten1010.aipub.projectcontroller.domain.k8s.ResourceTarget;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1PartialObject;
 import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1PartialObjectList;
 import io.ten1010.aipub.projectcontroller.domain.k8s.util.K8sObjectUtils;
@@ -31,20 +32,21 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.Call;
 import org.jspecify.annotations.Nullable;
 
 /**
- * CRD 를 워치하여 CRD 마다 username 레이블 셀렉터가 걸린 메타데이터 전용 동적 인포머를 기동/중지하고,
- * 소유 CR 변화를 개인 Role/ClusterRole 리컨실 큐로 라우팅한다. 리컨실러는 이 매니저를 통해
- * 사용자별 소유 CR 목록을 조회하여 resourceNames 기반 RBAC 규칙을 생성한다.
+ * 소유권 추적 대상 리소스 타입마다 username 레이블 셀렉터가 걸린 메타데이터 전용 인포머를
+ * 기동/중지하고, 소유 오브젝트 변화를 개인 Role/ClusterRole 리컨실 큐로 라우팅한다.
+ * 대상은 두 종류다: CRD 워치로 발견되는 임의 CR 타입(생성/삭제에 따라 동적 기동/중지)과
+ * {@link DynamicCrConstants#NATIVE_OWNED_TARGETS} 의 네이티브 타입(기동 시 상시 추적).
+ * 리컨실러는 이 매니저를 통해 사용자별 소유 오브젝트 목록을 조회하여 resourceNames 기반
+ * RBAC 규칙을 생성한다.
  */
 @Slf4j
 public class DynamicCrInformerManager {
 
-  record CrdTarget(String group, String version, String plural, boolean namespaced) {
-  }
-
-  private record TrackedCrd(CrdTarget target, SharedInformerFactory informerFactory,
+  private record TrackedTarget(ResourceTarget target, SharedInformerFactory informerFactory,
       SharedIndexInformer<V1PartialObject> informer) {
   }
 
@@ -52,7 +54,7 @@ public class DynamicCrInformerManager {
   private final AipubUserRoleNameResolver roleNameResolver;
   private final Indexer<V1Role> roleIndexer;
   private final Indexer<V1ClusterRole> clusterRoleIndexer;
-  private final Map<String, TrackedCrd> trackedCrds;
+  private final Map<String, TrackedTarget> trackedTargets;
 
   @Setter
   private volatile WorkQueue<Request> aipubUserRoleWorkQueue;
@@ -69,7 +71,10 @@ public class DynamicCrInformerManager {
     this.clusterRoleIndexer = sharedInformerFactory
         .getExistingSharedIndexInformer(V1ClusterRole.class)
         .getIndexer();
-    this.trackedCrds = new ConcurrentHashMap<>();
+    this.trackedTargets = new ConcurrentHashMap<>();
+    for (ResourceTarget nativeTarget : DynamicCrConstants.NATIVE_OWNED_TARGETS) {
+      startTracking(trackingKey(nativeTarget.group(), nativeTarget.plural()), nativeTarget);
+    }
     sharedInformerFactory.getExistingSharedIndexInformer(V1CustomResourceDefinition.class)
         .addEventHandler(new ResourceEventHandler<>() {
 
@@ -103,7 +108,7 @@ public class DynamicCrInformerManager {
   private List<OwnedCrObject> getOwnedObjects(boolean namespaced,
       Predicate<V1PartialObject> filter, String aipubUserName) {
     List<OwnedCrObject> owned = new ArrayList<>();
-    for (TrackedCrd tracked : this.trackedCrds.values()) {
+    for (TrackedTarget tracked : this.trackedTargets.values()) {
       if (tracked.target().namespaced() != namespaced) {
         continue;
       }
@@ -125,7 +130,7 @@ public class DynamicCrInformerManager {
     return owned;
   }
 
-  static Optional<CrdTarget> resolveTarget(V1CustomResourceDefinition crd) {
+  static Optional<ResourceTarget> resolveTarget(V1CustomResourceDefinition crd) {
     V1CustomResourceDefinitionSpec spec = crd.getSpec();
     if (spec == null || spec.getGroup() == null || spec.getNames() == null
         || spec.getNames().getPlural() == null) {
@@ -144,7 +149,7 @@ public class DynamicCrInformerManager {
             .filter(v -> Boolean.TRUE.equals(v.getServed()))
             .map(V1CustomResourceDefinitionVersion::getName)
             .findFirst());
-    return versionOpt.map(version -> new CrdTarget(
+    return versionOpt.map(version -> new ResourceTarget(
         spec.getGroup(),
         version,
         spec.getNames().getPlural(),
@@ -156,13 +161,13 @@ public class DynamicCrInformerManager {
   }
 
   private synchronized void track(V1CustomResourceDefinition crd) {
-    Optional<CrdTarget> targetOpt = resolveTarget(crd);
+    Optional<ResourceTarget> targetOpt = resolveTarget(crd);
     if (targetOpt.isEmpty()) {
       return;
     }
-    CrdTarget target = targetOpt.get();
+    ResourceTarget target = targetOpt.get();
     String key = trackingKey(target.group(), target.plural());
-    TrackedCrd existing = this.trackedCrds.get(key);
+    TrackedTarget existing = this.trackedTargets.get(key);
     if (existing != null) {
       if (existing.target().equals(target)) {
         return;
@@ -179,23 +184,17 @@ public class DynamicCrInformerManager {
       return;
     }
     String key = trackingKey(spec.getGroup(), spec.getNames().getPlural());
-    TrackedCrd tracked = this.trackedCrds.get(key);
+    TrackedTarget tracked = this.trackedTargets.get(key);
     if (tracked == null) {
       return;
     }
     stopTracking(key, tracked);
   }
 
-  private void startTracking(String key, CrdTarget target) {
+  private synchronized void startTracking(String key, ResourceTarget target) {
     SharedInformerFactory informerFactory = new SharedInformerFactory(this.apiClient);
     SharedIndexInformer<V1PartialObject> informer = informerFactory.sharedIndexInformerFor(
-        (CallGeneratorParams params) -> new CustomObjectsApi(this.apiClient)
-            .listClusterCustomObject(target.group(), target.version(), target.plural())
-            .labelSelector(LabelConstants.OBJECT_OWN_USERNAME_KEY)
-            .resourceVersion(params.resourceVersion)
-            .watch(params.watch)
-            .timeoutSeconds(params.timeoutSeconds)
-            .buildCall(null),
+        (CallGeneratorParams params) -> buildListCall(target, params),
         V1PartialObject.class,
         V1PartialObjectList.class);
     informer.addEventHandler(new ResourceEventHandler<>() {
@@ -217,20 +216,54 @@ public class DynamicCrInformerManager {
       }
 
     });
-    this.trackedCrds.put(key, new TrackedCrd(target, informerFactory, informer));
+    this.trackedTargets.put(key, new TrackedTarget(target, informerFactory, informer));
     informerFactory.startAllRegisteredInformers();
-    log.info("Started dynamic CR informer: group={}, version={}, plural={}, namespaced={}",
+    log.info("Started owned-object informer: group={}, version={}, plural={}, namespaced={}",
         target.group(), target.version(), target.plural(), target.namespaced());
   }
 
-  private void stopTracking(String key, TrackedCrd tracked) {
-    this.trackedCrds.remove(key);
+  private void stopTracking(String key, TrackedTarget tracked) {
+    this.trackedTargets.remove(key);
     tracked.informerFactory().stopAllRegisteredInformers();
     enqueueAllPersonalRoles(tracked.target().namespaced());
-    log.info("Stopped dynamic CR informer: {}", key);
+    log.info("Stopped owned-object informer: {}", key);
   }
 
-  private void enqueueOwnerRole(CrdTarget target, V1PartialObject obj) {
+  /**
+   * core("") 그룹은 /api/v1, 나머지는 /apis/{group}/{version} 경로를 사용한다.
+   * username 레이블이 있는 오브젝트만 list/watch 한다.
+   */
+  private Call buildListCall(ResourceTarget target, CallGeneratorParams params) {
+    String basePath = target.group().isEmpty()
+        ? "/api/" + target.version()
+        : "/apis/" + target.group() + "/" + target.version();
+    String path = basePath + "/" + target.plural();
+
+    List<Pair> queryParams = new ArrayList<>();
+    queryParams.add(new Pair("labelSelector", LabelConstants.OBJECT_OWN_USERNAME_KEY));
+    if (params.resourceVersion != null) {
+      queryParams.add(new Pair("resourceVersion", params.resourceVersion));
+    }
+    if (params.watch != null) {
+      queryParams.add(new Pair("watch", String.valueOf(params.watch)));
+    }
+    if (params.timeoutSeconds != null) {
+      queryParams.add(new Pair("timeoutSeconds", String.valueOf(params.timeoutSeconds)));
+    }
+
+    try {
+      return this.apiClient.buildCall(
+          this.apiClient.getBasePath(), path, "GET",
+          queryParams, List.of(),
+          null,
+          Map.of(), Map.of(), Map.of(),
+          new String[]{"BearerToken"}, null);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to build list call: " + path, e);
+    }
+  }
+
+  private void enqueueOwnerRole(ResourceTarget target, V1PartialObject obj) {
     Optional<String> usernameOpt = UsernameUtils.getUsername(obj);
     if (usernameOpt.isEmpty()) {
       return;

--- a/src/main/java/io/ten1010/aipub/projectcontroller/informer/dynamic/OwnedObjectRoleResweeper.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/informer/dynamic/OwnedObjectRoleResweeper.java
@@ -1,0 +1,32 @@
+package io.ten1010.aipub.projectcontroller.informer.dynamic;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+
+/**
+ * 개인 Role/ClusterRole 을 주기적으로 전체 재큐잉하는 백스톱.
+ * 소유권 반영은 이벤트 기반(level-based 리컨실)이 기본 경로지만, 이벤트가 유실되는
+ * 예외 상황(기동 타이밍 레이스, 예기치 못한 드리프트)에서도 한 주기 안에 수렴을 보장한다.
+ * 비용은 개인 Role 수에 비례하고 워크큐가 중복을 흡수하므로 주기를 짧게 잡을 필요가 없다.
+ */
+@Slf4j
+public class OwnedObjectRoleResweeper {
+
+  private static final long RESWEEP_INTERVAL_MS = 600_000; // 10분
+
+  private final DynamicCrInformerManager dynamicCrInformerManager;
+
+  public OwnedObjectRoleResweeper(DynamicCrInformerManager dynamicCrInformerManager) {
+    this.dynamicCrInformerManager = dynamicCrInformerManager;
+  }
+
+  @Scheduled(fixedDelay = RESWEEP_INTERVAL_MS, initialDelay = RESWEEP_INTERVAL_MS)
+  public void resweep() {
+    try {
+      this.dynamicCrInformerManager.resweepPersonalRoles();
+    } catch (Exception e) {
+      log.warn("Failed to resweep personal roles", e);
+    }
+  }
+
+}

--- a/src/main/java/io/ten1010/aipub/projectcontroller/informer/dynamic/package-info.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/informer/dynamic/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * CRD 워치 기반으로 임의 CR 타입의 인포머를 동적으로 관리하는 패키지.
+ */
+package io.ten1010.aipub.projectcontroller.informer.dynamic;

--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/UserLabelReviewHandler.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/UserLabelReviewHandler.java
@@ -50,10 +50,8 @@ public class UserLabelReviewHandler implements ReviewHandler {
     Objects.requireNonNull(review.getRequest());
 
     V1AdmissionReviewRequest request = review.getRequest();
-    if (!OPERATION_CREATE.equals(request.getOperation())) {
-      return false;
-    }
-    return request.getNamespace() != null && !request.getNamespace().isEmpty();
+    // 클러스터 스코프 CR 생성에도 소유자 레이블을 낙인해야 하므로 네임스페이스를 요구하지 않는다
+    return OPERATION_CREATE.equals(request.getOperation());
   }
 
   @Override
@@ -63,7 +61,6 @@ public class UserLabelReviewHandler implements ReviewHandler {
     V1AdmissionReviewRequest request = review.getRequest();
     Objects.requireNonNull(request.getUserInfo());
     Objects.requireNonNull(request.getObject());
-    Objects.requireNonNull(request.getNamespace());
 
     log.debug("UserLabel handle: user={}, namespace={}, operation={}",
         request.getUserInfo().getUsername(), request.getNamespace(), request.getOperation());
@@ -97,6 +94,12 @@ public class UserLabelReviewHandler implements ReviewHandler {
           "Not found aipub user: " + analysis.getUsername());
       return;
     } else {
+      if (request.getNamespace() == null || request.getNamespace().isEmpty()) {
+        // 오너 레이블 전파는 네임스페이스 오브젝트에만 적용된다
+        log.debug("UserLabel: cluster-scoped object from non aipub member, allowing without mutation");
+        V1AdmissionReviewUtils.allowMerging(review);
+        return;
+      }
       log.debug("UserLabel: not aipub member, looking up owner labels");
       String[] ownerLabels;
       try {

--- a/src/test/java/io/ten1010/aipub/projectcontroller/controller/webhook/UserLabelWebhookConfigurationReconcilerTest.java
+++ b/src/test/java/io/ten1010/aipub/projectcontroller/controller/webhook/UserLabelWebhookConfigurationReconcilerTest.java
@@ -1,0 +1,52 @@
+package io.ten1010.aipub.projectcontroller.controller.webhook;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.kubernetes.client.openapi.models.V1CustomResourceDefinition;
+import io.kubernetes.client.openapi.models.V1CustomResourceDefinitionBuilder;
+import io.kubernetes.client.openapi.models.V1RuleWithOperations;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class UserLabelWebhookConfigurationReconcilerTest {
+
+  private static V1CustomResourceDefinition crd(String group) {
+    return new V1CustomResourceDefinitionBuilder()
+        .withNewSpec()
+        .withGroup(group)
+        .endSpec()
+        .build();
+  }
+
+  @Test
+  void buildDesiredRules_appendsCrdGroupRulesSorted() {
+    List<V1RuleWithOperations> rules = UserLabelWebhookConfigurationReconciler.buildDesiredRules(
+        List.of(crd("zeta.example.com"), crd("alpha.example.com"), crd("zeta.example.com")));
+
+    List<V1RuleWithOperations> baseOnly = UserLabelWebhookConfigurationReconciler
+        .buildDesiredRules(List.of());
+    assertThat(rules).hasSize(baseOnly.size() + 2);
+
+    V1RuleWithOperations alphaRule = rules.get(rules.size() - 2);
+    assertThat(alphaRule.getApiGroups()).containsExactly("alpha.example.com");
+    assertThat(alphaRule.getApiVersions()).containsExactly("*");
+    assertThat(alphaRule.getOperations()).containsExactly("CREATE");
+    assertThat(alphaRule.getResources()).containsExactly("*");
+    assertThat(alphaRule.getScope()).isEqualTo("*");
+
+    V1RuleWithOperations zetaRule = rules.get(rules.size() - 1);
+    assertThat(zetaRule.getApiGroups()).containsExactly("zeta.example.com");
+  }
+
+  @Test
+  void buildDesiredRules_excludesPlatformGroups() {
+    List<V1RuleWithOperations> rules = UserLabelWebhookConfigurationReconciler.buildDesiredRules(
+        List.of(crd("project.aipub.ten1010.io"), crd("aipub.ten1010.io"),
+            crd("coaster.ten1010.io")));
+
+    List<V1RuleWithOperations> baseOnly = UserLabelWebhookConfigurationReconciler
+        .buildDesiredRules(List.of());
+    assertThat(rules).isEqualTo(baseOnly);
+  }
+
+}

--- a/src/test/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationServiceOwnedCrRulesTest.java
+++ b/src/test/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationServiceOwnedCrRulesTest.java
@@ -1,0 +1,95 @@
+package io.ten1010.aipub.projectcontroller.domain.k8s;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1PolicyRule;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1AipubUser;
+import io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1Project;
+import io.ten1010.aipub.projectcontroller.domain.k8s.util.WorkloadExclusionResolver;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ReconciliationServiceOwnedCrRulesTest {
+
+  private ReconciliationService reconciliationService;
+  private V1alpha1AipubUser user;
+  private V1alpha1Project project;
+
+  @BeforeEach
+  void setUp() {
+    SubjectResolver subjectResolver = new SubjectResolver() {
+
+      @Override
+      public Optional<io.kubernetes.client.openapi.models.RbacV1Subject> resolve(
+          io.ten1010.aipub.projectcontroller.domain.k8s.dto.V1alpha1ProjectMember member) {
+        return Optional.empty();
+      }
+
+      @Override
+      public Optional<io.kubernetes.client.openapi.models.RbacV1Subject> resolve(
+          V1alpha1AipubUser user) {
+        return Optional.empty();
+      }
+
+    };
+    this.reconciliationService = new ReconciliationService(
+        subjectResolver,
+        project -> java.util.Map.of(),
+        List.of(),
+        new WorkloadExclusionResolver(List.of()));
+
+    this.user = new V1alpha1AipubUser();
+    V1ObjectMeta userMeta = new V1ObjectMeta();
+    userMeta.setName("alice");
+    this.user.setMetadata(userMeta);
+
+    this.project = new V1alpha1Project();
+    V1ObjectMeta projectMeta = new V1ObjectMeta();
+    projectMeta.setName("proj1");
+    this.project.setMetadata(projectMeta);
+  }
+
+  @Test
+  void reconcileAipubUserRoleRules_withOwnedCrObjects_appendsOwnedCrRules() {
+    List<V1PolicyRule> rules = this.reconciliationService.reconcileAipubUserRoleRules(
+        this.user, this.project, List.of(),
+        List.of(new OwnedCrObject("example.com", "widgets", "my-widget")));
+
+    assertThat(rules).hasSize(1);
+    V1PolicyRule rule = rules.get(0);
+    assertThat(rule.getApiGroups()).containsExactly("example.com");
+    assertThat(rule.getResources()).containsExactly("widgets");
+    assertThat(rule.getResourceNames()).containsExactly("my-widget");
+    assertThat(rule.getVerbs()).containsExactly("get", "update", "patch", "delete");
+  }
+
+  @Test
+  void reconcileAipubUserRoleRules_withoutOwnedCrObjects_returnsSameAsLegacyOverload() {
+    List<V1PolicyRule> legacy = this.reconciliationService.reconcileAipubUserRoleRules(
+        this.user, this.project, List.of());
+    List<V1PolicyRule> rules = this.reconciliationService.reconcileAipubUserRoleRules(
+        this.user, this.project, List.of(), List.of());
+
+    assertThat(rules).isEqualTo(legacy);
+  }
+
+  @Test
+  void reconcileClusterRoleRules_withOwnedCrObjects_appendsOwnedCrRules() {
+    List<V1PolicyRule> baseRules = this.reconciliationService.reconcileClusterRoleRules(this.user);
+    List<V1PolicyRule> rules = this.reconciliationService.reconcileClusterRoleRules(
+        this.user,
+        List.of(new OwnedCrObject("example.com", "clusterwidgets", "my-cluster-widget")));
+
+    assertThat(rules).hasSize(baseRules.size() + 1);
+    assertThat(rules.subList(0, baseRules.size())).isEqualTo(baseRules);
+    V1PolicyRule appended = rules.get(rules.size() - 1);
+    assertThat(appended.getApiGroups()).containsExactly("example.com");
+    assertThat(appended.getResources()).containsExactly("clusterwidgets");
+    assertThat(appended.getResourceNames()).containsExactly("my-cluster-widget");
+    assertThat(appended.getVerbs()).containsExactly("get", "update", "patch", "delete");
+  }
+
+}

--- a/src/test/java/io/ten1010/aipub/projectcontroller/informer/dynamic/DynamicCrInformerManagerTest.java
+++ b/src/test/java/io/ten1010/aipub/projectcontroller/informer/dynamic/DynamicCrInformerManagerTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.openapi.models.V1CustomResourceDefinition;
 import io.kubernetes.client.openapi.models.V1CustomResourceDefinitionBuilder;
+import io.ten1010.aipub.projectcontroller.domain.k8s.DynamicCrConstants;
+import io.ten1010.aipub.projectcontroller.domain.k8s.ResourceTarget;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +40,7 @@ class DynamicCrInformerManagerTest {
 
   @Test
   void resolveTarget_picksStorageVersion() {
-    Optional<DynamicCrInformerManager.CrdTarget> target =
+    Optional<ResourceTarget> target =
         DynamicCrInformerManager.resolveTarget(crd("example.com", "widgets", "Namespaced", true));
 
     assertThat(target).isPresent();
@@ -50,11 +52,24 @@ class DynamicCrInformerManagerTest {
 
   @Test
   void resolveTarget_clusterScope_namespacedFalse() {
-    Optional<DynamicCrInformerManager.CrdTarget> target =
+    Optional<ResourceTarget> target =
         DynamicCrInformerManager.resolveTarget(crd("example.com", "widgets", "Cluster", true));
 
     assertThat(target).isPresent();
     assertThat(target.get().namespaced()).isFalse();
+  }
+
+  // 네이티브 대상은 낙인 웹훅이 CREATE 를 인터셉트하는 네임스페이스 타입만 허용된다
+  @Test
+  void nativeOwnedTargets_areNamespaced_andExcludePlatformGroups() {
+    assertThat(DynamicCrConstants.NATIVE_OWNED_TARGETS)
+        .allSatisfy(target -> {
+          assertThat(target.namespaced()).isTrue();
+          assertThat(DynamicCrConstants.EXCLUDED_GROUPS).doesNotContain(target.group());
+        });
+    assertThat(DynamicCrConstants.NATIVE_OWNED_TARGETS)
+        .extracting(ResourceTarget::plural)
+        .contains("configmaps", "secrets", "services", "deployments");
   }
 
   @Test

--- a/src/test/java/io/ten1010/aipub/projectcontroller/informer/dynamic/DynamicCrInformerManagerTest.java
+++ b/src/test/java/io/ten1010/aipub/projectcontroller/informer/dynamic/DynamicCrInformerManagerTest.java
@@ -1,0 +1,76 @@
+package io.ten1010.aipub.projectcontroller.informer.dynamic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.kubernetes.client.openapi.models.V1CustomResourceDefinition;
+import io.kubernetes.client.openapi.models.V1CustomResourceDefinitionBuilder;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class DynamicCrInformerManagerTest {
+
+  private static V1CustomResourceDefinition crd(String group, String plural, String scope,
+      boolean storageServed) {
+    return new V1CustomResourceDefinitionBuilder()
+        .withNewMetadata()
+        .withName(plural + "." + group)
+        .endMetadata()
+        .withNewSpec()
+        .withGroup(group)
+        .withScope(scope)
+        .withNewNames()
+        .withKind("Widget")
+        .withPlural(plural)
+        .endNames()
+        .addNewVersion()
+        .withName("v1alpha1")
+        .withServed(true)
+        .withStorage(false)
+        .endVersion()
+        .addNewVersion()
+        .withName("v1")
+        .withServed(storageServed)
+        .withStorage(true)
+        .endVersion()
+        .endSpec()
+        .build();
+  }
+
+  @Test
+  void resolveTarget_picksStorageVersion() {
+    Optional<DynamicCrInformerManager.CrdTarget> target =
+        DynamicCrInformerManager.resolveTarget(crd("example.com", "widgets", "Namespaced", true));
+
+    assertThat(target).isPresent();
+    assertThat(target.get().group()).isEqualTo("example.com");
+    assertThat(target.get().version()).isEqualTo("v1");
+    assertThat(target.get().plural()).isEqualTo("widgets");
+    assertThat(target.get().namespaced()).isTrue();
+  }
+
+  @Test
+  void resolveTarget_clusterScope_namespacedFalse() {
+    Optional<DynamicCrInformerManager.CrdTarget> target =
+        DynamicCrInformerManager.resolveTarget(crd("example.com", "widgets", "Cluster", true));
+
+    assertThat(target).isPresent();
+    assertThat(target.get().namespaced()).isFalse();
+  }
+
+  @Test
+  void resolveTarget_excludedGroups_returnsEmpty() {
+    assertThat(DynamicCrInformerManager.resolveTarget(
+        crd("project.aipub.ten1010.io", "projects", "Cluster", true))).isEmpty();
+    assertThat(DynamicCrInformerManager.resolveTarget(
+        crd("aipub.ten1010.io", "workspaces", "Namespaced", true))).isEmpty();
+    assertThat(DynamicCrInformerManager.resolveTarget(
+        crd("coaster.ten1010.io", "noderesources", "Cluster", true))).isEmpty();
+  }
+
+  @Test
+  void resolveTarget_missingSpecFields_returnsEmpty() {
+    V1CustomResourceDefinition crd = new V1CustomResourceDefinition();
+    assertThat(DynamicCrInformerManager.resolveTarget(crd)).isEmpty();
+  }
+
+}

--- a/src/test/java/io/ten1010/aipub/projectcontroller/mutating/service/UserLabelReviewHandlerTest.java
+++ b/src/test/java/io/ten1010/aipub/projectcontroller/mutating/service/UserLabelReviewHandlerTest.java
@@ -90,10 +90,11 @@ class UserLabelReviewHandlerTest {
     assertThat(this.handler.canHandle(review)).isFalse();
   }
 
+  // 클러스터 스코프 CR 생성에도 소유자 레이블을 낙인해야 하므로 네임스페이스 없는 CREATE 도 처리한다
   @Test
-  void canHandle_noNamespace_returnsFalse() {
+  void canHandle_noNamespace_returnsTrue() {
     V1AdmissionReview review = createReview("CREATE", null);
-    assertThat(this.handler.canHandle(review)).isFalse();
+    assertThat(this.handler.canHandle(review)).isTrue();
   }
 
   @Test
@@ -140,6 +141,43 @@ class UserLabelReviewHandlerTest {
 
     UserInfoAnalysis analysis = new UserInfoAnalysis(
         "system:serviceaccount:kube-system:replicaset-controller",
+        List.of("system:serviceaccounts", "system:authenticated"),
+        null);
+    when(this.mockAnalyzer.analyzeV2(any())).thenReturn(analysis);
+
+    this.handler.handle(review);
+
+    assertThat(review.getResponse()).isNotNull();
+    assertThat(review.getResponse().getAllowed()).isTrue();
+    assertThat(review.getResponse().getPatch()).isNull();
+  }
+
+  @Test
+  void handle_memberUserClusterScoped_addsLabels() {
+    V1AdmissionReview review = createReview("CREATE", null);
+
+    V1alpha1AipubUser aipubUser = createAipubUser("testuser", "uid-123", "user-id-456");
+    UserInfoAnalysis analysis = new UserInfoAnalysis(
+        "oidc:testuser",
+        List.of("oidc:aipub-member", "system:authenticated"),
+        aipubUser);
+    when(this.mockAnalyzer.analyzeV2(any())).thenReturn(analysis);
+
+    this.handler.handle(review);
+
+    assertThat(review.getResponse()).isNotNull();
+    assertThat(review.getResponse().getAllowed()).isTrue();
+    assertThat(review.getResponse().getPatch()).isNotNull();
+    assertThat(review.getResponse().getPatchType()).isEqualTo("JSONPatch");
+  }
+
+  // 클러스터 스코프 오브젝트는 오너 레이블 전파 대상이 아니므로 무변경 허용된다
+  @Test
+  void handle_nonMemberClusterScoped_allowsWithoutPatch() {
+    V1AdmissionReview review = createReview("CREATE", null);
+
+    UserInfoAnalysis analysis = new UserInfoAnalysis(
+        "system:serviceaccount:kube-system:some-controller",
         List.of("system:serviceaccounts", "system:authenticated"),
         null);
     when(this.mockAnalyzer.analyzeV2(any())).thenReturn(analysis);


### PR DESCRIPTION
## Summary

일반 사용자가 임의 CRD의 CR을 소유(생성)했을 때 "본인 것만 수정/삭제 가능" 정책을, **권한 판정은 표준 K8s RBAC이 수행**하도록 반영합니다. 컨트롤러는 소유 CR 목록에 맞춰 사용자별 Role/ClusterRole의 resourceNames 규칙을 자동 관리하고, 실제 허용/거부는 kube-apiserver RBAC 평가로 이뤄집니다 — 따라서 `kubectl auth can-i`와 권한 분석(UserAuthorityReview)에 실권한이 그대로 나타납니다.

기존에 워크로드 8종(Workspace, Operation, ChainJob, Job, CronJob, AipubVolume, SftpServer, ImageBuild)에 하드코딩돼 있던 소유권 메커니즘을 클러스터 스코프 포함 모든 CR 타입으로 일반화한 것입니다. 프론트 CustomResource 메뉴/버튼 분기는 권한 분석 status.authorities의 이름 목록을 기준으로 하면 됩니다.

## How it works

```
CRD 존재/생성 ──[CRD informer]──> GVR 추출 → 타입별 동적 인포머 기동
                                    (username 레이블 셀렉터 + 메타데이터 전용 DTO)
사용자가 CR 생성 ──[낙인 웹훅]──> aipub.ten1010.io/username 레이블 강제
                                    ↓
                   CR 이벤트 → 개인 Role/ClusterRole 리컨실 큐 enqueue
                                    ↓
                   resourceNames: [소유 CR 이름], verbs: get/update/patch/delete
```

- `DynamicCrInformerManager` (신규): CRD 워치 → CRD마다 메타데이터 전용 인포머 기동/중지, 소유 CR 변화를 개인 Role(네임스페이스)/ClusterRole(클러스터 스코프) 큐로 라우팅. CRD 삭제 시 관련 개인 롤 전체 재큐잉으로 stale 권한 정리.
- `ReconciliationService`: 소유 CR 규칙 오버로드 추가 (`get/update/patch/delete` + resourceNames).
- `UserLabelReviewHandler`: 클러스터 스코프 CREATE에도 소유자 레이블 낙인.
- `UserLabelWebhookConfigurationReconciler` (신규): 낙인 웹훅의 rules를 CRD 그룹 목록에 맞춰 자동 리컨실 (`scope "*"`, 와일드카드 대신 CRD 그룹만 정확히 인터셉트).
- 플랫폼 그룹(project.aipub/aipub/coaster.ten1010.io)은 기존 정적 경로 유지, 동적 경로에서 제외.

## Scope

- 대상: **이미 존재하거나 새로 등록되는 CRD의 CR에 대한 소유자 사후 권한 관리** (조회 get 포함). 새 CRD 등록 인식은 워치 기반이라 사실상 즉시입니다.
- 범위 외: 멤버에게 임의 CR **생성 권한 부여** (별도 작업 — Project spec 선언 방식 논의됨), "내 것만 목록 보기"(RBAC 한계, 프론트 필터 필요)

## Test plan

- [x] 유닛 테스트 96개 통과 (신규: owned-CR 규칙 생성, CRD target 해석, 웹훅 rules 생성) — upstream main(Gradle 전환) 위에서 재검증
- [x] 로컬 kind 클러스터 E2E:
  - 네임스페이스/클러스터 스코프 CRD 인식 → 동적 인포머 기동
  - 소유 CR 생성 → 개인 Role/ClusterRole에 resourceNames 규칙 반영
  - `kubectl auth can-i`: 소유자 yes / 비소유자 no / create no
  - CR 삭제 → 규칙 제거·권한 회수
- [ ] 스테이징: 낙인 웹훅 경로(TLS 배포 환경) E2E, 웹훅 rules 자동 갱신 확인
- [ ] 스테이징: 컨트롤러 다운 시 fail-closed 영향 범위 확인 (CRD 그룹 CR 생성 차단)

## Operational notes

- 웹훅 `failurePolicy: Fail` + CRD 그룹 rules → 컨트롤러 다운 중엔 해당 그룹 CR 생성이 차단됩니다. 인프라 오퍼레이터(KubeVirt 등) CRD도 대상이므로 필요 시 제외 그룹의 설정화(후속)를 검토해주세요.
- CRD 수만큼 인포머가 생기지만 username 레이블 셀렉터 + 메타데이터 전용 역직렬화로 캐시 부담은 최소화했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)