### PR TITLE
refactor: unify owned-object verbs with legacy workload path

### DIFF
--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/OwnershipPolicy.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/OwnershipPolicy.java
@@ -3,18 +3,13 @@ package io.ten1010.aipub.projectcontroller.domain.k8s;
 import java.util.List;
 
 /**
- * 생성자 소유권(creator-ownership) RBAC 정책의 단일 정의처.
- * "어떤 타입을"(OWNED_TARGETS) "어떤 verbs 로"(OWNED_VERBS) 소유자에게 부여하는지가
- * 전부 이 파일에 모여 있다. 관측 메커니즘(인포머)은 informer.owned 패키지가 담당한다.
+ * 생성자 소유권(creator-ownership) RBAC 정책의 단일 정의처: 어떤 타입을 추적하고
+ * (OWNED_TARGETS) 무엇을 제외하는지(SYSTEM_DERIVED_LABEL_KEYS)를 정의한다.
+ * 부여 verbs 는 기존 워크로드 경로와 완전히 동일하며(update/patch/delete),
+ * ReconciliationService 의 공용 빌더(buildUpdateDeleteRoleRule)가 생성한다.
+ * 관측 메커니즘(인포머)은 informer.owned 패키지가 담당한다.
  */
 public final class OwnershipPolicy {
-
-  /**
-   * 소유 오브젝트에 개인 Role 로 부여하는 verbs. 기존 워크로드 경로(UPDATABLE_VERBS)와
-   * 동일하다: 조회(create/get/watch/list)는 멤버 공통 Role 이 OWNED_TARGETS 전 타입에
-   * 네임스페이스 단위로 이미 부여하므로, 개인 Role 은 쓰기 계열만 소유 오브젝트로 제한한다.
-   */
-  public static final List<String> OWNED_VERBS = List.of("update", "patch", "delete");
 
   /**
    * 시스템 파생물 표식 레이블. 이 레이블이 붙은 오브젝트는 소유자 레이블이 있어도

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/OwnershipPolicy.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/OwnershipPolicy.java
@@ -10,11 +10,11 @@ import java.util.List;
 public final class OwnershipPolicy {
 
   /**
-   * 소유 오브젝트에 개인 Role 로 부여하는 verbs.
-   * update/patch/delete 에 더해 get 을 포함하는 이유: 멤버 공통 Role 이 조회를 주지 않는
-   * 타입이 목록에 들어올 수 있고, 중복 get 은 무해하기 때문이다.
+   * 소유 오브젝트에 개인 Role 로 부여하는 verbs. 기존 워크로드 경로(UPDATABLE_VERBS)와
+   * 동일하다: 조회(create/get/watch/list)는 멤버 공통 Role 이 OWNED_TARGETS 전 타입에
+   * 네임스페이스 단위로 이미 부여하므로, 개인 Role 은 쓰기 계열만 소유 오브젝트로 제한한다.
    */
-  public static final List<String> OWNED_VERBS = List.of("get", "update", "patch", "delete");
+  public static final List<String> OWNED_VERBS = List.of("update", "patch", "delete");
 
   /**
    * 시스템 파생물 표식 레이블. 이 레이블이 붙은 오브젝트는 소유자 레이블이 있어도

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationService.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationService.java
@@ -839,7 +839,8 @@ public class ReconciliationService {
     List<V1PolicyRule> reconciledRules = new ArrayList<>(
         reconcileAipubUserRoleRules(aipubUser, project, workloads));
     for (OwnedObject ownedObject : ownedObjects) {
-      reconciledRules.add(buildOwnedObjectRoleRule(ownedObject));
+      reconciledRules.add(buildUpdateDeleteRoleRule(ownedObject.group(),
+          ownedObject.resource(), ownedObject.name()));
     }
     return reconciledRules;
   }
@@ -1163,14 +1164,6 @@ public class ReconciliationService {
         .withResources(resource)
         .withVerbs(UPDATABLE_VERBS)
         .withResourceNames(resourceName)
-        .build();
-  }
-
-  private V1PolicyRule buildOwnedObjectRoleRule(OwnedObject ownedObject) {
-    return new V1PolicyRuleBuilder().withApiGroups(ownedObject.group())
-        .withResources(ownedObject.resource())
-        .withVerbs(OwnershipPolicy.OWNED_VERBS)
-        .withResourceNames(ownedObject.name())
         .build();
   }
 

--- a/src/test/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationServiceOwnedRulesTest.java
+++ b/src/test/java/io/ten1010/aipub/projectcontroller/domain/k8s/ReconciliationServiceOwnedRulesTest.java
@@ -63,7 +63,8 @@ class ReconciliationServiceOwnedRulesTest {
     assertThat(rule.getApiGroups()).containsExactly("");
     assertThat(rule.getResources()).containsExactly("configmaps");
     assertThat(rule.getResourceNames()).containsExactly("my-config");
-    assertThat(rule.getVerbs()).isEqualTo(OwnershipPolicy.OWNED_VERBS);
+    // 기존 워크로드 경로(buildUpdateDeleteRoleRule)와 동일한 verbs
+    assertThat(rule.getVerbs()).containsExactly("update", "patch", "delete");
   }
 
   @Test


### PR DESCRIPTION
## Summary

소유 오브젝트(네이티브 16종) 개인 Role verbs 를 기존 워크로드 경로와 동일하게 통일합니다.

| 권한 | 부여 위치 | verbs |
|---|---|---|
| 조회·생성 (네임스페이스 공개) | 멤버 공통 Role (developer) | create, get, watch, list |
| 쓰기 (소유 오브젝트 한정) | 개인 Role | **update, patch, delete** (기존 `get` 제거) |

`get` 은 임의 CRD 경로(멤버 Role 에 조회가 없던 타입) 시절의 잔재로, 16종 확정 후에는 전부 멤버 Role 이 조회를 부여하므로 중복이었습니다. 이제 기존 워크로드 8종(UPDATABLE_VERBS)과 신규 16종의 부여 체계가 완전히 동일합니다.

## Test plan

- [x] 유닛 105개 통과
- [x] kind E2E: 개인 Role 규칙 verbs=update/patch/delete 확인, 소유자 get(멤버 Role 경유)/update/delete yes, 비소유자 get yes(조회 공개)·update no

🤖 Generated with [Claude Code](https://claude.com/claude-code)