### PR TITLE
feat(AIP-2459): user label 동기화를 워크로드 파생 중간 오브젝트 전체로 확장

### DIFF
--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscovery.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscovery.java
@@ -147,6 +147,7 @@ public class ApiResourceDiscovery {
           String groupResource = "/" + name;
           plurals.put("v1/" + kind, name);
           namespacedInfo.put(groupResource, namespaced);
+          groupVersions.put(groupResource, "v1");
           groupResources.add(groupResource);
           kindDict.computeIfAbsent(kind, k -> new ArrayList<>()).add(groupResource);
           coreCount++;

--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/UserLabelSynchronizer.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/UserLabelSynchronizer.java
@@ -7,10 +7,13 @@ import io.ten1010.aipub.projectcontroller.domain.k8s.LabelConstants;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ObjectMapperFactory;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -24,8 +27,26 @@ import org.springframework.context.event.EventListener;
 @Slf4j
 public class UserLabelSynchronizer {
 
-  private static final long SYNC_INTERVAL_MS = 300_000; // 5 minutes
+  private static final long SYNC_INTERVAL_MS = 60_000; // 1 minute
   private static final String LOG_PREFIX = "[USER-LABEL-SYNC]";
+  private static final int PAGE_LIMIT = 500;
+  private static final int MAX_PAGES = 1_000;
+
+  /**
+   * Sync targets — must stay 1:1 with the workload-label webhook rules
+   * (kubernetes/controller/project-controller/templates/java-webhook-configuration.yaml).
+   * Intermediate workload objects come first and pods last: pods born mid-cycle copy
+   * their parent's labels via the mutating webhook, so parents must be corrected first.
+   */
+  private static final List<SyncTarget> SYNC_TARGETS = List.of(
+      new SyncTarget("", "v1", "replicationcontrollers"),
+      new SyncTarget("apps", "v1", "statefulsets"),
+      new SyncTarget("apps", "v1", "deployments"),
+      new SyncTarget("apps", "v1", "replicasets"),
+      new SyncTarget("apps", "v1", "daemonsets"),
+      new SyncTarget("batch", "v1", "jobs"),
+      new SyncTarget("batch", "v1", "cronjobs"),
+      new SyncTarget("", "v1", "pods"));
 
   private final ApiResourceDiscovery apiResourceDiscovery;
   private final ApiClient apiClient;
@@ -54,48 +75,75 @@ public class UserLabelSynchronizer {
     long startNanos = System.nanoTime();
     log.debug("{} Sync cycle started", LOG_PREFIX);
     try {
-      Counters counters = run();
+      CycleResult result = run();
+      Counters counters = result.total();
       long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
-      log.debug("{} Sync cycle done: pods={}, processed={}, skippedNoWorkloadLabel={}, "
-              + "ownerLookupFailed={}, alreadyInSync={}, patched={}, patchFailed={}, elapsedMs={}",
-          LOG_PREFIX, counters.totalPods, counters.processed, counters.skippedNoWorkloadLabel,
+      log.debug("{} Sync cycle done: objects={}, processed={}, skippedNoWorkloadLabel={}, "
+              + "ownerLookupFailed={}, alreadyInSync={}, patched={}, patchFailed={}, "
+              + "listFailed={}, targetFailed={}, elapsedMs={}, breakdown=[{}]",
+          LOG_PREFIX, counters.totalObjects, counters.processed, counters.skippedNoWorkloadLabel,
           counters.ownerLookupFailed, counters.alreadyInSync, counters.patched,
-          counters.patchFailed, elapsedMs);
+          counters.patchFailed, counters.listFailed, counters.targetFailed, elapsedMs,
+          result.breakdown());
     } catch (Exception e) {
       long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
       log.warn("{} Sync cycle failed after {}ms", LOG_PREFIX, elapsedMs, e);
     }
   }
 
-  private Counters run() {
+  private CycleResult run() {
+    Counters total = new Counters();
+    // Owner maps shared across all sync targets within a single cycle: one paginated
+    // LIST per owner kind instead of one GET per owner object.
+    OwnerCache ownerCache = new OwnerCache();
+    StringBuilder breakdown = new StringBuilder();
+
+    for (SyncTarget target : SYNC_TARGETS) {
+      Counters counters;
+      try {
+        counters = processTarget(target, ownerCache);
+      } catch (Exception e) {
+        log.warn("{} {} target processing failed unexpectedly — target skipped",
+            LOG_PREFIX, target.gvr(), e);
+        counters = new Counters();
+        counters.targetFailed++;
+      }
+      total.add(counters);
+      if (breakdown.length() > 0) {
+        breakdown.append(", ");
+      }
+      breakdown.append(target.gvr()).append(counters.toBreakdownEntry());
+    }
+
+    log.debug("{} Owner kinds this cycle: loaded={}, loadFailed={}",
+        LOG_PREFIX, ownerCache.mapsByKind.size(), ownerCache.failedKinds.size());
+    return new CycleResult(total, breakdown.toString());
+  }
+
+  private Counters processTarget(SyncTarget target, OwnerCache ownerCache) {
     Counters c = new Counters();
 
-    JsonNode podList = listPodsWithWorkloadLabel();
-    if (podList == null) {
-      log.warn("{} Pod list fetch returned null — sync cycle aborted", LOG_PREFIX);
+    List<JsonNode> items = listObjectsWithWorkloadLabel(target);
+    if (items == null) {
+      log.warn("{} {} list fetch returned null — target skipped", LOG_PREFIX, target.gvr());
+      c.listFailed++;
       return c;
     }
-    JsonNode items = podList.path("items");
-    if (!items.isArray()) {
-      log.warn("{} Pod list items not array — sync cycle aborted", LOG_PREFIX);
-      return c;
-    }
-    c.totalPods = items.size();
-    log.debug("{} Listed {} pods with workload-kind label", LOG_PREFIX, c.totalPods);
+    c.totalObjects = items.size();
+    log.debug("{} Listed {} {} with workload-kind label", LOG_PREFIX, c.totalObjects, target.gvr());
 
-    Map<String, String @Nullable []> cache = new HashMap<>();
-
-    for (JsonNode pod : items) {
-      String namespace = pod.path("metadata").path("namespace").textValue();
-      String podName = pod.path("metadata").path("name").textValue();
-      if (namespace == null || podName == null) {
+    for (JsonNode object : items) {
+      String namespace = object.path("metadata").path("namespace").textValue();
+      String objectName = object.path("metadata").path("name").textValue();
+      if (namespace == null || objectName == null) {
         c.skippedNoWorkloadLabel++;
         continue;
       }
 
-      JsonNode labels = pod.path("metadata").path("labels");
+      JsonNode labels = object.path("metadata").path("labels");
       if (!labels.isObject()) {
-        log.debug("{} Skip pod {}/{}: no labels object", LOG_PREFIX, namespace, podName);
+        log.debug("{} Skip {} {}/{}: no labels object",
+            LOG_PREFIX, target.gvr(), namespace, objectName);
         c.skippedNoWorkloadLabel++;
         continue;
       }
@@ -103,44 +151,40 @@ public class UserLabelSynchronizer {
       JsonNode kindNode = labels.get(LabelConstants.WORKLOAD_KIND_KEY);
       JsonNode nameNode = labels.get(LabelConstants.WORKLOAD_NAME_KEY);
       if (kindNode == null || nameNode == null) {
-        log.debug("{} Skip pod {}/{}: missing workload-kind/workload-name label",
-            LOG_PREFIX, namespace, podName);
+        log.debug("{} Skip {} {}/{}: missing workload-kind/workload-name label",
+            LOG_PREFIX, target.gvr(), namespace, objectName);
         c.skippedNoWorkloadLabel++;
         continue;
       }
       String kind = kindNode.textValue();
       String name = nameNode.textValue();
       if (kind == null || name == null) {
-        log.debug("{} Skip pod {}/{}: workload-kind/workload-name label has null text",
-            LOG_PREFIX, namespace, podName);
+        log.debug("{} Skip {} {}/{}: workload-kind/workload-name label has null text",
+            LOG_PREFIX, target.gvr(), namespace, objectName);
         c.skippedNoWorkloadLabel++;
         continue;
       }
 
       c.processed++;
-      log.debug("{} Processing pod {}/{}: owner={}/{}", LOG_PREFIX, namespace, podName, kind, name);
+      log.debug("{} Processing {} {}/{}: owner={}/{}",
+          LOG_PREFIX, target.gvr(), namespace, objectName, kind, name);
 
-      String cacheKey = namespace + "::" + kind + "/" + name;
-      String @Nullable [] ownerLabels;
-      if (cache.containsKey(cacheKey)) {
-        ownerLabels = cache.get(cacheKey);
-        log.debug("{} Owner cache hit for {} → username={}, userid={}",
-            LOG_PREFIX, cacheKey,
-            ownerLabels == null ? null : ownerLabels[0],
-            ownerLabels == null ? null : ownerLabels[1]);
-      } else {
-        ownerLabels = getOwnerUserLabels(kind, name, namespace);
-        cache.put(cacheKey, ownerLabels);
-      }
-
+      loadOwnerKindIfNeeded(kind, ownerCache);
+      String @Nullable [] ownerLabels = ownerCache.lookup(kind, namespace, name);
       if (ownerLabels == null) {
         c.ownerLookupFailed++;
-        log.warn("{} Owner lookup failed for pod {}/{}: owner={}/{} returned null — patch skipped",
-            LOG_PREFIX, namespace, podName, kind, name);
+        if (ownerCache.isFailed(kind)) {
+          log.debug("{} Owner lookup skipped for {} {}/{}: owner kind={} load failed — "
+                  + "patch skipped",
+              LOG_PREFIX, target.gvr(), namespace, objectName, kind);
+        } else {
+          log.warn("{} Owner lookup failed for {} {}/{}: owner={}/{} not found — patch skipped",
+              LOG_PREFIX, target.gvr(), namespace, objectName, kind, name);
+        }
         continue;
       }
 
-      SyncResult result = syncPodIfNeeded(labels, podName, namespace, ownerLabels);
+      SyncResult result = syncObjectIfNeeded(target, labels, objectName, namespace, ownerLabels);
       switch (result) {
         case ALREADY_IN_SYNC -> c.alreadyInSync++;
         case PATCHED -> c.patched++;
@@ -151,22 +195,22 @@ public class UserLabelSynchronizer {
     return c;
   }
 
-  private SyncResult syncPodIfNeeded(JsonNode labels, String podName, String namespace,
-      String[] ownerLabels) {
+  private SyncResult syncObjectIfNeeded(SyncTarget target, JsonNode labels, String objectName,
+      String namespace, String[] ownerLabels) {
     String currentUsername = getTextValue(labels, LabelConstants.OBJECT_OWN_USERNAME_KEY);
     String currentUserid = getTextValue(labels, LabelConstants.OBJECT_OWN_USERID_KEY);
 
     if (Objects.equals(ownerLabels[0], currentUsername)
         && Objects.equals(ownerLabels[1], currentUserid)) {
-      log.debug("{} Pod {}/{} already in sync (username={}, userid={})",
-          LOG_PREFIX, namespace, podName, currentUsername, currentUserid);
+      log.debug("{} {} {}/{} already in sync (username={}, userid={})",
+          LOG_PREFIX, target.gvr(), namespace, objectName, currentUsername, currentUserid);
       return SyncResult.ALREADY_IN_SYNC;
     }
 
-    log.debug("{} Patching pod {}/{}: username=[{}→{}], userid=[{}→{}]",
-        LOG_PREFIX, namespace, podName,
+    log.debug("{} Patching {} {}/{}: username=[{}→{}], userid=[{}→{}]",
+        LOG_PREFIX, target.gvr(), namespace, objectName,
         currentUsername, ownerLabels[0], currentUserid, ownerLabels[1]);
-    return patchPodLabels(podName, namespace, ownerLabels[0], ownerLabels[1]);
+    return patchObjectLabels(target, objectName, namespace, ownerLabels[0], ownerLabels[1]);
   }
 
   @Nullable
@@ -179,95 +223,170 @@ public class UserLabelSynchronizer {
   }
 
   /**
-   * Fetches the username/userid labels from the owner object identified by kind/name.
-   * Uses ApiResourceDiscovery.getResourcesByKind to resolve kind to API paths,
-   * matching the Python _get_object behavior.
+   * Loads the owner map for the given kind once per cycle via cluster-scoped LISTs.
    *
-   * @return String[]{username, userid} or null if not found/no labels
+   * <p>Referenced owners are always root objects WITHOUT the workload-kind label: the
+   * stamping webhook copies a parent's workload-kind/name labels verbatim when the parent
+   * carries them, so a workload-kind/name reference can only ever point at an object that
+   * has no workload-kind label itself. This lets us fetch all possible owners of a kind
+   * with a single label-absence LIST (labelSelector=!workload-kind) instead of one GET
+   * per owner object.
+   *
+   * <p>Any failure (all candidate LISTs failing, or an unexpected exception) marks the
+   * kind as failed in the cache so later targets hitting the same kind neither retry nor
+   * re-throw — objects referencing a failed kind are counted as ownerLookupFailed.
+   */
+  private void loadOwnerKindIfNeeded(String kind, OwnerCache ownerCache) {
+    if (ownerCache.isLoaded(kind)) {
+      return;
+    }
+    try {
+      List<ApiResourceDiscovery.ResourceInfo> resources =
+          this.apiResourceDiscovery.getResourcesByKind(kind);
+      if (resources.isEmpty()) {
+        log.warn("{} Owner load: no API resources found for kind={} (discovery snapshot miss)",
+            LOG_PREFIX, kind);
+        ownerCache.mapsByKind.put(kind, Map.of());
+        return;
+      }
+      log.debug("{} Owner load for kind={}: trying {} candidate resource(s)",
+          LOG_PREFIX, kind, resources.size());
+
+      Map<String, String @Nullable []> ownerMap = new HashMap<>();
+      boolean anyListed = false;
+      for (ApiResourceDiscovery.ResourceInfo resourceInfo : resources) {
+        String apiVersion = resourceInfo.apiVersion();
+        String plural = resourceInfo.plural();
+        String group = apiVersion.contains("/") ? apiVersion.split("/")[0] : "";
+        String groupResource = group + "/" + plural;
+
+        boolean namespaced;
+        try {
+          namespaced = this.apiResourceDiscovery.isNamespaced(groupResource);
+        } catch (GroupResourceNotFoundException e) {
+          log.debug("{} Owner load: groupResource={} not in discovery — skipping candidate",
+              LOG_PREFIX, groupResource);
+          continue;
+        }
+        if (!namespaced) {
+          // Root workloads are always namespaced; owner references are namespace-scoped,
+          // so a non-namespaced candidate can never be a referenced owner.
+          log.debug("{} Owner load: groupResource={} is not namespaced — skipping candidate",
+              LOG_PREFIX, groupResource);
+          continue;
+        }
+
+        String prefix = group.isEmpty() ? "/api/" + apiVersion : "/apis/" + apiVersion;
+        String basePath = prefix + "/" + plural + "?labelSelector="
+            + URLEncoder.encode("!" + LabelConstants.WORKLOAD_KIND_KEY, StandardCharsets.UTF_8);
+        log.debug("{} Owner load attempt: LIST {}", LOG_PREFIX, basePath);
+        List<JsonNode> items = listAllPages(basePath);
+        if (items == null) {
+          log.debug("{} Owner load LIST failed: {}", LOG_PREFIX, basePath);
+          continue;
+        }
+        anyListed = true;
+        for (JsonNode item : items) {
+          String namespace = item.path("metadata").path("namespace").textValue();
+          String name = item.path("metadata").path("name").textValue();
+          if (namespace == null || name == null) {
+            continue;
+          }
+          JsonNode labels = item.path("metadata").path("labels");
+          if (!labels.isObject()) {
+            // Not stored → lookup returns null → same skip semantics as the previous
+            // per-object GET path ("owner has no labels object").
+            continue;
+          }
+          String username = getTextValue(labels, LabelConstants.OBJECT_OWN_USERNAME_KEY);
+          String userid = getTextValue(labels, LabelConstants.OBJECT_OWN_USERID_KEY);
+          // putIfAbsent: earlier candidates win, preserving the previous GET try-order.
+          ownerMap.putIfAbsent(namespace + "::" + name, new String[]{username, userid});
+        }
+      }
+
+      if (!anyListed) {
+        log.warn("{} Owner load failed for kind={}: no candidate LIST succeeded — "
+                + "objects referencing this kind are skipped this cycle",
+            LOG_PREFIX, kind);
+        ownerCache.failedKinds.add(kind);
+        return;
+      }
+      log.debug("{} Owner map loaded for kind={}: {} entries", LOG_PREFIX, kind, ownerMap.size());
+      ownerCache.mapsByKind.put(kind, ownerMap);
+    } catch (Exception e) {
+      log.warn("{} Owner load for kind={} threw unexpectedly — kind marked failed for this cycle",
+          LOG_PREFIX, kind, e);
+      ownerCache.failedKinds.add(kind);
+    }
+  }
+
+  @Nullable
+  private List<JsonNode> listObjectsWithWorkloadLabel(SyncTarget target) {
+    String labelSelector = URLEncoder.encode(LabelConstants.WORKLOAD_KIND_KEY, StandardCharsets.UTF_8);
+    String path = target.apiPrefix() + "/" + target.plural() + "?labelSelector=" + labelSelector;
+    return listAllPages(path);
+  }
+
+  /**
+   * Paginated LIST: repeatedly GETs the given path with limit={@value #PAGE_LIMIT}
+   * (and continue=&lt;token&gt;, URL-encoded, from the second page on), accumulating
+   * items until metadata.continue is empty.
+   *
+   * @param basePath list path including its query string (e.g. ?labelSelector=...)
+   * @return all items across pages, or null if ANY page fails — a partial result must
+   *     never be treated as a complete one
    */
   @Nullable
-  private String[] getOwnerUserLabels(String kind, String name, String namespace) {
-    List<ApiResourceDiscovery.ResourceInfo> resources =
-        this.apiResourceDiscovery.getResourcesByKind(kind);
-    if (resources.isEmpty()) {
-      log.warn("{} Owner lookup: no API resources found for kind={} (discovery snapshot miss)",
-          LOG_PREFIX, kind);
-      return null;
-    }
-    log.debug("{} Owner lookup {}/{} ns={}: trying {} candidate resource(s)",
-        LOG_PREFIX, kind, name, namespace, resources.size());
-
-    for (ApiResourceDiscovery.ResourceInfo resourceInfo : resources) {
-      String apiVersion = resourceInfo.apiVersion();
-      String plural = resourceInfo.plural();
-      String group = apiVersion.contains("/") ? apiVersion.split("/")[0] : "";
-      String groupResource = group + "/" + plural;
-
-      boolean namespaced;
-      try {
-        namespaced = this.apiResourceDiscovery.isNamespaced(groupResource);
-      } catch (GroupResourceNotFoundException e) {
-        log.debug("{} Owner lookup: groupResource={} not in discovery — skipping candidate",
-            LOG_PREFIX, groupResource);
-        continue;
+  private List<JsonNode> listAllPages(String basePath) {
+    List<JsonNode> items = new ArrayList<>();
+    String continueToken = null;
+    // A misbehaving API server (e.g. an aggregated server backing an arbitrary owner
+    // CRD) could return continue tokens forever; without a guard the single-threaded
+    // synchronizer would wedge permanently and accumulate items unboundedly.
+    for (int page = 1; page <= MAX_PAGES; page++) {
+      String path = basePath + (basePath.contains("?") ? "&" : "?") + "limit=" + PAGE_LIMIT;
+      if (continueToken != null) {
+        path = path + "&continue=" + URLEncoder.encode(continueToken, StandardCharsets.UTF_8);
       }
-
-      String path;
-      if (namespaced) {
-        if (group.isEmpty()) {
-          path = "/api/v1/namespaces/" + namespace + "/" + plural + "/" + name;
-        } else {
-          path = "/apis/" + apiVersion + "/namespaces/" + namespace + "/" + plural + "/" + name;
-        }
-      } else {
-        if (group.isEmpty()) {
-          path = "/api/v1/" + plural + "/" + name;
-        } else {
-          path = "/apis/" + apiVersion + "/" + plural + "/" + name;
-        }
-      }
-
-      log.debug("{} Owner lookup attempt: GET {}", LOG_PREFIX, path);
-      JsonNode obj = fetchJson(path);
-      if (obj == null) {
-        log.debug("{} Owner lookup attempt returned null (404 or fetch error): {}",
-            LOG_PREFIX, path);
-        continue;
-      }
-
-      JsonNode labels = obj.path("metadata").path("labels");
-      if (!labels.isObject()) {
-        log.warn("{} Owner object {}/{} has no labels object — returning null",
-            LOG_PREFIX, kind, name);
+      JsonNode pageNode = fetchJson(path);
+      if (pageNode == null) {
         return null;
       }
-
-      String username = getTextValue(labels, LabelConstants.OBJECT_OWN_USERNAME_KEY);
-      String userid = getTextValue(labels, LabelConstants.OBJECT_OWN_USERID_KEY);
-      log.debug("{} Owner labels resolved {}/{} ns={}: username={}, userid={}",
-          LOG_PREFIX, kind, name, namespace, username, userid);
-      return new String[]{username, userid};
+      JsonNode pageItems = pageNode.path("items");
+      if (!pageItems.isArray()) {
+        log.warn("{} listAllPages: items not array — path={}", LOG_PREFIX, path);
+        return null;
+      }
+      for (JsonNode item : pageItems) {
+        items.add(item);
+      }
+      String nextToken = pageNode.path("metadata").path("continue").textValue();
+      if (nextToken == null || nextToken.isEmpty()) {
+        return items;
+      }
+      if (nextToken.equals(continueToken)) {
+        log.warn("{} listAllPages: continue token repeated — aborting to avoid a loop, path={}",
+            LOG_PREFIX, basePath);
+        return null;
+      }
+      continueToken = nextToken;
     }
-
-    log.warn("{} Owner lookup exhausted all candidates for {}/{} ns={} — returning null",
-        LOG_PREFIX, kind, name, namespace);
+    log.warn("{} listAllPages: exceeded {} pages — aborting, path={}",
+        LOG_PREFIX, MAX_PAGES, basePath);
     return null;
   }
 
-  @Nullable
-  private JsonNode listPodsWithWorkloadLabel() {
-    String labelSelector = URLEncoder.encode(LabelConstants.WORKLOAD_KIND_KEY, StandardCharsets.UTF_8);
-    String path = "/api/v1/pods?labelSelector=" + labelSelector;
-    return fetchJson(path);
-  }
-
-  private SyncResult patchPodLabels(String name, String namespace,
+  private SyncResult patchObjectLabels(SyncTarget target, String name, String namespace,
       @Nullable String username, @Nullable String userid) {
-    String path = "/api/v1/namespaces/" + namespace + "/pods/" + name;
+    String path = target.apiPrefix() + "/namespaces/" + namespace + "/" + target.plural()
+        + "/" + name;
     try {
       Map<String, Object> labels = new HashMap<>();
       labels.put(LabelConstants.OBJECT_OWN_USERNAME_KEY, username);
       labels.put(LabelConstants.OBJECT_OWN_USERID_KEY, userid);
+      // Merge-patch of metadata.labels only — spec/spec.template must never be included
+      // (patching spec.template would trigger rolling restarts of workloads).
       byte[] bodyBytes = this.mapper.writeValueAsBytes(
           Map.of("metadata", Map.of("labels", labels)));
 
@@ -281,22 +400,22 @@ public class UserLabelSynchronizer {
 
       try (Response response = call.execute()) {
         if (response.isSuccessful()) {
-          log.debug("{} Patched pod {}/{} (status={})",
-              LOG_PREFIX, namespace, name, response.code());
+          log.debug("{} Patched {} {}/{} (status={})",
+              LOG_PREFIX, target.gvr(), namespace, name, response.code());
           return SyncResult.PATCHED;
         }
         if (response.code() == 404) {
-          log.debug("{} Pod {}/{} not found for patch (already deleted?)",
-              LOG_PREFIX, namespace, name);
+          log.debug("{} {} {}/{} not found for patch (already deleted?)",
+              LOG_PREFIX, target.gvr(), namespace, name);
           return SyncResult.PATCH_FAILED;
         }
         String errorBody = response.body() != null ? response.body().string() : "";
-        log.warn("{} Failed to patch pod {}/{}: status={}, body={}",
-            LOG_PREFIX, namespace, name, response.code(), errorBody);
+        log.warn("{} Failed to patch {} {}/{}: status={}, body={}",
+            LOG_PREFIX, target.gvr(), namespace, name, response.code(), errorBody);
         return SyncResult.PATCH_FAILED;
       }
     } catch (Exception e) {
-      log.warn("{} Failed to patch pod {}/{}", LOG_PREFIX, namespace, name, e);
+      log.warn("{} Failed to patch {} {}/{}", LOG_PREFIX, target.gvr(), namespace, name, e);
       return SyncResult.PATCH_FAILED;
     }
   }
@@ -331,6 +450,57 @@ public class UserLabelSynchronizer {
     }
   }
 
+  private record SyncTarget(String group, String version, String plural) {
+
+    String apiPrefix() {
+      if (this.group.isEmpty()) {
+        return "/api/" + this.version;
+      }
+      return "/apis/" + this.group + "/" + this.version;
+    }
+
+    String gvr() {
+      if (this.group.isEmpty()) {
+        return this.version + "/" + this.plural;
+      }
+      return this.group + "/" + this.version + "/" + this.plural;
+    }
+  }
+
+  private record CycleResult(Counters total, String breakdown) {
+  }
+
+  /**
+   * Per-cycle owner state: user labels of root workload objects, loaded once per kind.
+   * A kind is in exactly one of three states — not loaded (absent from both fields),
+   * loaded ({@link #mapsByKind} entry, possibly empty), or load-failed
+   * ({@link #failedKinds} entry).
+   */
+  private static final class OwnerCache {
+
+    /** kind → (namespace::name → {username, userid}). */
+    final Map<String, Map<String, String @Nullable []>> mapsByKind = new HashMap<>();
+    /** Kinds whose owner map load failed — cached so later targets neither retry nor re-throw. */
+    final Set<String> failedKinds = new HashSet<>();
+
+    boolean isLoaded(String kind) {
+      return this.mapsByKind.containsKey(kind) || this.failedKinds.contains(kind);
+    }
+
+    boolean isFailed(String kind) {
+      return this.failedKinds.contains(kind);
+    }
+
+    String @Nullable [] lookup(String kind, String namespace, String name) {
+      Map<String, String @Nullable []> ownerMap = this.mapsByKind.get(kind);
+      if (ownerMap == null) {
+        return null;
+      }
+      return ownerMap.get(namespace + "::" + name);
+    }
+
+  }
+
   private enum SyncResult {
     ALREADY_IN_SYNC,
     PATCHED,
@@ -338,13 +508,39 @@ public class UserLabelSynchronizer {
   }
 
   private static final class Counters {
-    int totalPods;
+    int totalObjects;
     int processed;
     int skippedNoWorkloadLabel;
     int ownerLookupFailed;
     int alreadyInSync;
     int patched;
     int patchFailed;
+    int listFailed;
+    int targetFailed;
+
+    void add(Counters other) {
+      this.totalObjects += other.totalObjects;
+      this.processed += other.processed;
+      this.skippedNoWorkloadLabel += other.skippedNoWorkloadLabel;
+      this.ownerLookupFailed += other.ownerLookupFailed;
+      this.alreadyInSync += other.alreadyInSync;
+      this.patched += other.patched;
+      this.patchFailed += other.patchFailed;
+      this.listFailed += other.listFailed;
+      this.targetFailed += other.targetFailed;
+    }
+
+    String toBreakdownEntry() {
+      return "{total=" + this.totalObjects
+          + ", processed=" + this.processed
+          + ", skipped=" + this.skippedNoWorkloadLabel
+          + ", ownerLookupFailed=" + this.ownerLookupFailed
+          + ", alreadyInSync=" + this.alreadyInSync
+          + ", patched=" + this.patched
+          + ", patchFailed=" + this.patchFailed
+          + ", listFailed=" + this.listFailed
+          + ", targetFailed=" + this.targetFailed + "}";
+    }
   }
 
 }

--- a/src/test/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscoveryTest.java
+++ b/src/test/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscoveryTest.java
@@ -225,6 +225,48 @@ class ApiResourceDiscoveryTest {
     }
   }
 
+  // === getResourcesByKind — core groupVersions 버그 수정 검증 ===
+
+  @Nested
+  class GetResourcesByKind {
+
+    // 수정 전: core 루프가 groupVersions를 채우지 않아 core kind는 항상 빈 목록 반환.
+    // 수정 후: core groupResource("/pods" 등)에 "v1"이 기록되어 ResourceInfo("v1", plural) 반환.
+    @Test
+    void coreKind_returnsV1Resource() {
+      assertThat(discovery.getResourcesByKind("Pod"))
+          .containsExactly(new ApiResourceDiscovery.ResourceInfo("v1", "pods"));
+    }
+
+    @Test
+    void coreKind_namespacedService_returnsV1Resource() {
+      assertThat(discovery.getResourcesByKind("Service"))
+          .containsExactly(new ApiResourceDiscovery.ResourceInfo("v1", "services"));
+    }
+
+    @Test
+    void coreKind_clusterScoped_returnsV1Resource() {
+      assertThat(discovery.getResourcesByKind("Node"))
+          .containsExactly(new ApiResourceDiscovery.ResourceInfo("v1", "nodes"));
+    }
+
+    @Test
+    void nonCoreKind_returnsGroupVersionResource() {
+      assertThat(discovery.getResourcesByKind("Deployment"))
+          .containsExactly(new ApiResourceDiscovery.ResourceInfo("apps/v1", "deployments"));
+    }
+
+    @Test
+    void unknownKind_returnsEmptyList() {
+      assertThat(discovery.getResourcesByKind("Unknown")).isEmpty();
+    }
+
+    @Test
+    void coreGroupResource_getGroupVersion_returnsV1() {
+      assertThat(discovery.getGroupVersion("/pods")).isEqualTo("v1");
+    }
+  }
+
   // === isExist / isNamespaced 기본 동작 ===
 
   @Nested

--- a/src/test/java/io/ten1010/aipub/projectcontroller/mutating/service/UserLabelSynchronizerTest.java
+++ b/src/test/java/io/ten1010/aipub/projectcontroller/mutating/service/UserLabelSynchronizerTest.java
@@ -13,12 +13,18 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kubernetes.client.openapi.ApiClient;
 import io.ten1010.aipub.projectcontroller.domain.k8s.LabelConstants;
 import io.ten1010.aipub.projectcontroller.domain.k8s.ObjectMapperFactory;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import okhttp3.Call;
 import okhttp3.Protocol;
 import okhttp3.Request;
@@ -29,6 +35,25 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 class UserLabelSynchronizerTest {
+
+  private static final String ENCODED_SELECTOR =
+      URLEncoder.encode(LabelConstants.WORKLOAD_KIND_KEY, StandardCharsets.UTF_8);
+  // Owner LISTs match on label ABSENCE: referenced owners are always root objects
+  // without the workload-kind label (stamping webhook invariant).
+  private static final String ENCODED_OWNER_SELECTOR =
+      URLEncoder.encode("!" + LabelConstants.WORKLOAD_KIND_KEY, StandardCharsets.UTF_8);
+  // Must stay 1:1 with UserLabelSynchronizer.SYNC_TARGETS (intermediates first, pods last)
+  private static final List<String> LIST_PATH_PREFIXES = List.of(
+      "/api/v1/replicationcontrollers",
+      "/apis/apps/v1/statefulsets",
+      "/apis/apps/v1/deployments",
+      "/apis/apps/v1/replicasets",
+      "/apis/apps/v1/daemonsets",
+      "/apis/batch/v1/jobs",
+      "/apis/batch/v1/cronjobs",
+      "/api/v1/pods");
+  private static final String WORKSPACES_PREFIX = "/apis/aipub.ten1010.io/v1alpha1/workspaces";
+  private static final String OPERATIONS_PREFIX = "/apis/aipub.ten1010.io/v1alpha1/operations";
 
   private UserLabelSynchronizer synchronizer;
   private ApiClient mockApiClient;
@@ -60,14 +85,23 @@ class UserLabelSynchronizerTest {
     return call;
   }
 
-  private String podListJson(List<Map<String, Object>> pods) throws Exception {
+  private String listJson(List<Map<String, Object>> items) throws Exception {
     return this.mapper.writeValueAsString(Map.of(
         "apiVersion", "v1",
-        "kind", "PodList",
-        "items", pods));
+        "kind", "List",
+        "items", items));
   }
 
-  private Map<String, Object> podMap(String name, String namespace,
+  private String listJsonWithContinue(List<Map<String, Object>> items, String continueToken)
+      throws Exception {
+    return this.mapper.writeValueAsString(Map.of(
+        "apiVersion", "v1",
+        "kind", "List",
+        "metadata", Map.of("continue", continueToken),
+        "items", items));
+  }
+
+  private Map<String, Object> objectMap(String name, String namespace,
       Map<String, String> labels) {
     return Map.of(
         "metadata", Map.of(
@@ -76,32 +110,129 @@ class UserLabelSynchronizerTest {
             "labels", labels));
   }
 
-  private String ownerObjectJson(Map<String, String> labels) throws Exception {
-    return this.mapper.writeValueAsString(Map.of(
-        "metadata", Map.of(
-            "name", "test-workspace",
-            "namespace", "test-ns",
-            "labels", labels)));
+  /**
+   * First-page LIST path for a sync target — must match the exact query string
+   * the synchronizer builds (labelSelector on workload-kind presence, then limit).
+   */
+  private String listPath(String prefix) {
+    return prefix + "?labelSelector=" + ENCODED_SELECTOR + "&limit=500";
   }
 
-  @Test
-  void sync_noPods_doesNothing() throws Exception {
-    String emptyPodList = podListJson(List.of());
-    Call listCall = mockCallWithResponse(buildResponse(200, emptyPodList));
+  /** Continuation-page LIST path for a sync target (URL-encoded continue token). */
+  private String listPath(String prefix, String continueToken) {
+    return listPath(prefix) + "&continue="
+        + URLEncoder.encode(continueToken, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * First-page owner LIST path — labelSelector on workload-kind ABSENCE, then limit.
+   * Centralized so tests always match the implementation's query string exactly.
+   */
+  private String ownerListPath(String prefix) {
+    return prefix + "?labelSelector=" + ENCODED_OWNER_SELECTOR + "&limit=500";
+  }
+
+  /** Continuation-page owner LIST path (URL-encoded continue token). */
+  private String ownerListPath(String prefix, String continueToken) {
+    return ownerListPath(prefix) + "&continue="
+        + URLEncoder.encode(continueToken, StandardCharsets.UTF_8);
+  }
+
+  /** Returns list stubs for all 8 sync targets, each with an empty item list. */
+  private Map<String, String> emptyListStubs() throws Exception {
+    Map<String, String> stubs = new HashMap<>();
+    String empty = listJson(List.of());
+    for (String prefix : LIST_PATH_PREFIXES) {
+      stubs.put(listPath(prefix), empty);
+    }
+    return stubs;
+  }
+
+  /**
+   * Stubs all GET buildCalls keyed by request path. Unknown paths get 404,
+   * paths in serverErrorPaths get 500. A fresh Call/Response is created per
+   * invocation so bodies can be consumed independently.
+   */
+  private void stubGetByPath(Map<String, String> pathToBody, Set<String> serverErrorPaths)
+      throws Exception {
     when(this.mockApiClient.buildCall(
         anyString(), anyString(), eq("GET"),
         anyList(), anyList(), isNull(),
         anyMap(), anyMap(), anyMap(),
         any(String[].class), isNull()))
-        .thenReturn(listCall);
+        .thenAnswer(invocation -> {
+          String path = invocation.getArgument(1);
+          if (serverErrorPaths.contains(path)) {
+            return mockCallWithResponse(buildResponse(500, "{}"));
+          }
+          String body = pathToBody.get(path);
+          if (body == null) {
+            return mockCallWithResponse(buildResponse(404, ""));
+          }
+          return mockCallWithResponse(buildResponse(200, body));
+        });
+  }
 
-    this.synchronizer.sync();
+  private void stubGetByPath(Map<String, String> pathToBody) throws Exception {
+    stubGetByPath(pathToBody, Set.of());
+  }
 
+  private void stubPatchAlwaysOk() throws Exception {
+    when(this.mockApiClient.buildCall(
+        anyString(), anyString(), eq("PATCH"),
+        anyList(), anyList(), any(),
+        anyMap(), anyMap(), anyMap(),
+        any(String[].class), isNull()))
+        .thenAnswer(invocation -> mockCallWithResponse(buildResponse(200, "{}")));
+  }
+
+  private void stubWorkspaceOwnerDiscovery() {
+    when(this.mockDiscovery.getResourcesByKind("Workspace"))
+        .thenReturn(List.of(new ApiResourceDiscovery.ResourceInfo(
+            "aipub.ten1010.io/v1alpha1", "workspaces")));
+    when(this.mockDiscovery.isNamespaced("aipub.ten1010.io/workspaces")).thenReturn(true);
+  }
+
+  private void stubOperationOwnerDiscovery() {
+    when(this.mockDiscovery.getResourcesByKind("Operation"))
+        .thenReturn(List.of(new ApiResourceDiscovery.ResourceInfo(
+            "aipub.ten1010.io/v1alpha1", "operations")));
+    when(this.mockDiscovery.isNamespaced("aipub.ten1010.io/operations")).thenReturn(true);
+  }
+
+  private void verifyNeverPatched() throws Exception {
     verify(this.mockApiClient, never()).buildCall(
         anyString(), anyString(), eq("PATCH"),
         anyList(), anyList(), any(),
         anyMap(), anyMap(), anyMap(),
         any(String[].class), isNull());
+  }
+
+  private List<String> capturePatchPaths(int expectedCount) throws Exception {
+    ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
+    verify(this.mockApiClient, times(expectedCount)).buildCall(
+        anyString(), pathCaptor.capture(), eq("PATCH"),
+        anyList(), anyList(), any(),
+        anyMap(), anyMap(), anyMap(),
+        any(String[].class), isNull());
+    return pathCaptor.getAllValues();
+  }
+
+  private void verifyGetCount(String path, int expectedCount) throws Exception {
+    verify(this.mockApiClient, times(expectedCount)).buildCall(
+        anyString(), eq(path), eq("GET"),
+        anyList(), anyList(), isNull(),
+        anyMap(), anyMap(), anyMap(),
+        any(String[].class), isNull());
+  }
+
+  @Test
+  void sync_noObjects_doesNothing() throws Exception {
+    stubGetByPath(emptyListStubs());
+
+    this.synchronizer.sync();
+
+    verifyNeverPatched();
   }
 
   @Test
@@ -111,36 +242,21 @@ class UserLabelSynchronizerTest {
         LabelConstants.WORKLOAD_NAME_KEY, "my-ws",
         LabelConstants.OBJECT_OWN_USERNAME_KEY, "testuser",
         LabelConstants.OBJECT_OWN_USERID_KEY, "user-123");
-    String podList = podListJson(List.of(podMap("pod-1", "test-ns", podLabels)));
-
     Map<String, String> ownerLabels = Map.of(
         LabelConstants.OBJECT_OWN_USERNAME_KEY, "testuser",
         LabelConstants.OBJECT_OWN_USERID_KEY, "user-123");
-    String ownerJson = ownerObjectJson(ownerLabels);
 
-    Call listCall = mockCallWithResponse(buildResponse(200, podList));
-    Call ownerCall = mockCallWithResponse(buildResponse(200, ownerJson));
-
-    when(this.mockDiscovery.getResourcesByKind("Workspace"))
-        .thenReturn(List.of(new ApiResourceDiscovery.ResourceInfo(
-            "aipub.ten1010.io/v1alpha1", "workspaces")));
-    when(this.mockDiscovery.isNamespaced("aipub.ten1010.io/workspaces")).thenReturn(true);
-
-    when(this.mockApiClient.buildCall(
-        anyString(), anyString(), eq("GET"),
-        anyList(), anyList(), isNull(),
-        anyMap(), anyMap(), anyMap(),
-        any(String[].class), isNull()))
-        .thenReturn(listCall)
-        .thenReturn(ownerCall);
+    Map<String, String> stubs = emptyListStubs();
+    stubs.put(listPath("/api/v1/pods"),
+        listJson(List.of(objectMap("pod-1", "test-ns", podLabels))));
+    stubs.put(ownerListPath(WORKSPACES_PREFIX),
+        listJson(List.of(objectMap("my-ws", "test-ns", ownerLabels))));
+    stubGetByPath(stubs);
+    stubWorkspaceOwnerDiscovery();
 
     this.synchronizer.sync();
 
-    verify(this.mockApiClient, never()).buildCall(
-        anyString(), anyString(), eq("PATCH"),
-        anyList(), anyList(), any(),
-        anyMap(), anyMap(), anyMap(),
-        any(String[].class), isNull());
+    verifyNeverPatched();
   }
 
   @Test
@@ -150,44 +266,23 @@ class UserLabelSynchronizerTest {
         LabelConstants.WORKLOAD_NAME_KEY, "my-ws",
         LabelConstants.OBJECT_OWN_USERNAME_KEY, "olduser",
         LabelConstants.OBJECT_OWN_USERID_KEY, "old-123");
-    String podList = podListJson(List.of(podMap("pod-1", "test-ns", podLabels)));
-
     Map<String, String> ownerLabels = Map.of(
         LabelConstants.OBJECT_OWN_USERNAME_KEY, "newuser",
         LabelConstants.OBJECT_OWN_USERID_KEY, "new-456");
-    String ownerJson = ownerObjectJson(ownerLabels);
 
-    Call listCall = mockCallWithResponse(buildResponse(200, podList));
-    Call ownerCall = mockCallWithResponse(buildResponse(200, ownerJson));
-    Call patchCall = mockCallWithResponse(buildResponse(200, "{}"));
-
-    when(this.mockDiscovery.getResourcesByKind("Workspace"))
-        .thenReturn(List.of(new ApiResourceDiscovery.ResourceInfo(
-            "aipub.ten1010.io/v1alpha1", "workspaces")));
-    when(this.mockDiscovery.isNamespaced("aipub.ten1010.io/workspaces")).thenReturn(true);
-
-    when(this.mockApiClient.buildCall(
-        anyString(), anyString(), eq("GET"),
-        anyList(), anyList(), isNull(),
-        anyMap(), anyMap(), anyMap(),
-        any(String[].class), isNull()))
-        .thenReturn(listCall)
-        .thenReturn(ownerCall);
-
-    when(this.mockApiClient.buildCall(
-        anyString(), anyString(), eq("PATCH"),
-        anyList(), anyList(), any(),
-        anyMap(), anyMap(), anyMap(),
-        any(String[].class), isNull()))
-        .thenReturn(patchCall);
+    Map<String, String> stubs = emptyListStubs();
+    stubs.put(listPath("/api/v1/pods"),
+        listJson(List.of(objectMap("pod-1", "test-ns", podLabels))));
+    stubs.put(ownerListPath(WORKSPACES_PREFIX),
+        listJson(List.of(objectMap("my-ws", "test-ns", ownerLabels))));
+    stubGetByPath(stubs);
+    stubWorkspaceOwnerDiscovery();
+    stubPatchAlwaysOk();
 
     this.synchronizer.sync();
 
-    verify(this.mockApiClient).buildCall(
-        anyString(), anyString(), eq("PATCH"),
-        anyList(), anyList(), any(),
-        anyMap(), anyMap(), anyMap(),
-        any(String[].class), isNull());
+    List<String> patchPaths = capturePatchPaths(1);
+    assertThat(patchPaths).containsExactly("/api/v1/namespaces/test-ns/pods/pod-1");
   }
 
   @Test
@@ -195,96 +290,48 @@ class UserLabelSynchronizerTest {
     Map<String, String> podLabels = Map.of(
         LabelConstants.WORKLOAD_KIND_KEY, "Workspace",
         LabelConstants.WORKLOAD_NAME_KEY, "missing-ws");
-    String podList = podListJson(List.of(podMap("pod-1", "test-ns", podLabels)));
 
-    Call listCall = mockCallWithResponse(buildResponse(200, podList));
-    Call ownerCall = mockCallWithResponse(buildResponse(404, ""));
-
-    when(this.mockDiscovery.getResourcesByKind("Workspace"))
-        .thenReturn(List.of(new ApiResourceDiscovery.ResourceInfo(
-            "aipub.ten1010.io/v1alpha1", "workspaces")));
-    when(this.mockDiscovery.isNamespaced("aipub.ten1010.io/workspaces")).thenReturn(true);
-
-    when(this.mockApiClient.buildCall(
-        anyString(), anyString(), eq("GET"),
-        anyList(), anyList(), isNull(),
-        anyMap(), anyMap(), anyMap(),
-        any(String[].class), isNull()))
-        .thenReturn(listCall)
-        .thenReturn(ownerCall);
+    Map<String, String> stubs = emptyListStubs();
+    stubs.put(listPath("/api/v1/pods"),
+        listJson(List.of(objectMap("pod-1", "test-ns", podLabels))));
+    // Owner LIST loads fine but contains no matching owner → lookup miss → skip
+    stubs.put(ownerListPath(WORKSPACES_PREFIX), listJson(List.of()));
+    stubGetByPath(stubs);
+    stubWorkspaceOwnerDiscovery();
 
     this.synchronizer.sync();
 
-    verify(this.mockApiClient, never()).buildCall(
-        anyString(), anyString(), eq("PATCH"),
-        anyList(), anyList(), any(),
-        anyMap(), anyMap(), anyMap(),
-        any(String[].class), isNull());
+    verifyNeverPatched();
   }
 
   @Test
-  void sync_cacheHit_doesNotFetchOwnerAgain() throws Exception {
-    Map<String, String> podLabels1 = Map.of(
+  void sync_multipleObjectsSameKind_ownerListedOnce() throws Exception {
+    Map<String, String> staleLabels = Map.of(
         LabelConstants.WORKLOAD_KIND_KEY, "Workspace",
         LabelConstants.WORKLOAD_NAME_KEY, "my-ws",
         LabelConstants.OBJECT_OWN_USERNAME_KEY, "olduser",
         LabelConstants.OBJECT_OWN_USERID_KEY, "old-123");
-    Map<String, String> podLabels2 = Map.of(
-        LabelConstants.WORKLOAD_KIND_KEY, "Workspace",
-        LabelConstants.WORKLOAD_NAME_KEY, "my-ws",
-        LabelConstants.OBJECT_OWN_USERNAME_KEY, "olduser",
-        LabelConstants.OBJECT_OWN_USERID_KEY, "old-123");
-    String podList = podListJson(List.of(
-        podMap("pod-1", "test-ns", podLabels1),
-        podMap("pod-2", "test-ns", podLabels2)));
-
     Map<String, String> ownerLabels = Map.of(
         LabelConstants.OBJECT_OWN_USERNAME_KEY, "newuser",
         LabelConstants.OBJECT_OWN_USERID_KEY, "new-456");
-    String ownerJson = ownerObjectJson(ownerLabels);
 
-    Call listCall = mockCallWithResponse(buildResponse(200, podList));
-    Call ownerCall = mockCallWithResponse(buildResponse(200, ownerJson));
-    Call patchCall1 = mockCallWithResponse(buildResponse(200, "{}"));
-    Call patchCall2 = mockCallWithResponse(buildResponse(200, "{}"));
-
-    when(this.mockDiscovery.getResourcesByKind("Workspace"))
-        .thenReturn(List.of(new ApiResourceDiscovery.ResourceInfo(
-            "aipub.ten1010.io/v1alpha1", "workspaces")));
-    when(this.mockDiscovery.isNamespaced("aipub.ten1010.io/workspaces")).thenReturn(true);
-
-    // GET: first call returns pod list, second returns owner (only once)
-    when(this.mockApiClient.buildCall(
-        anyString(), anyString(), eq("GET"),
-        anyList(), anyList(), isNull(),
-        anyMap(), anyMap(), anyMap(),
-        any(String[].class), isNull()))
-        .thenReturn(listCall)
-        .thenReturn(ownerCall);
-
-    when(this.mockApiClient.buildCall(
-        anyString(), anyString(), eq("PATCH"),
-        anyList(), anyList(), any(),
-        anyMap(), anyMap(), anyMap(),
-        any(String[].class), isNull()))
-        .thenReturn(patchCall1)
-        .thenReturn(patchCall2);
+    Map<String, String> stubs = emptyListStubs();
+    stubs.put(listPath("/api/v1/pods"), listJson(List.of(
+        objectMap("pod-1", "test-ns", staleLabels),
+        objectMap("pod-2", "test-ns", staleLabels))));
+    stubs.put(ownerListPath(WORKSPACES_PREFIX),
+        listJson(List.of(objectMap("my-ws", "test-ns", ownerLabels))));
+    stubGetByPath(stubs);
+    stubWorkspaceOwnerDiscovery();
+    stubPatchAlwaysOk();
 
     this.synchronizer.sync();
 
-    // Owner fetched only once (1 list + 1 owner = 2 GET calls)
-    verify(this.mockApiClient, times(2)).buildCall(
-        anyString(), anyString(), eq("GET"),
-        anyList(), anyList(), isNull(),
-        anyMap(), anyMap(), anyMap(),
-        any(String[].class), isNull());
+    // Owner kind listed only once despite two out-of-sync pods
+    verifyGetCount(ownerListPath(WORKSPACES_PREFIX), 1);
 
     // Both pods patched
-    verify(this.mockApiClient, times(2)).buildCall(
-        anyString(), anyString(), eq("PATCH"),
-        anyList(), anyList(), any(),
-        anyMap(), anyMap(), anyMap(),
-        any(String[].class), isNull());
+    capturePatchPaths(2);
   }
 
   @Test
@@ -292,35 +339,21 @@ class UserLabelSynchronizerTest {
     Map<String, String> podLabels = Map.of(
         LabelConstants.WORKLOAD_KIND_KEY, "Workspace",
         LabelConstants.WORKLOAD_NAME_KEY, "my-ws");
-    String podList = podListJson(List.of(podMap("pod-1", "test-ns", podLabels)));
 
-    // Owner object with no labels
-    String ownerJson = this.mapper.writeValueAsString(Map.of(
-        "metadata", Map.of("name", "my-ws", "namespace", "test-ns")));
+    // Owner item with no labels object → not stored in owner map → lookup miss → skip
+    Map<String, Object> ownerWithoutLabels = Map.of(
+        "metadata", Map.of("name", "my-ws", "namespace", "test-ns"));
 
-    Call listCall = mockCallWithResponse(buildResponse(200, podList));
-    Call ownerCall = mockCallWithResponse(buildResponse(200, ownerJson));
-
-    when(this.mockDiscovery.getResourcesByKind("Workspace"))
-        .thenReturn(List.of(new ApiResourceDiscovery.ResourceInfo(
-            "aipub.ten1010.io/v1alpha1", "workspaces")));
-    when(this.mockDiscovery.isNamespaced("aipub.ten1010.io/workspaces")).thenReturn(true);
-
-    when(this.mockApiClient.buildCall(
-        anyString(), anyString(), eq("GET"),
-        anyList(), anyList(), isNull(),
-        anyMap(), anyMap(), anyMap(),
-        any(String[].class), isNull()))
-        .thenReturn(listCall)
-        .thenReturn(ownerCall);
+    Map<String, String> stubs = emptyListStubs();
+    stubs.put(listPath("/api/v1/pods"),
+        listJson(List.of(objectMap("pod-1", "test-ns", podLabels))));
+    stubs.put(ownerListPath(WORKSPACES_PREFIX), listJson(List.of(ownerWithoutLabels)));
+    stubGetByPath(stubs);
+    stubWorkspaceOwnerDiscovery();
 
     this.synchronizer.sync();
 
-    verify(this.mockApiClient, never()).buildCall(
-        anyString(), anyString(), eq("PATCH"),
-        anyList(), anyList(), any(),
-        anyMap(), anyMap(), anyMap(),
-        any(String[].class), isNull());
+    verifyNeverPatched();
   }
 
   @Test
@@ -334,6 +367,351 @@ class UserLabelSynchronizerTest {
 
     // Should not throw
     this.synchronizer.sync();
+  }
+
+  @Test
+  void sync_staleStatefulSetLabels_patchesStatefulSet() throws Exception {
+    Map<String, String> stsLabels = Map.of(
+        LabelConstants.WORKLOAD_KIND_KEY, "Workspace",
+        LabelConstants.WORKLOAD_NAME_KEY, "my-ws",
+        LabelConstants.OBJECT_OWN_USERNAME_KEY, "olduser",
+        LabelConstants.OBJECT_OWN_USERID_KEY, "old-123");
+    Map<String, String> ownerLabels = Map.of(
+        LabelConstants.OBJECT_OWN_USERNAME_KEY, "newuser",
+        LabelConstants.OBJECT_OWN_USERID_KEY, "new-456");
+
+    Map<String, String> stubs = emptyListStubs();
+    stubs.put(listPath("/apis/apps/v1/statefulsets"),
+        listJson(List.of(objectMap("sts-1", "test-ns", stsLabels))));
+    stubs.put(ownerListPath(WORKSPACES_PREFIX),
+        listJson(List.of(objectMap("my-ws", "test-ns", ownerLabels))));
+    stubGetByPath(stubs);
+    stubWorkspaceOwnerDiscovery();
+    stubPatchAlwaysOk();
+
+    this.synchronizer.sync();
+
+    List<String> patchPaths = capturePatchPaths(1);
+    assertThat(patchPaths)
+        .containsExactly("/apis/apps/v1/namespaces/test-ns/statefulsets/sts-1");
+  }
+
+  @Test
+  void sync_patchBody_containsOnlyMetadataLabels() throws Exception {
+    Map<String, String> stsLabels = Map.of(
+        LabelConstants.WORKLOAD_KIND_KEY, "Workspace",
+        LabelConstants.WORKLOAD_NAME_KEY, "my-ws",
+        LabelConstants.OBJECT_OWN_USERNAME_KEY, "olduser",
+        LabelConstants.OBJECT_OWN_USERID_KEY, "old-123");
+    Map<String, String> ownerLabels = Map.of(
+        LabelConstants.OBJECT_OWN_USERNAME_KEY, "newuser",
+        LabelConstants.OBJECT_OWN_USERID_KEY, "new-456");
+
+    Map<String, String> stubs = emptyListStubs();
+    stubs.put(listPath("/apis/apps/v1/statefulsets"),
+        listJson(List.of(objectMap("sts-1", "test-ns", stsLabels))));
+    stubs.put(ownerListPath(WORKSPACES_PREFIX),
+        listJson(List.of(objectMap("my-ws", "test-ns", ownerLabels))));
+    stubGetByPath(stubs);
+    stubWorkspaceOwnerDiscovery();
+    stubPatchAlwaysOk();
+
+    this.synchronizer.sync();
+
+    ArgumentCaptor<byte[]> bodyCaptor = ArgumentCaptor.forClass(byte[].class);
+    verify(this.mockApiClient).buildCall(
+        anyString(), anyString(), eq("PATCH"),
+        anyList(), anyList(), bodyCaptor.capture(),
+        anyMap(), anyMap(), anyMap(),
+        any(String[].class), isNull());
+
+    JsonNode body = this.mapper.readTree(bodyCaptor.getValue());
+    List<String> rootFields = new ArrayList<>();
+    body.fieldNames().forEachRemaining(rootFields::add);
+    assertThat(rootFields).containsExactly("metadata");
+
+    List<String> metadataFields = new ArrayList<>();
+    body.get("metadata").fieldNames().forEachRemaining(metadataFields::add);
+    assertThat(metadataFields).containsExactly("labels");
+
+    JsonNode labels = body.path("metadata").path("labels");
+    assertThat(labels.path(LabelConstants.OBJECT_OWN_USERNAME_KEY).textValue())
+        .isEqualTo("newuser");
+    assertThat(labels.path(LabelConstants.OBJECT_OWN_USERID_KEY).textValue())
+        .isEqualTo("new-456");
+  }
+
+  @Test
+  void sync_coreKindOwner_replicationControllerLookupSucceeds() throws Exception {
+    // Pod stamped by a bare ReplicationController: workload-kind=ReplicationController.
+    // Discovery resolves the core kind to ResourceInfo("v1", plural); the synchronizer
+    // must LIST owners via the /api/v1/replicationcontrollers path (absence selector).
+    Map<String, String> podLabels = Map.of(
+        LabelConstants.WORKLOAD_KIND_KEY, "ReplicationController",
+        LabelConstants.WORKLOAD_NAME_KEY, "my-rc",
+        LabelConstants.OBJECT_OWN_USERNAME_KEY, "olduser",
+        LabelConstants.OBJECT_OWN_USERID_KEY, "old-123");
+    Map<String, String> ownerLabels = Map.of(
+        LabelConstants.OBJECT_OWN_USERNAME_KEY, "newuser",
+        LabelConstants.OBJECT_OWN_USERID_KEY, "new-456");
+
+    Map<String, String> stubs = emptyListStubs();
+    stubs.put(listPath("/api/v1/pods"),
+        listJson(List.of(objectMap("pod-1", "test-ns", podLabels))));
+    stubs.put(ownerListPath("/api/v1/replicationcontrollers"),
+        listJson(List.of(objectMap("my-rc", "test-ns", ownerLabels))));
+    stubGetByPath(stubs);
+
+    when(this.mockDiscovery.getResourcesByKind("ReplicationController"))
+        .thenReturn(List.of(new ApiResourceDiscovery.ResourceInfo(
+            "v1", "replicationcontrollers")));
+    when(this.mockDiscovery.isNamespaced("/replicationcontrollers")).thenReturn(true);
+    stubPatchAlwaysOk();
+
+    this.synchronizer.sync();
+
+    verifyGetCount(ownerListPath("/api/v1/replicationcontrollers"), 1);
+    List<String> patchPaths = capturePatchPaths(1);
+    assertThat(patchPaths).containsExactly("/api/v1/namespaces/test-ns/pods/pod-1");
+  }
+
+  @Test
+  void sync_intermediateObjectsPatchedBeforePods() throws Exception {
+    Map<String, String> staleLabels = Map.of(
+        LabelConstants.WORKLOAD_KIND_KEY, "Workspace",
+        LabelConstants.WORKLOAD_NAME_KEY, "my-ws",
+        LabelConstants.OBJECT_OWN_USERNAME_KEY, "olduser",
+        LabelConstants.OBJECT_OWN_USERID_KEY, "old-123");
+    Map<String, String> ownerLabels = Map.of(
+        LabelConstants.OBJECT_OWN_USERNAME_KEY, "newuser",
+        LabelConstants.OBJECT_OWN_USERID_KEY, "new-456");
+
+    Map<String, String> stubs = emptyListStubs();
+    stubs.put(listPath("/apis/apps/v1/statefulsets"),
+        listJson(List.of(objectMap("sts-1", "test-ns", staleLabels))));
+    stubs.put(listPath("/api/v1/pods"),
+        listJson(List.of(objectMap("pod-1", "test-ns", staleLabels))));
+    stubs.put(ownerListPath(WORKSPACES_PREFIX),
+        listJson(List.of(objectMap("my-ws", "test-ns", ownerLabels))));
+    stubGetByPath(stubs);
+    stubWorkspaceOwnerDiscovery();
+    stubPatchAlwaysOk();
+
+    this.synchronizer.sync();
+
+    // Intermediate object (StatefulSet) must be patched before the pod
+    List<String> patchPaths = capturePatchPaths(2);
+    assertThat(patchPaths).containsExactly(
+        "/apis/apps/v1/namespaces/test-ns/statefulsets/sts-1",
+        "/api/v1/namespaces/test-ns/pods/pod-1");
+
+    // Owner maps are shared across sync targets: single owner LIST for both objects
+    verifyGetCount(ownerListPath(WORKSPACES_PREFIX), 1);
+  }
+
+  @Test
+  void sync_oneTargetListFails_otherTargetsStillProcessed() throws Exception {
+    Map<String, String> podLabels = Map.of(
+        LabelConstants.WORKLOAD_KIND_KEY, "Workspace",
+        LabelConstants.WORKLOAD_NAME_KEY, "my-ws",
+        LabelConstants.OBJECT_OWN_USERNAME_KEY, "olduser",
+        LabelConstants.OBJECT_OWN_USERID_KEY, "old-123");
+    Map<String, String> ownerLabels = Map.of(
+        LabelConstants.OBJECT_OWN_USERNAME_KEY, "newuser",
+        LabelConstants.OBJECT_OWN_USERID_KEY, "new-456");
+
+    Map<String, String> stubs = emptyListStubs();
+    stubs.put(listPath("/api/v1/pods"),
+        listJson(List.of(objectMap("pod-1", "test-ns", podLabels))));
+    stubs.put(ownerListPath(WORKSPACES_PREFIX),
+        listJson(List.of(objectMap("my-ws", "test-ns", ownerLabels))));
+    // statefulsets list fails with 500 — pods must still be processed
+    stubGetByPath(stubs, Set.of(listPath("/apis/apps/v1/statefulsets")));
+    stubWorkspaceOwnerDiscovery();
+    stubPatchAlwaysOk();
+
+    this.synchronizer.sync();
+
+    List<String> patchPaths = capturePatchPaths(1);
+    assertThat(patchPaths).containsExactly("/api/v1/namespaces/test-ns/pods/pod-1");
+  }
+
+  @Test
+  void sync_ownerKindLoadThrows_otherKindsAndTargetsStillProcessed() throws Exception {
+    // Owner kind resolution for Workspace blows up. The failure must be caught and
+    // cached as a load-failure mark: only Workspace-referencing objects are skipped,
+    // while other objects in the SAME target and later targets keep processing.
+    Map<String, String> workspaceRefLabels = Map.of(
+        LabelConstants.WORKLOAD_KIND_KEY, "Workspace",
+        LabelConstants.WORKLOAD_NAME_KEY, "my-ws",
+        LabelConstants.OBJECT_OWN_USERNAME_KEY, "olduser",
+        LabelConstants.OBJECT_OWN_USERID_KEY, "old-123");
+    Map<String, String> operationRefLabels = Map.of(
+        LabelConstants.WORKLOAD_KIND_KEY, "Operation",
+        LabelConstants.WORKLOAD_NAME_KEY, "my-op",
+        LabelConstants.OBJECT_OWN_USERNAME_KEY, "olduser",
+        LabelConstants.OBJECT_OWN_USERID_KEY, "old-123");
+    Map<String, String> ownerLabels = Map.of(
+        LabelConstants.OBJECT_OWN_USERNAME_KEY, "newuser",
+        LabelConstants.OBJECT_OWN_USERID_KEY, "new-456");
+
+    Map<String, String> stubs = emptyListStubs();
+    stubs.put(listPath("/apis/apps/v1/statefulsets"), listJson(List.of(
+        objectMap("sts-1", "test-ns", workspaceRefLabels),
+        objectMap("sts-2", "test-ns", operationRefLabels))));
+    stubs.put(listPath("/api/v1/pods"), listJson(List.of(
+        objectMap("pod-1", "test-ns", workspaceRefLabels),
+        objectMap("pod-2", "test-ns", operationRefLabels))));
+    stubs.put(ownerListPath(OPERATIONS_PREFIX),
+        listJson(List.of(objectMap("my-op", "test-ns", ownerLabels))));
+    stubGetByPath(stubs);
+
+    when(this.mockDiscovery.getResourcesByKind("Workspace"))
+        .thenThrow(new RuntimeException("discovery snapshot corrupted"));
+    stubOperationOwnerDiscovery();
+    stubPatchAlwaysOk();
+
+    this.synchronizer.sync();
+
+    // Workspace-referencing objects skipped; Operation-referencing objects patched,
+    // both in the same target as the failure (sts-2) and in a later target (pod-2)
+    List<String> patchPaths = capturePatchPaths(2);
+    assertThat(patchPaths).containsExactly(
+        "/apis/apps/v1/namespaces/test-ns/statefulsets/sts-2",
+        "/api/v1/namespaces/test-ns/pods/pod-2");
+
+    // Load-failure mark is cached: the throwing kind is resolved only once per cycle
+    verify(this.mockDiscovery, times(1)).getResourcesByKind("Workspace");
+  }
+
+  @Test
+  void sync_targetListPaginated_processesAllPages() throws Exception {
+    Map<String, String> staleLabels = Map.of(
+        LabelConstants.WORKLOAD_KIND_KEY, "Workspace",
+        LabelConstants.WORKLOAD_NAME_KEY, "my-ws",
+        LabelConstants.OBJECT_OWN_USERNAME_KEY, "olduser",
+        LabelConstants.OBJECT_OWN_USERID_KEY, "old-123");
+    Map<String, String> ownerLabels = Map.of(
+        LabelConstants.OBJECT_OWN_USERNAME_KEY, "newuser",
+        LabelConstants.OBJECT_OWN_USERID_KEY, "new-456");
+
+    // Token with characters that require URL encoding ('=', '+', '/')
+    String continueToken = "eyJydiI6MTIzNDU2Nzg5fQ+/==";
+
+    Map<String, String> stubs = emptyListStubs();
+    stubs.put(listPath("/api/v1/pods"), listJsonWithContinue(
+        List.of(objectMap("pod-1", "test-ns", staleLabels)), continueToken));
+    stubs.put(listPath("/api/v1/pods", continueToken),
+        listJson(List.of(objectMap("pod-2", "test-ns", staleLabels))));
+    stubs.put(ownerListPath(WORKSPACES_PREFIX),
+        listJson(List.of(objectMap("my-ws", "test-ns", ownerLabels))));
+    stubGetByPath(stubs);
+    stubWorkspaceOwnerDiscovery();
+    stubPatchAlwaysOk();
+
+    this.synchronizer.sync();
+
+    // Objects from both pages processed and patched
+    List<String> patchPaths = capturePatchPaths(2);
+    assertThat(patchPaths).containsExactly(
+        "/api/v1/namespaces/test-ns/pods/pod-1",
+        "/api/v1/namespaces/test-ns/pods/pod-2");
+  }
+
+  @Test
+  void sync_ownerListPaginated_accumulatesAllPages() throws Exception {
+    Map<String, String> podLabels = Map.of(
+        LabelConstants.WORKLOAD_KIND_KEY, "Workspace",
+        LabelConstants.WORKLOAD_NAME_KEY, "my-ws",
+        LabelConstants.OBJECT_OWN_USERNAME_KEY, "olduser",
+        LabelConstants.OBJECT_OWN_USERID_KEY, "old-123");
+    Map<String, String> otherOwnerLabels = Map.of(
+        LabelConstants.OBJECT_OWN_USERNAME_KEY, "otheruser",
+        LabelConstants.OBJECT_OWN_USERID_KEY, "other-789");
+    Map<String, String> ownerLabels = Map.of(
+        LabelConstants.OBJECT_OWN_USERNAME_KEY, "newuser",
+        LabelConstants.OBJECT_OWN_USERID_KEY, "new-456");
+
+    String continueToken = "b3duZXItcGFnZS0y==";
+
+    Map<String, String> stubs = emptyListStubs();
+    stubs.put(listPath("/api/v1/pods"),
+        listJson(List.of(objectMap("pod-1", "test-ns", podLabels))));
+    // Owner appears only on the second page of the owner LIST
+    stubs.put(ownerListPath(WORKSPACES_PREFIX), listJsonWithContinue(
+        List.of(objectMap("other-ws", "test-ns", otherOwnerLabels)), continueToken));
+    stubs.put(ownerListPath(WORKSPACES_PREFIX, continueToken),
+        listJson(List.of(objectMap("my-ws", "test-ns", ownerLabels))));
+    stubGetByPath(stubs);
+    stubWorkspaceOwnerDiscovery();
+    stubPatchAlwaysOk();
+
+    this.synchronizer.sync();
+
+    verifyGetCount(ownerListPath(WORKSPACES_PREFIX), 1);
+    verifyGetCount(ownerListPath(WORKSPACES_PREFIX, continueToken), 1);
+    List<String> patchPaths = capturePatchPaths(1);
+    assertThat(patchPaths).containsExactly("/api/v1/namespaces/test-ns/pods/pod-1");
+  }
+
+  @Test
+  void sync_targetListPageFails_wholeTargetSkipped() throws Exception {
+    // Page 1 succeeds with a continue token, page 2 fails with 500: the whole list
+    // must be treated as failed — objects from page 1 must NOT be processed
+    // (a partial result must never be treated as a complete one).
+    Map<String, String> podLabels = Map.of(
+        LabelConstants.WORKLOAD_KIND_KEY, "Workspace",
+        LabelConstants.WORKLOAD_NAME_KEY, "my-ws",
+        LabelConstants.OBJECT_OWN_USERNAME_KEY, "olduser",
+        LabelConstants.OBJECT_OWN_USERID_KEY, "old-123");
+    Map<String, String> ownerLabels = Map.of(
+        LabelConstants.OBJECT_OWN_USERNAME_KEY, "newuser",
+        LabelConstants.OBJECT_OWN_USERID_KEY, "new-456");
+
+    String continueToken = "cGFnZS0y==";
+
+    Map<String, String> stubs = emptyListStubs();
+    stubs.put(listPath("/api/v1/pods"), listJsonWithContinue(
+        List.of(objectMap("pod-1", "test-ns", podLabels)), continueToken));
+    stubs.put(ownerListPath(WORKSPACES_PREFIX),
+        listJson(List.of(objectMap("my-ws", "test-ns", ownerLabels))));
+    stubGetByPath(stubs, Set.of(listPath("/api/v1/pods", continueToken)));
+    stubWorkspaceOwnerDiscovery();
+    stubPatchAlwaysOk();
+
+    this.synchronizer.sync();
+
+    verifyNeverPatched();
+  }
+
+  @Test
+  void sync_continueTokenRepeats_abortsInsteadOfLooping() throws Exception {
+    // A misbehaving API server keeps returning the same continue token: the list
+    // must abort (treated as failed) instead of looping forever and wedging the
+    // single-threaded synchronizer.
+    Map<String, String> podLabels = Map.of(
+        LabelConstants.WORKLOAD_KIND_KEY, "Workspace",
+        LabelConstants.WORKLOAD_NAME_KEY, "my-ws",
+        LabelConstants.OBJECT_OWN_USERNAME_KEY, "olduser",
+        LabelConstants.OBJECT_OWN_USERID_KEY, "old-123");
+
+    String loopToken = "bG9vcC10b2tlbg==";
+    String pageWithLoopToken = listJsonWithContinue(
+        List.of(objectMap("pod-1", "test-ns", podLabels)), loopToken);
+
+    Map<String, String> stubs = emptyListStubs();
+    stubs.put(listPath("/api/v1/pods"), pageWithLoopToken);
+    // The continuation page returns the SAME token again
+    stubs.put(listPath("/api/v1/pods", loopToken), pageWithLoopToken);
+    stubGetByPath(stubs);
+    stubWorkspaceOwnerDiscovery();
+    stubPatchAlwaysOk();
+
+    this.synchronizer.sync();
+
+    // Aborted after detecting the repeated token: exactly two page GETs, no patches
+    verifyGetCount(listPath("/api/v1/pods", loopToken), 1);
+    verifyNeverPatched();
   }
 
 }


### PR DESCRIPTION
## Summary

transfer(소유권 이전) 후 StatefulSet 등 중간 오브젝트의 `username`/`userid` label이 갱신되지 않는 문제를 수정한다. 기존에는 `UserLabelSynchronizer`(5분 인프로세스 배치)가 pod만 재동기화해서:

- 중간 오브젝트(statefulsets/deployments 등)는 `NATIVE_OWNED_TARGETS` 기반 개인 Role 규칙의 원천이므로, label이 낡으면 **이전 소유자가 transfer 후에도 해당 오브젝트에 update/delete 권한을 계속 보유**하고 새 소유자는 권한을 받지 못했다
- 새 pod은 낙인 웹훅이 부모 STS의 낡은 metadata label을 복사하므로 옛 소유자 label로 태어나고, 다음 배치 사이클에야 교정되는 오염이 반복됐다

## Changes

- **UserLabelSynchronizer**: 동기화 대상을 pod 전용에서 workload-label 웹훅 rules와 1:1인 8개 GVR로 확장 — core `pods`·`replicationcontrollers`, apps/v1 `statefulsets`·`deployments`·`replicasets`·`daemonsets`, batch/v1 `jobs`·`cronjobs`. 별도 배치 신설 없이 기존 사이클 하나가 전 GVR을 순회한다.
  - 배치 주기를 완료 후 5분 → **1분**로 단축 (`scheduleWithFixedDelay`) — transfer 반영 지연 최대 1분+α
  - owner 조회를 단건 GET → **kind별 LIST**로 교체 (N+1 해소: 워크로드 M개당 M회 GET → 등장 kind 수 K회 LIST). `labelSelector=!workload-kind`로 루트만 조회 — "참조되는 owner는 항상 workload-kind label이 없는 루트"라는 낙인 웹훅 불변식 활용
  - 모든 LIST에 **페이지네이션**(limit=500 + continue) — 대규모 클러스터에서 단일 거대 응답 방지. 부분 페이지 실패는 전체 실패 처리, MAX_PAGES 상한 + 동일 continue 토큰 반복 감지 가드(단일 스레드 synchronizer 영구 중단 방지)
  - 중간 오브젝트를 pod보다 먼저 패치 — 사이클 도중 생성되는 pod이 웹훅에서 교정된 부모 label을 복사받도록
  - 실패 격리: GVR별 LIST 실패(`listFailed`)·타깃별 예상외 예외(`targetFailed`)·owner kind 로드 실패 각각 해당 범위만 skip, 사이클 요약 로그에 GVR별 breakdown
  - patch는 기존과 동일하게 `metadata.labels`만 merge-patch — **spec/spec.template 불변, 롤링 재시작 없음**
- **ApiResourceDiscovery**: core 루프가 `groupVersions`를 채우지 않아 `getResourcesByKind()`가 core kind에 대해 항상 빈 목록을 반환하던 기존 버그 수정 (bare ReplicationController 하위 pod의 owner lookup이 매 사이클 실패하던 문제)

## Test plan

- [x] `./gradlew build` 성공 (전체 테스트 포함)
- [x] `UserLabelSynchronizerTest` 17건 — STS 낡은 label 교정, patch body에 `metadata.labels`만 존재, core kind(RC) owner lookup, 중간 오브젝트 우선 순서, 타깃/kind 단위 실패 격리, 대상·owner LIST 페이지네이션, 페이지 중간 실패 전체 실패 처리, continue 토큰 반복 루프 중단
- [x] `ApiResourceDiscoveryTest` 신규 6건 — core/non-core/unknown kind 해석

🤖 Generated with [Claude Code](https://claude.com/claude-code)
