### PR TITLE
feat: refresh API resource discovery on cache miss for newly created CRDs

### DIFF
--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscovery.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscovery.java
@@ -11,6 +11,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Call;
 import okhttp3.Response;
@@ -19,13 +26,39 @@ import org.jspecify.annotations.Nullable;
 @Slf4j
 public class ApiResourceDiscovery {
 
+  /** miss로 확인된 그룹/리소스를 짧게 기억하여 반복 라이브 조회를 막는 negative cache TTL. */
+  private static final long NEGATIVE_CACHE_TTL_NANOS = TimeUnit.SECONDS.toNanos(15);
+  /**
+   * 미스 1건당 targeted refresh 대기 상한. 초과 시 기존 스냅샷 기준으로 판정한다.
+   * 한 웹훅 요청 안에서 서로 다른 그룹 미스가 순차 발생해도 누적 대기가 웹훅
+   * timeoutSeconds(10초, failurePolicy: Fail) 예산을 넘지 않도록 짧게 유지한다.
+   * 인클러스터 디스커버리 GET 수 회는 정상적으로 수백 ms 내에 끝난다.
+   */
+  private static final long PER_MISS_REFRESH_WAIT_TIMEOUT_MS = 2_000;
+
   private final ApiClient apiClient;
   private final ObjectMapper mapper;
   private volatile Snapshot snapshot;
+  /** 스냅샷 참조 교체(전체 refresh 커밋, targeted 병합)를 직렬화하는 락. 읽기는 락 없이 volatile로. */
+  private final Object snapshotWriteLock = new Object();
+  /** 그룹별 진행 중인 targeted refresh. 동일 그룹 동시 미스는 하나의 refresh를 공유한다. */
+  private final ConcurrentHashMap<String, CompletableFuture<Boolean>> inFlightGroupRefreshes =
+      new ConcurrentHashMap<>();
+  /** API 서버에도 존재하지 않는 그룹의 negative cache. 값은 만료 시각(nanoTime 기준). */
+  private final ConcurrentHashMap<String, Long> negativeGroupCache = new ConcurrentHashMap<>();
+  /** 그룹은 존재하지만 리소스가 없는 groupResource의 negative cache. 값은 만료 시각(nanoTime 기준). */
+  private final ConcurrentHashMap<String, Long> negativeGroupResourceCache =
+      new ConcurrentHashMap<>();
+  private final ExecutorService targetedRefreshExecutor;
 
   public ApiResourceDiscovery(ApiClient apiClient) {
     this.apiClient = apiClient;
     this.mapper = new ObjectMapperFactory().createObjectMapper();
+    this.targetedRefreshExecutor = Executors.newCachedThreadPool(runnable -> {
+      Thread thread = new Thread(runnable, "api-resource-discovery-targeted-refresh");
+      thread.setDaemon(true);
+      return thread;
+    });
     log.info("Initializing API resource discovery");
     this.snapshot = buildSnapshot();
     updateConfigMap(this.snapshot);
@@ -35,7 +68,12 @@ public class ApiResourceDiscovery {
     log.info("Refreshing API resource discovery");
     long startNanos = System.nanoTime();
     Snapshot newSnapshot = buildSnapshot();
-    this.snapshot = newSnapshot;
+    synchronized (this.snapshotWriteLock) {
+      this.snapshot = newSnapshot;
+    }
+    // 전체 refresh가 최신 진실이므로 negative cache를 비워 즉시 재판정 가능하게 한다.
+    this.negativeGroupCache.clear();
+    this.negativeGroupResourceCache.clear();
     updateConfigMap(newSnapshot);
     long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
     log.info("API resource discovery refresh complete: plurals={}, namespacedInfo={}, kinds={}, "
@@ -231,13 +269,200 @@ public class ApiResourceDiscovery {
   public boolean isNamespaced(String groupResource) {
     Boolean result = this.snapshot.namespacedInfo().get(groupResource);
     if (result == null) {
+      refreshOnMiss(groupResource);
+      result = this.snapshot.namespacedInfo().get(groupResource);
+    }
+    if (result == null) {
       throw new GroupResourceNotFoundException(groupResource);
     }
     return result;
   }
 
   public boolean isExist(String groupResource) {
+    if (this.snapshot.groupResources().contains(groupResource)) {
+      return true;
+    }
+    refreshOnMiss(groupResource);
     return this.snapshot.groupResources().contains(groupResource);
+  }
+
+  /**
+   * 스냅샷 미스 시 해당 그룹만 라이브로 targeted refresh 한다.
+   * CRD 생성 직후 주기적 전체 refresh(5분) 전에 들어온 웹훅 요청이 캐시 미스로 거부되는 문제를 해결.
+   *
+   * <p>동일 그룹에 대한 동시 미스는 in-flight 맵으로 하나의 refresh를 공유하고,
+   * miss로 확인된 그룹/리소스는 짧은 TTL의 negative cache로 반복 라이브 조회를 막는다.
+   * 대기 타임아웃/실패 시에는 기존 스냅샷 기준으로 판정한다(호출부 재조회가 miss 처리).
+   */
+  private void refreshOnMiss(String groupResource) {
+    String group = extractTargetedRefreshGroup(groupResource);
+    if (group == null) {
+      // 코어 리소스("" 또는 "core" alias)와 형식 오류는 targeted refresh 대상이 아님. 기존 동작 유지.
+      return;
+    }
+    if (isNegativeCached(this.negativeGroupCache, group)
+        || isNegativeCached(this.negativeGroupResourceCache, groupResource)) {
+      return;
+    }
+    CompletableFuture<Boolean> refreshFuture = this.inFlightGroupRefreshes.computeIfAbsent(group,
+        g -> CompletableFuture
+            .supplyAsync(() -> refreshGroup(g), this.targetedRefreshExecutor)
+            .whenComplete((found, throwable) -> this.inFlightGroupRefreshes.remove(g)));
+    try {
+      boolean groupFound = refreshFuture.get(PER_MISS_REFRESH_WAIT_TIMEOUT_MS,
+          TimeUnit.MILLISECONDS);
+      if (groupFound && !this.snapshot.groupResources().contains(groupResource)) {
+        // 그룹은 방금 갱신됐지만 요청된 리소스가 없음 → 리소스 단위 negative cache로 반복 재조회 차단.
+        this.negativeGroupResourceCache.put(groupResource,
+            System.nanoTime() + NEGATIVE_CACHE_TTL_NANOS);
+        log.info("Group refreshed but resource not found, negative-cached: groupResource={}, "
+                + "ttlMs={}",
+            groupResource, TimeUnit.NANOSECONDS.toMillis(NEGATIVE_CACHE_TTL_NANOS));
+      }
+    } catch (TimeoutException e) {
+      log.warn("Targeted API discovery refresh wait timed out, judging by current snapshot: "
+              + "group={}, timeoutMs={}", group, PER_MISS_REFRESH_WAIT_TIMEOUT_MS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      log.warn("Interrupted while waiting for targeted API discovery refresh: group={}", group);
+    } catch (ExecutionException e) {
+      log.error("Targeted API discovery refresh failed: group={}", group, e.getCause());
+    }
+  }
+
+  /**
+   * targeted refresh 대상 그룹을 추출한다.
+   * 코어 리소스(빈 그룹 "/pods" 형태), "core" alias, 구분자 없는 형식 오류는 null 반환.
+   */
+  @Nullable
+  private String extractTargetedRefreshGroup(String groupResource) {
+    int separatorIndex = groupResource.indexOf('/');
+    if (separatorIndex <= 0) {
+      return null;
+    }
+    String group = groupResource.substring(0, separatorIndex);
+    if ("core".equals(group)) {
+      return null;
+    }
+    return group;
+  }
+
+  private boolean isNegativeCached(ConcurrentHashMap<String, Long> cache, String key) {
+    Long deadlineNanos = cache.get(key);
+    if (deadlineNanos == null) {
+      return false;
+    }
+    if (System.nanoTime() - deadlineNanos < 0) {
+      return true;
+    }
+    cache.remove(key, deadlineNanos);
+    return false;
+  }
+
+  /**
+   * 단일 그룹의 버전/리소스를 라이브 조회하여 스냅샷에 병합한다.
+   * targetedRefreshExecutor 스레드에서 실행되며, 웹훅 대기자들은 이 결과를 공유한다.
+   *
+   * @return 그룹이 API 서버에 존재하고 리소스가 하나 이상 병합되었으면 true
+   */
+  private boolean refreshGroup(String group) {
+    log.info("Refreshing API resource discovery for missed group: group={}", group);
+    JsonNode groupNode = fetchJson("/apis/" + group);
+    if (groupNode == null) {
+      markGroupMissing(group);
+      return false;
+    }
+    List<String> groupVersionNames = new ArrayList<>();
+    for (JsonNode version : groupNode.path("versions")) {
+      String groupVersion = version.path("groupVersion").textValue();
+      if (groupVersion != null) {
+        groupVersionNames.add(groupVersion);
+      }
+    }
+
+    Map<String, String> plurals = new HashMap<>();
+    Map<String, Boolean> namespacedInfo = new HashMap<>();
+    Map<String, String> groupVersions = new HashMap<>();
+    Map<String, List<String>> kindEntries = new HashMap<>();
+    Set<String> groupResources = new HashSet<>();
+    for (String groupVersion : groupVersionNames) {
+      JsonNode resources = fetchJson("/apis/" + groupVersion);
+      if (resources == null) {
+        log.error("Targeted API group/version discovery failed: groupVersion={}", groupVersion);
+        continue;
+      }
+      for (JsonNode resource : resources.path("resources")) {
+        String name = resource.path("name").textValue();
+        if (name == null || name.contains("/")) {
+          continue;
+        }
+        String kind = resource.path("kind").textValue();
+        boolean namespaced = resource.path("namespaced").booleanValue();
+
+        String groupResource = group + "/" + name;
+        plurals.put(groupVersion + "/" + kind, name);
+        namespacedInfo.put(groupResource, namespaced);
+        groupVersions.put(groupResource, groupVersion);
+        groupResources.add(groupResource);
+        kindEntries.computeIfAbsent(kind, k -> new ArrayList<>()).add(groupResource);
+      }
+    }
+    if (groupResources.isEmpty()) {
+      markGroupMissing(group);
+      return false;
+    }
+    mergeSnapshot(plurals, namespacedInfo, groupVersions, kindEntries, groupResources);
+    log.info("Targeted API discovery refresh complete: group={}, groupVersions={}, resources={}",
+        group, groupVersionNames.size(), groupResources.size());
+    return true;
+  }
+
+  private void markGroupMissing(String group) {
+    this.negativeGroupCache.put(group, System.nanoTime() + NEGATIVE_CACHE_TTL_NANOS);
+    log.info("Group not found on API server, negative-cached: group={}, ttlMs={}",
+        group, TimeUnit.NANOSECONDS.toMillis(NEGATIVE_CACHE_TTL_NANOS));
+  }
+
+  /**
+   * targeted refresh 결과를 스냅샷에 병합한다.
+   * 기존 스냅샷의 맵을 변경하지 않고 복사 + 병합한 새 Snapshot으로 참조를 교체한다.
+   * snapshotWriteLock으로 전체 refresh 커밋 및 다른 그룹의 targeted 병합과 직렬화하여
+   * lost-update를 막는다.
+   */
+  private void mergeSnapshot(
+      Map<String, String> newPlurals,
+      Map<String, Boolean> newNamespacedInfo,
+      Map<String, String> newGroupVersions,
+      Map<String, List<String>> newKindEntries,
+      Set<String> newGroupResources) {
+    synchronized (this.snapshotWriteLock) {
+      Snapshot current = this.snapshot;
+      Map<String, String> plurals = new HashMap<>(current.plurals());
+      plurals.putAll(newPlurals);
+      Map<String, Boolean> namespacedInfo = new HashMap<>(current.namespacedInfo());
+      namespacedInfo.putAll(newNamespacedInfo);
+      Map<String, String> groupVersions = new HashMap<>(current.groupVersions());
+      groupVersions.putAll(newGroupVersions);
+      Set<String> groupResources = new HashSet<>(current.groupResources());
+      groupResources.addAll(newGroupResources);
+      Map<String, List<String>> kindDict = new HashMap<>(current.kindDict());
+      for (Map.Entry<String, List<String>> entry : newKindEntries.entrySet()) {
+        List<String> merged = new ArrayList<>(kindDict.getOrDefault(entry.getKey(), List.of()));
+        for (String groupResource : entry.getValue()) {
+          if (!merged.contains(groupResource)) {
+            merged.add(groupResource);
+          }
+        }
+        kindDict.put(entry.getKey(), merged);
+      }
+      this.snapshot = new Snapshot(plurals, namespacedInfo, groupVersions, kindDict,
+          groupResources);
+    }
+  }
+
+  /** Spring @Bean inferred destroy method — 컨텍스트 종료 시 targeted refresh executor 정리. */
+  public void shutdown() {
+    this.targetedRefreshExecutor.shutdownNow();
   }
 
   @Nullable

--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscovery.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscovery.java
@@ -49,19 +49,22 @@ public class ApiResourceDiscovery {
   /** 그룹은 존재하지만 리소스가 없는 groupResource의 negative cache. 값은 만료 시각(nanoTime 기준). */
   private final ConcurrentHashMap<String, Long> negativeGroupResourceCache =
       new ConcurrentHashMap<>();
-  private final ExecutorService targetedRefreshExecutor;
+  private final ExecutorService targetedRefreshExecutor = createTargetedRefreshExecutor();
 
   public ApiResourceDiscovery(ApiClient apiClient) {
     this.apiClient = apiClient;
     this.mapper = new ObjectMapperFactory().createObjectMapper();
-    this.targetedRefreshExecutor = Executors.newCachedThreadPool(runnable -> {
+    log.info("Initializing API resource discovery");
+    this.snapshot = buildSnapshot();
+    updateConfigMap(this.snapshot);
+  }
+
+  private static ExecutorService createTargetedRefreshExecutor() {
+    return Executors.newCachedThreadPool(runnable -> {
       Thread thread = new Thread(runnable, "api-resource-discovery-targeted-refresh");
       thread.setDaemon(true);
       return thread;
     });
-    log.info("Initializing API resource discovery");
-    this.snapshot = buildSnapshot();
-    updateConfigMap(this.snapshot);
   }
 
   public void refresh() {

--- a/src/test/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscoveryTest.java
+++ b/src/test/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscoveryTest.java
@@ -4,10 +4,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import okhttp3.Call;
 import okhttp3.MediaType;
 import okhttp3.Protocol;
@@ -293,6 +303,221 @@ class ApiResourceDiscoveryTest {
     @Test
     void coreAliasResource_doesNotExist() {
       assertThat(discovery.isExist("core/pods")).isFalse();
+    }
+  }
+
+  // === refresh-on-miss — 스냅샷 미스 시 targeted refresh ===
+
+  @Nested
+  class RefreshOnMiss {
+
+    // (a) 스냅샷 미스 → 해당 그룹만 targeted refresh → 히트.
+    // CRD 생성 직후 5분 주기 전체 refresh 전에 들어온 웹훅 요청이 400 거부되던 문제의 재현/수정 검증.
+    @Test
+    void missedGroup_targetedRefresh_thenHit() throws Exception {
+      mockApiCallRepeatable("/apis/qa-collision.ten1010.io", """
+          {
+            "kind": "APIGroup",
+            "name": "qa-collision.ten1010.io",
+            "versions": [
+              {"groupVersion": "qa-collision.ten1010.io/v1", "version": "v1"},
+              {"groupVersion": "qa-collision.ten1010.io/v2", "version": "v2"}
+            ]
+          }
+          """);
+      mockApiCallRepeatable("/apis/qa-collision.ten1010.io/v1", """
+          {
+            "resources": [
+              {"name": "qamultiversions", "kind": "QaMultiVersion", "namespaced": true}
+            ]
+          }
+          """);
+      mockApiCallRepeatable("/apis/qa-collision.ten1010.io/v2", """
+          {
+            "resources": [
+              {"name": "qamultiversions", "kind": "QaMultiVersion", "namespaced": true}
+            ]
+          }
+          """);
+
+      assertThat(discovery.isExist("qa-collision.ten1010.io/qamultiversions")).isTrue();
+      assertThat(discovery.isNamespaced("qa-collision.ten1010.io/qamultiversions")).isTrue();
+      assertThat(discovery.getGroupVersion("qa-collision.ten1010.io/qamultiversions"))
+          .isEqualTo("qa-collision.ten1010.io/v2");
+      // 병합이 기존 스냅샷 항목을 덮어쓰지 않음
+      assertThat(discovery.isExist("/pods")).isTrue();
+      assertThat(discovery.isExist("apps/deployments")).isTrue();
+      assertThat(discovery.getResourcesByKind("Deployment"))
+          .containsExactly(new ApiResourceDiscovery.ResourceInfo("apps/v1", "deployments"));
+      // 첫 miss의 targeted refresh 이후에는 스냅샷 히트 → 그룹 재조회 없음
+      verifyBuildCallCount("/apis/qa-collision.ten1010.io", 1);
+      verifyBuildCallCount("/apis/qa-collision.ten1010.io/v1", 1);
+      verifyBuildCallCount("/apis/qa-collision.ten1010.io/v2", 1);
+    }
+
+    // (b) API 서버에도 없는 그룹 → miss + 그룹 negative cache. TTL 내 동일 그룹 재조회 없음.
+    @Test
+    void missingGroup_negativeCached_noRepeatedApiCalls() throws Exception {
+      mockApiCallNotFound("/apis/ghost.example.io");
+
+      assertThat(discovery.isExist("ghost.example.io/things")).isFalse();
+      // TTL 내 동일 그룹의 어떤 리소스든 API 호출 없이 즉시 miss
+      assertThat(discovery.isExist("ghost.example.io/things")).isFalse();
+      assertThat(discovery.isExist("ghost.example.io/others")).isFalse();
+      assertThatThrownBy(() -> discovery.isNamespaced("ghost.example.io/things"))
+          .isInstanceOf(GroupResourceNotFoundException.class);
+
+      verifyBuildCallCount("/apis/ghost.example.io", 1);
+    }
+
+    // (c) 동일 그룹 동시 미스 → in-flight refresh 하나를 공유, API 호출 1회
+    @Test
+    void concurrentMisses_shareSingleInFlightRefresh() throws Exception {
+      CountDownLatch releaseLatch = new CountDownLatch(1);
+      Call groupCall = mock(Call.class);
+      when(groupCall.execute()).thenAnswer(invocation -> {
+        // 두 스레드 모두 in-flight future 대기에 진입할 때까지 응답을 지연
+        releaseLatch.await(5, TimeUnit.SECONDS);
+        return buildJsonResponse("/apis/newgroup.example.io", 200, """
+            {
+              "kind": "APIGroup",
+              "name": "newgroup.example.io",
+              "versions": [{"groupVersion": "newgroup.example.io/v1", "version": "v1"}]
+            }
+            """);
+      });
+      when(mockApiClient.buildCall(
+          any(), eq("/apis/newgroup.example.io"), any(), any(), any(), any(), any(), any(), any(),
+          any(), any()))
+          .thenReturn(groupCall);
+      mockApiCallRepeatable("/apis/newgroup.example.io/v1", """
+          {
+            "resources": [
+              {"name": "newthings", "kind": "NewThing", "namespaced": true}
+            ]
+          }
+          """);
+
+      ExecutorService pool = Executors.newFixedThreadPool(2);
+      try {
+        CountDownLatch started = new CountDownLatch(2);
+        List<Future<Boolean>> results = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+          results.add(pool.submit(() -> {
+            started.countDown();
+            return discovery.isExist("newgroup.example.io/newthings");
+          }));
+        }
+        assertThat(started.await(2, TimeUnit.SECONDS)).isTrue();
+        Thread.sleep(300);
+        releaseLatch.countDown();
+
+        assertThat(results.get(0).get(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(results.get(1).get(5, TimeUnit.SECONDS)).isTrue();
+      } finally {
+        pool.shutdownNow();
+      }
+
+      verifyBuildCallCount("/apis/newgroup.example.io", 1);
+      verifyBuildCallCount("/apis/newgroup.example.io/v1", 1);
+    }
+
+    // (d) 기존 히트 경로는 API 호출 없음
+    @Test
+    void hitPath_makesNoApiCalls() {
+      clearInvocations(mockApiClient);
+
+      assertThat(discovery.isExist("apps/deployments")).isTrue();
+      assertThat(discovery.isNamespaced("apps/deployments")).isTrue();
+      assertThat(discovery.isExist("/pods")).isTrue();
+      assertThat(discovery.isNamespaced("/nodes")).isFalse();
+
+      verifyNoBuildCall();
+    }
+
+    // 코어 그룹("", "core" alias)과 형식 오류의 미스는 targeted refresh 대상이 아님 — 기존 동작 유지
+    @Test
+    void coreOrMalformedMiss_doesNotTriggerTargetedRefresh() {
+      clearInvocations(mockApiClient);
+
+      assertThat(discovery.isExist("/ghosts")).isFalse();
+      assertThat(discovery.isExist("core/ghosts")).isFalse();
+      assertThat(discovery.isExist("noslash")).isFalse();
+      assertThatThrownBy(() -> discovery.isNamespaced("/ghosts"))
+          .isInstanceOf(GroupResourceNotFoundException.class);
+
+      verifyNoBuildCall();
+    }
+
+    // 그룹은 존재하지만 요청 리소스가 없음 → miss + 리소스 단위 negative cache.
+    // TTL 내 동일 groupResource 반복 미스가 그룹 재조회를 유발하지 않음.
+    @Test
+    void existingGroup_missingResource_negativeCachedPerResource() throws Exception {
+      mockApiCallRepeatable("/apis/qa.example.io", """
+          {
+            "kind": "APIGroup",
+            "name": "qa.example.io",
+            "versions": [{"groupVersion": "qa.example.io/v1", "version": "v1"}]
+          }
+          """);
+      mockApiCallRepeatable("/apis/qa.example.io/v1", """
+          {
+            "resources": [
+              {"name": "widgets", "kind": "Widget", "namespaced": true}
+            ]
+          }
+          """);
+
+      assertThat(discovery.isExist("qa.example.io/gadgets")).isFalse();
+      assertThat(discovery.isExist("qa.example.io/gadgets")).isFalse();
+      // targeted refresh로 병합된 같은 그룹의 실제 리소스는 히트
+      assertThat(discovery.isExist("qa.example.io/widgets")).isTrue();
+
+      verifyBuildCallCount("/apis/qa.example.io", 1);
+      verifyBuildCallCount("/apis/qa.example.io/v1", 1);
+    }
+
+    private void mockApiCallRepeatable(String path, String responseBody) throws Exception {
+      Call call = mock(Call.class);
+      // Response body는 1회성이므로 호출마다 새 Response 생성
+      when(call.execute()).thenAnswer(invocation -> buildJsonResponse(path, 200, responseBody));
+      when(mockApiClient.buildCall(
+          any(), eq(path), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+          .thenReturn(call);
+    }
+
+    private void mockApiCallNotFound(String path) throws Exception {
+      Call call = mock(Call.class);
+      when(call.execute()).thenAnswer(invocation -> buildJsonResponse(path, 404, """
+          {"kind": "Status", "status": "Failure", "reason": "NotFound", "code": 404}
+          """));
+      when(mockApiClient.buildCall(
+          any(), eq(path), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+          .thenReturn(call);
+    }
+
+    private Response buildJsonResponse(String path, int code, String body) {
+      return new Response.Builder()
+          .request(new Request.Builder().url("https://localhost:6443" + path).build())
+          .protocol(Protocol.HTTP_1_1)
+          .code(code)
+          .message(code == 200 ? "OK" : "Not Found")
+          .body(ResponseBody.create(body, MediaType.get("application/json")))
+          .build();
+    }
+
+    private void verifyBuildCallCount(String path, int expectedCount) throws Exception {
+      verify(mockApiClient, times(expectedCount)).buildCall(
+          any(), eq(path), any(), any(), any(), any(), any(), any(), any(), any(), any());
+    }
+
+    private void verifyNoBuildCall() {
+      try {
+        verify(mockApiClient, never()).buildCall(
+            any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+      } catch (Exception e) {
+        throw new AssertionError(e);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- UserAuthorityReview mutating webhook rejected requests with `Not found group/resource: <group>/<resource>` when the target CRD was created after the last discovery snapshot, because `ApiResourceDiscovery` only rebuilds its in-memory snapshot at startup and every 5 minutes (`ApiResourceDiscoveryRefresher`).
- On a snapshot miss, `isExist()`/`isNamespaced()` now perform a targeted live re-discovery of just the missed group (`GET /apis/<group>` → each `GET /apis/<groupVersion>`) and merge the result into the snapshot before re-judging.

## Changes
- `ApiResourceDiscovery.java` (only production change; callers, webhook configs, Helm charts, and RBAC are untouched)
  - **Refresh-on-miss**: targeted re-discovery of the missed group, merged copy-on-write into the volatile snapshot under a write lock (no lost updates against the periodic full refresh).
  - **In-flight sharing**: concurrent misses on the same group share a single in-flight refresh via `ConcurrentHashMap` + `computeIfAbsent`; entries are removed on completion.
  - **Bounded blocking**: each miss waits at most 2s, then falls back to the current snapshot while the refresh continues in the background — keeps cumulative waits within the webhook `timeoutSeconds: 10` (`failurePolicy: Fail`) budget.
  - **Negative caching (15s TTL)**: groups missing from the API server and existing-group/missing-resource combinations are negative-cached to prevent repeated live lookups; cleared on every periodic full refresh.
  - Core resources (empty group / `core` alias) keep the previous behavior and are never targeted-refreshed.
- `ApiResourceDiscoveryTest.java`: 6 new tests covering miss→refresh→hit (multi-version merge), negative cache TTL behavior, single shared refresh under concurrent misses, no API calls on the hit path, core-group exclusion, and resource-level negative caching.

## Test plan
- [x] `./gradlew build` passes
- [x] `./gradlew test` passes (`ApiResourceDiscoveryTest` 25 tests: 19 existing + 6 new)
- [x] Original bug scenario reproduced in a test with `qa-collision.ten1010.io/qamultiversions`: after CRD creation, the first webhook lookup triggers a targeted refresh and succeeds instead of returning 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)