### PR TITLE
fix: look up only the missed CRD instead of re-discovering its group

### DIFF
--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscovery.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscovery.java
@@ -29,6 +29,13 @@ public class ApiResourceDiscovery {
   /** miss로 확인된 그룹/리소스를 짧게 기억하여 반복 라이브 조회를 막는 negative cache TTL. */
   private static final long NEGATIVE_CACHE_TTL_NANOS = TimeUnit.SECONDS.toNanos(15);
   /**
+   * targeted refresh 완료 직후 같은 그룹의 미스가 재조회를 다시 트리거하지 않는 쿨다운.
+   * RBAC 룰의 그룹×리소스 크로스곱 조회처럼 없는 조합이 연달아 들어와도 그룹당 재조회는
+   * 쿨다운마다 최대 1회로 제한된다. 쿨다운 중 새로 생긴 CRD의 인식은 최대 이 시간만큼 늦어질
+   * 수 있으므로 negative cache TTL보다 짧게 유지한다.
+   */
+  private static final long GROUP_REFRESH_COOLDOWN_NANOS = TimeUnit.SECONDS.toNanos(5);
+  /**
    * 미스 1건당 targeted refresh 대기 상한. 초과 시 기존 스냅샷 기준으로 판정한다.
    * 한 웹훅 요청 안에서 서로 다른 그룹 미스가 순차 발생해도 누적 대기가 웹훅
    * timeoutSeconds(10초, failurePolicy: Fail) 예산을 넘지 않도록 짧게 유지한다.
@@ -46,8 +53,8 @@ public class ApiResourceDiscovery {
       new ConcurrentHashMap<>();
   /** API 서버에도 존재하지 않는 그룹의 negative cache. 값은 만료 시각(nanoTime 기준). */
   private final ConcurrentHashMap<String, Long> negativeGroupCache = new ConcurrentHashMap<>();
-  /** 그룹은 존재하지만 리소스가 없는 groupResource의 negative cache. 값은 만료 시각(nanoTime 기준). */
-  private final ConcurrentHashMap<String, Long> negativeGroupResourceCache =
+  /** targeted refresh가 최근 완료된 그룹의 쿨다운. 값은 만료 시각(nanoTime 기준). */
+  private final ConcurrentHashMap<String, Long> refreshedGroupCooldowns =
       new ConcurrentHashMap<>();
   private final ExecutorService targetedRefreshExecutor = createTargetedRefreshExecutor();
 
@@ -74,9 +81,9 @@ public class ApiResourceDiscovery {
     synchronized (this.snapshotWriteLock) {
       this.snapshot = newSnapshot;
     }
-    // 전체 refresh가 최신 진실이므로 negative cache를 비워 즉시 재판정 가능하게 한다.
+    // 전체 refresh가 최신 진실이므로 negative cache와 쿨다운을 비워 즉시 재판정 가능하게 한다.
     this.negativeGroupCache.clear();
-    this.negativeGroupResourceCache.clear();
+    this.refreshedGroupCooldowns.clear();
     updateConfigMap(newSnapshot);
     long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
     log.info("API resource discovery refresh complete: plurals={}, namespacedInfo={}, kinds={}, "
@@ -293,8 +300,9 @@ public class ApiResourceDiscovery {
    * 스냅샷 미스 시 해당 그룹만 라이브로 targeted refresh 한다.
    * CRD 생성 직후 주기적 전체 refresh(5분) 전에 들어온 웹훅 요청이 캐시 미스로 거부되는 문제를 해결.
    *
-   * <p>동일 그룹에 대한 동시 미스는 in-flight 맵으로 하나의 refresh를 공유하고,
-   * miss로 확인된 그룹/리소스는 짧은 TTL의 negative cache로 반복 라이브 조회를 막는다.
+   * <p>동일 그룹에 대한 동시 미스는 in-flight 맵으로 하나의 refresh를 공유한다.
+   * 존재하지 않는 그룹은 짧은 TTL의 negative cache로, 방금 재조회된 그룹은 그룹 단위
+   * 쿨다운으로 반복 라이브 조회를 막는다(쿨다운 내 미스는 신선한 스냅샷 기준의 확정 miss).
    * 대기 타임아웃/실패 시에는 기존 스냅샷 기준으로 판정한다(호출부 재조회가 miss 처리).
    */
   private void refreshOnMiss(String groupResource) {
@@ -303,8 +311,8 @@ public class ApiResourceDiscovery {
       // 코어 리소스("" 또는 "core" alias)와 형식 오류는 targeted refresh 대상이 아님. 기존 동작 유지.
       return;
     }
-    if (isNegativeCached(this.negativeGroupCache, group)
-        || isNegativeCached(this.negativeGroupResourceCache, groupResource)) {
+    if (isWithinTtl(this.negativeGroupCache, group)
+        || isWithinTtl(this.refreshedGroupCooldowns, group)) {
       return;
     }
     CompletableFuture<Boolean> refreshFuture = this.inFlightGroupRefreshes.computeIfAbsent(group,
@@ -315,12 +323,7 @@ public class ApiResourceDiscovery {
       boolean groupFound = refreshFuture.get(PER_MISS_REFRESH_WAIT_TIMEOUT_MS,
           TimeUnit.MILLISECONDS);
       if (groupFound && !this.snapshot.groupResources().contains(groupResource)) {
-        // 그룹은 방금 갱신됐지만 요청된 리소스가 없음 → 리소스 단위 negative cache로 반복 재조회 차단.
-        this.negativeGroupResourceCache.put(groupResource,
-            System.nanoTime() + NEGATIVE_CACHE_TTL_NANOS);
-        log.info("Group refreshed but resource not found, negative-cached: groupResource={}, "
-                + "ttlMs={}",
-            groupResource, TimeUnit.NANOSECONDS.toMillis(NEGATIVE_CACHE_TTL_NANOS));
+        log.debug("Group refreshed but resource not found: groupResource={}", groupResource);
       }
     } catch (TimeoutException e) {
       log.warn("Targeted API discovery refresh wait timed out, judging by current snapshot: "
@@ -350,7 +353,7 @@ public class ApiResourceDiscovery {
     return group;
   }
 
-  private boolean isNegativeCached(ConcurrentHashMap<String, Long> cache, String key) {
+  private boolean isWithinTtl(ConcurrentHashMap<String, Long> cache, String key) {
     Long deadlineNanos = cache.get(key);
     if (deadlineNanos == null) {
       return false;
@@ -415,6 +418,7 @@ public class ApiResourceDiscovery {
       return false;
     }
     mergeSnapshot(plurals, namespacedInfo, groupVersions, kindEntries, groupResources);
+    this.refreshedGroupCooldowns.put(group, System.nanoTime() + GROUP_REFRESH_COOLDOWN_NANOS);
     log.info("Targeted API discovery refresh complete: group={}, groupVersions={}, resources={}",
         group, groupVersionNames.size(), groupResources.size());
     return true;

--- a/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscovery.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscovery.java
@@ -26,37 +26,28 @@ import org.jspecify.annotations.Nullable;
 @Slf4j
 public class ApiResourceDiscovery {
 
-  /** miss로 확인된 그룹/리소스를 짧게 기억하여 반복 라이브 조회를 막는 negative cache TTL. */
+  /** miss로 확인된 group/resource 조합을 짧게 기억하여 반복 조회를 막는 negative cache TTL. */
   private static final long NEGATIVE_CACHE_TTL_NANOS = TimeUnit.SECONDS.toNanos(15);
   /**
-   * targeted refresh 완료 직후 같은 그룹의 미스가 재조회를 다시 트리거하지 않는 쿨다운.
-   * RBAC 룰의 그룹×리소스 크로스곱 조회처럼 없는 조합이 연달아 들어와도 그룹당 재조회는
-   * 쿨다운마다 최대 1회로 제한된다. 쿨다운 중 새로 생긴 CRD의 인식은 최대 이 시간만큼 늦어질
-   * 수 있으므로 negative cache TTL보다 짧게 유지한다.
-   */
-  private static final long GROUP_REFRESH_COOLDOWN_NANOS = TimeUnit.SECONDS.toNanos(5);
-  /**
-   * 미스 1건당 targeted refresh 대기 상한. 초과 시 기존 스냅샷 기준으로 판정한다.
-   * 한 웹훅 요청 안에서 서로 다른 그룹 미스가 순차 발생해도 누적 대기가 웹훅
+   * 미스 1건당 CRD 단건 조회 대기 상한. 초과 시 기존 스냅샷 기준으로 판정한다.
+   * 한 웹훅 요청 안에서 서로 다른 조합 미스가 순차 발생해도 누적 대기가 웹훅
    * timeoutSeconds(10초, failurePolicy: Fail) 예산을 넘지 않도록 짧게 유지한다.
-   * 인클러스터 디스커버리 GET 수 회는 정상적으로 수백 ms 내에 끝난다.
+   * 단일 오브젝트 GET은 정상적으로 수십 ms 내에 끝난다.
    */
-  private static final long PER_MISS_REFRESH_WAIT_TIMEOUT_MS = 2_000;
+  private static final long PER_MISS_LOOKUP_WAIT_TIMEOUT_MS = 2_000;
 
   private final ApiClient apiClient;
   private final ObjectMapper mapper;
   private volatile Snapshot snapshot;
   /** 스냅샷 참조 교체(전체 refresh 커밋, targeted 병합)를 직렬화하는 락. 읽기는 락 없이 volatile로. */
   private final Object snapshotWriteLock = new Object();
-  /** 그룹별 진행 중인 targeted refresh. 동일 그룹 동시 미스는 하나의 refresh를 공유한다. */
-  private final ConcurrentHashMap<String, CompletableFuture<Boolean>> inFlightGroupRefreshes =
+  /** group/resource 조합별 진행 중인 CRD 단건 조회. 동일 조합 동시 미스는 하나의 조회를 공유한다. */
+  private final ConcurrentHashMap<String, CompletableFuture<Boolean>> inFlightResourceLookups =
       new ConcurrentHashMap<>();
-  /** API 서버에도 존재하지 않는 그룹의 negative cache. 값은 만료 시각(nanoTime 기준). */
-  private final ConcurrentHashMap<String, Long> negativeGroupCache = new ConcurrentHashMap<>();
-  /** targeted refresh가 최근 완료된 그룹의 쿨다운. 값은 만료 시각(nanoTime 기준). */
-  private final ConcurrentHashMap<String, Long> refreshedGroupCooldowns =
+  /** CRD가 없거나 서빙되지 않는 group/resource 조합의 negative cache. 값은 만료 시각(nanoTime 기준). */
+  private final ConcurrentHashMap<String, Long> negativeGroupResourceCache =
       new ConcurrentHashMap<>();
-  private final ExecutorService targetedRefreshExecutor = createTargetedRefreshExecutor();
+  private final ExecutorService resourceLookupExecutor = createResourceLookupExecutor();
 
   public ApiResourceDiscovery(ApiClient apiClient) {
     this.apiClient = apiClient;
@@ -66,9 +57,9 @@ public class ApiResourceDiscovery {
     updateConfigMap(this.snapshot);
   }
 
-  private static ExecutorService createTargetedRefreshExecutor() {
+  private static ExecutorService createResourceLookupExecutor() {
     return Executors.newCachedThreadPool(runnable -> {
-      Thread thread = new Thread(runnable, "api-resource-discovery-targeted-refresh");
+      Thread thread = new Thread(runnable, "api-resource-discovery-crd-lookup");
       thread.setDaemon(true);
       return thread;
     });
@@ -81,9 +72,8 @@ public class ApiResourceDiscovery {
     synchronized (this.snapshotWriteLock) {
       this.snapshot = newSnapshot;
     }
-    // 전체 refresh가 최신 진실이므로 negative cache와 쿨다운을 비워 즉시 재판정 가능하게 한다.
-    this.negativeGroupCache.clear();
-    this.refreshedGroupCooldowns.clear();
+    // 전체 refresh가 최신 진실이므로 negative cache를 비워 즉시 재판정 가능하게 한다.
+    this.negativeGroupResourceCache.clear();
     updateConfigMap(newSnapshot);
     long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
     log.info("API resource discovery refresh complete: plurals={}, namespacedInfo={}, kinds={}, "
@@ -297,60 +287,61 @@ public class ApiResourceDiscovery {
   }
 
   /**
-   * 스냅샷 미스 시 해당 그룹만 라이브로 targeted refresh 한다.
-   * CRD 생성 직후 주기적 전체 refresh(5분) 전에 들어온 웹훅 요청이 캐시 미스로 거부되는 문제를 해결.
+   * 스냅샷 미스 시 해당 group/resource의 CRD만 이름({@code <plural>.<group>})으로 단건
+   * 조회하여 스냅샷에 병합한다. CRD 생성 직후 주기적 전체 refresh(5분) 전에 들어온 웹훅
+   * 요청이 캐시 미스로 거부되는 문제를, 그룹 전체 디스커버리 없이 요청된 리소스만 조회해서 해결.
    *
-   * <p>동일 그룹에 대한 동시 미스는 in-flight 맵으로 하나의 refresh를 공유한다.
-   * 존재하지 않는 그룹은 짧은 TTL의 negative cache로, 방금 재조회된 그룹은 그룹 단위
-   * 쿨다운으로 반복 라이브 조회를 막는다(쿨다운 내 미스는 신선한 스냅샷 기준의 확정 miss).
-   * 대기 타임아웃/실패 시에는 기존 스냅샷 기준으로 판정한다(호출부 재조회가 miss 처리).
+   * <p>동일 조합에 대한 동시 미스는 in-flight 맵으로 하나의 조회를 공유하고, miss로 확인된
+   * 조합은 짧은 TTL의 negative cache로 반복 조회를 막는다. 대기 타임아웃/실패 시에는 기존
+   * 스냅샷 기준으로 판정한다(호출부 재조회가 miss 처리).
+   *
+   * <p>CRD가 아닌 aggregated API 리소스는 이 경로로 발견되지 않으며 주기적 전체 refresh에서
+   * 수렴한다.
    */
   private void refreshOnMiss(String groupResource) {
-    String group = extractTargetedRefreshGroup(groupResource);
-    if (group == null) {
-      // 코어 리소스("" 또는 "core" alias)와 형식 오류는 targeted refresh 대상이 아님. 기존 동작 유지.
+    String[] groupAndResource = parseCustomGroupResource(groupResource);
+    if (groupAndResource == null) {
+      // 코어 리소스("" 또는 "core" alias)와 형식 오류는 CRD 조회 대상이 아님. 기존 동작 유지.
       return;
     }
-    if (isWithinTtl(this.negativeGroupCache, group)
-        || isWithinTtl(this.refreshedGroupCooldowns, group)) {
+    if (isWithinTtl(this.negativeGroupResourceCache, groupResource)) {
       return;
     }
-    CompletableFuture<Boolean> refreshFuture = this.inFlightGroupRefreshes.computeIfAbsent(group,
-        g -> CompletableFuture
-            .supplyAsync(() -> refreshGroup(g), this.targetedRefreshExecutor)
-            .whenComplete((found, throwable) -> this.inFlightGroupRefreshes.remove(g)));
+    CompletableFuture<Boolean> lookupFuture = this.inFlightResourceLookups.computeIfAbsent(
+        groupResource,
+        gr -> CompletableFuture
+            .supplyAsync(
+                () -> lookupCustomResourceDefinition(gr, groupAndResource[0], groupAndResource[1]),
+                this.resourceLookupExecutor)
+            .whenComplete((found, throwable) -> this.inFlightResourceLookups.remove(gr)));
     try {
-      boolean groupFound = refreshFuture.get(PER_MISS_REFRESH_WAIT_TIMEOUT_MS,
-          TimeUnit.MILLISECONDS);
-      if (groupFound && !this.snapshot.groupResources().contains(groupResource)) {
-        log.debug("Group refreshed but resource not found: groupResource={}", groupResource);
-      }
+      lookupFuture.get(PER_MISS_LOOKUP_WAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     } catch (TimeoutException e) {
-      log.warn("Targeted API discovery refresh wait timed out, judging by current snapshot: "
-              + "group={}, timeoutMs={}", group, PER_MISS_REFRESH_WAIT_TIMEOUT_MS);
+      log.warn("CRD lookup wait timed out, judging by current snapshot: groupResource={}, "
+          + "timeoutMs={}", groupResource, PER_MISS_LOOKUP_WAIT_TIMEOUT_MS);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      log.warn("Interrupted while waiting for targeted API discovery refresh: group={}", group);
+      log.warn("Interrupted while waiting for CRD lookup: groupResource={}", groupResource);
     } catch (ExecutionException e) {
-      log.error("Targeted API discovery refresh failed: group={}", group, e.getCause());
+      log.error("CRD lookup failed: groupResource={}", groupResource, e.getCause());
     }
   }
 
   /**
-   * targeted refresh 대상 그룹을 추출한다.
-   * 코어 리소스(빈 그룹 "/pods" 형태), "core" alias, 구분자 없는 형식 오류는 null 반환.
+   * CRD 단건 조회 대상인 커스텀 group/resource를 {group, resource}로 분해한다.
+   * 코어 리소스(빈 그룹 "/pods" 형태), "core" alias, 형식 오류는 null 반환.
    */
   @Nullable
-  private String extractTargetedRefreshGroup(String groupResource) {
+  private String[] parseCustomGroupResource(String groupResource) {
     int separatorIndex = groupResource.indexOf('/');
-    if (separatorIndex <= 0) {
+    if (separatorIndex <= 0 || separatorIndex == groupResource.length() - 1) {
       return null;
     }
     String group = groupResource.substring(0, separatorIndex);
     if ("core".equals(group)) {
       return null;
     }
-    return group;
+    return new String[] {group, groupResource.substring(separatorIndex + 1)};
   }
 
   private boolean isWithinTtl(ConcurrentHashMap<String, Long> cache, String key) {
@@ -366,68 +357,81 @@ public class ApiResourceDiscovery {
   }
 
   /**
-   * 단일 그룹의 버전/리소스를 라이브 조회하여 스냅샷에 병합한다.
-   * targetedRefreshExecutor 스레드에서 실행되며, 웹훅 대기자들은 이 결과를 공유한다.
+   * CRD를 이름({@code <plural>.<group>})으로 단건 조회하여 해당 리소스만 스냅샷에 병합한다.
+   * resourceLookupExecutor 스레드에서 실행되며, 웹훅 대기자들은 이 결과를 공유한다.
    *
-   * @return 그룹이 API 서버에 존재하고 리소스가 하나 이상 병합되었으면 true
+   * @return CRD가 Established 상태로 존재하여 스냅샷에 병합되었으면 true
    */
-  private boolean refreshGroup(String group) {
-    log.info("Refreshing API resource discovery for missed group: group={}", group);
-    JsonNode groupNode = fetchJson("/apis/" + group);
-    if (groupNode == null) {
-      markGroupMissing(group);
-      return false;
+  private boolean lookupCustomResourceDefinition(String groupResource, String group,
+      String resource) {
+    log.info("Looking up CRD for missed group/resource: groupResource={}", groupResource);
+    JsonNode crd = fetchJson(
+        "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/" + resource + "." + group,
+        true);
+    if (crd == null) {
+      return markResourceMissing(groupResource, "CRD not found on API server");
     }
-    List<String> groupVersionNames = new ArrayList<>();
-    for (JsonNode version : groupNode.path("versions")) {
-      String groupVersion = version.path("groupVersion").textValue();
-      if (groupVersion != null) {
-        groupVersionNames.add(groupVersion);
-      }
+    if (!isCrdEstablished(crd)) {
+      return markResourceMissing(groupResource, "CRD not established");
     }
+
+    JsonNode names = crd.path("status").path("acceptedNames");
+    if (names.path("plural").textValue() == null) {
+      names = crd.path("spec").path("names");
+    }
+    String plural = names.path("plural").textValue();
+    String kind = names.path("kind").textValue();
+    if (plural == null || kind == null) {
+      return markResourceMissing(groupResource, "CRD names are incomplete");
+    }
+    boolean namespaced = "Namespaced".equals(crd.path("spec").path("scope").textValue());
 
     Map<String, String> plurals = new HashMap<>();
-    Map<String, Boolean> namespacedInfo = new HashMap<>();
-    Map<String, String> groupVersions = new HashMap<>();
-    Map<String, List<String>> kindEntries = new HashMap<>();
-    Set<String> groupResources = new HashSet<>();
-    for (String groupVersion : groupVersionNames) {
-      JsonNode resources = fetchJson("/apis/" + groupVersion);
-      if (resources == null) {
-        log.error("Targeted API group/version discovery failed: groupVersion={}", groupVersion);
+    String lastServedGroupVersion = null;
+    for (JsonNode version : crd.path("spec").path("versions")) {
+      if (!version.path("served").booleanValue()) {
         continue;
       }
-      for (JsonNode resource : resources.path("resources")) {
-        String name = resource.path("name").textValue();
-        if (name == null || name.contains("/")) {
-          continue;
-        }
-        String kind = resource.path("kind").textValue();
-        boolean namespaced = resource.path("namespaced").booleanValue();
-
-        String groupResource = group + "/" + name;
-        plurals.put(groupVersion + "/" + kind, name);
-        namespacedInfo.put(groupResource, namespaced);
-        groupVersions.put(groupResource, groupVersion);
-        groupResources.add(groupResource);
-        kindEntries.computeIfAbsent(kind, k -> new ArrayList<>()).add(groupResource);
+      String versionName = version.path("name").textValue();
+      if (versionName == null) {
+        continue;
       }
+      String groupVersion = group + "/" + versionName;
+      plurals.put(groupVersion + "/" + kind, plural);
+      lastServedGroupVersion = groupVersion;
     }
-    if (groupResources.isEmpty()) {
-      markGroupMissing(group);
-      return false;
+    if (lastServedGroupVersion == null) {
+      return markResourceMissing(groupResource, "CRD has no served versions");
     }
-    mergeSnapshot(plurals, namespacedInfo, groupVersions, kindEntries, groupResources);
-    this.refreshedGroupCooldowns.put(group, System.nanoTime() + GROUP_REFRESH_COOLDOWN_NANOS);
-    log.info("Targeted API discovery refresh complete: group={}, groupVersions={}, resources={}",
-        group, groupVersionNames.size(), groupResources.size());
+
+    String mergedGroupResource = group + "/" + plural;
+    mergeSnapshot(
+        plurals,
+        Map.of(mergedGroupResource, namespaced),
+        Map.of(mergedGroupResource, lastServedGroupVersion),
+        Map.of(kind, List.of(mergedGroupResource)),
+        Set.of(mergedGroupResource));
+    log.info("CRD lookup merged into snapshot: groupResource={}, servedVersions={}",
+        mergedGroupResource, plurals.size());
     return true;
   }
 
-  private void markGroupMissing(String group) {
-    this.negativeGroupCache.put(group, System.nanoTime() + NEGATIVE_CACHE_TTL_NANOS);
-    log.info("Group not found on API server, negative-cached: group={}, ttlMs={}",
-        group, TimeUnit.NANOSECONDS.toMillis(NEGATIVE_CACHE_TTL_NANOS));
+  private boolean isCrdEstablished(JsonNode crd) {
+    for (JsonNode condition : crd.path("status").path("conditions")) {
+      if ("Established".equals(condition.path("type").textValue())) {
+        return "True".equals(condition.path("status").textValue());
+      }
+    }
+    return false;
+  }
+
+  private boolean markResourceMissing(String groupResource, String reason) {
+    this.negativeGroupResourceCache.put(groupResource,
+        System.nanoTime() + NEGATIVE_CACHE_TTL_NANOS);
+    log.info("Group/resource judged missing, negative-cached: groupResource={}, reason={}, "
+        + "ttlMs={}", groupResource, reason,
+        TimeUnit.NANOSECONDS.toMillis(NEGATIVE_CACHE_TTL_NANOS));
+    return false;
   }
 
   /**
@@ -467,9 +471,9 @@ public class ApiResourceDiscovery {
     }
   }
 
-  /** Spring @Bean inferred destroy method — 컨텍스트 종료 시 targeted refresh executor 정리. */
+  /** Spring @Bean inferred destroy method — 컨텍스트 종료 시 CRD lookup executor 정리. */
   public void shutdown() {
-    this.targetedRefreshExecutor.shutdownNow();
+    this.resourceLookupExecutor.shutdownNow();
   }
 
   @Nullable
@@ -561,6 +565,11 @@ public class ApiResourceDiscovery {
 
   @Nullable
   private JsonNode fetchJson(String path) {
+    return fetchJson(path, false);
+  }
+
+  @Nullable
+  private JsonNode fetchJson(String path, boolean notFoundExpected) {
     try {
       Call call = this.apiClient.buildCall(
           this.apiClient.getBasePath(), path, "GET",
@@ -572,7 +581,11 @@ public class ApiResourceDiscovery {
         int code = response.code();
         if (!response.isSuccessful()) {
           String errorBody = response.body() != null ? response.body().string() : "";
-          log.error("API fetch failed: path={}, status={}, body={}", path, code, errorBody);
+          if (notFoundExpected && code == 404) {
+            log.debug("API fetch returned 404: path={}", path);
+          } else {
+            log.error("API fetch failed: path={}, status={}, body={}", path, code, errorBody);
+          }
           return null;
         }
         if (response.body() == null) {

--- a/src/test/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscoveryTest.java
+++ b/src/test/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscoveryTest.java
@@ -449,10 +449,11 @@ class ApiResourceDiscoveryTest {
       verifyNoBuildCall();
     }
 
-    // 그룹은 존재하지만 요청 리소스가 없음 → miss + 리소스 단위 negative cache.
-    // TTL 내 동일 groupResource 반복 미스가 그룹 재조회를 유발하지 않음.
+    // 그룹은 존재하지만 요청 리소스가 없음 → miss + 그룹 단위 쿨다운.
+    // 쿨다운 내에는 같은 그룹의 어떤 조합 미스도(처음 보는 조합 포함) 그룹 재조회를 다시 유발하지 않음.
+    // RBAC 룰의 그룹×리소스 크로스곱 조회가 없는 조합마다 그룹 재조회를 반복 트리거하던 문제의 검증.
     @Test
-    void existingGroup_missingResource_negativeCachedPerResource() throws Exception {
+    void existingGroup_missingResource_cooldownPreventsRepeatedGroupRefresh() throws Exception {
       mockApiCallRepeatable("/apis/qa.example.io", """
           {
             "kind": "APIGroup",
@@ -470,6 +471,11 @@ class ApiResourceDiscoveryTest {
 
       assertThat(discovery.isExist("qa.example.io/gadgets")).isFalse();
       assertThat(discovery.isExist("qa.example.io/gadgets")).isFalse();
+      // 처음 보는 다른 조합의 미스도 쿨다운 내에는 재조회 없이 즉시 miss
+      assertThat(discovery.isExist("qa.example.io/whatsits")).isFalse();
+      assertThat(discovery.isExist("qa.example.io/doohickeys")).isFalse();
+      assertThatThrownBy(() -> discovery.isNamespaced("qa.example.io/whatsits"))
+          .isInstanceOf(GroupResourceNotFoundException.class);
       // targeted refresh로 병합된 같은 그룹의 실제 리소스는 히트
       assertThat(discovery.isExist("qa.example.io/widgets")).isTrue();
 

--- a/src/test/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscoveryTest.java
+++ b/src/test/java/io/ten1010/aipub/projectcontroller/mutating/service/ApiResourceDiscoveryTest.java
@@ -311,32 +311,33 @@ class ApiResourceDiscoveryTest {
   @Nested
   class RefreshOnMiss {
 
-    // (a) 스냅샷 미스 → 해당 그룹만 targeted refresh → 히트.
+    // (a) 스냅샷 미스 → 해당 리소스의 CRD만 이름(<plural>.<group>)으로 단건 조회 → 히트.
     // CRD 생성 직후 5분 주기 전체 refresh 전에 들어온 웹훅 요청이 400 거부되던 문제의 재현/수정 검증.
     @Test
-    void missedGroup_targetedRefresh_thenHit() throws Exception {
-      mockApiCallRepeatable("/apis/qa-collision.ten1010.io", """
+    void missedResource_crdLookup_thenHit() throws Exception {
+      String crdPath = "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/"
+          + "qamultiversions.qa-collision.ten1010.io";
+      mockApiCallRepeatable(crdPath, """
           {
-            "kind": "APIGroup",
-            "name": "qa-collision.ten1010.io",
-            "versions": [
-              {"groupVersion": "qa-collision.ten1010.io/v1", "version": "v1"},
-              {"groupVersion": "qa-collision.ten1010.io/v2", "version": "v2"}
-            ]
-          }
-          """);
-      mockApiCallRepeatable("/apis/qa-collision.ten1010.io/v1", """
-          {
-            "resources": [
-              {"name": "qamultiversions", "kind": "QaMultiVersion", "namespaced": true}
-            ]
-          }
-          """);
-      mockApiCallRepeatable("/apis/qa-collision.ten1010.io/v2", """
-          {
-            "resources": [
-              {"name": "qamultiversions", "kind": "QaMultiVersion", "namespaced": true}
-            ]
+            "apiVersion": "apiextensions.k8s.io/v1",
+            "kind": "CustomResourceDefinition",
+            "metadata": {"name": "qamultiversions.qa-collision.ten1010.io"},
+            "spec": {
+              "group": "qa-collision.ten1010.io",
+              "names": {"plural": "qamultiversions", "kind": "QaMultiVersion"},
+              "scope": "Namespaced",
+              "versions": [
+                {"name": "v1", "served": true, "storage": false},
+                {"name": "v2", "served": true, "storage": true}
+              ]
+            },
+            "status": {
+              "acceptedNames": {"plural": "qamultiversions", "kind": "QaMultiVersion"},
+              "conditions": [
+                {"type": "NamesAccepted", "status": "True"},
+                {"type": "Established", "status": "True"}
+              ]
+            }
           }
           """);
 
@@ -344,59 +345,72 @@ class ApiResourceDiscoveryTest {
       assertThat(discovery.isNamespaced("qa-collision.ten1010.io/qamultiversions")).isTrue();
       assertThat(discovery.getGroupVersion("qa-collision.ten1010.io/qamultiversions"))
           .isEqualTo("qa-collision.ten1010.io/v2");
+      assertThat(discovery.getResourcesByKind("QaMultiVersion"))
+          .containsExactly(new ApiResourceDiscovery.ResourceInfo(
+              "qa-collision.ten1010.io/v2", "qamultiversions"));
       // 병합이 기존 스냅샷 항목을 덮어쓰지 않음
       assertThat(discovery.isExist("/pods")).isTrue();
       assertThat(discovery.isExist("apps/deployments")).isTrue();
       assertThat(discovery.getResourcesByKind("Deployment"))
           .containsExactly(new ApiResourceDiscovery.ResourceInfo("apps/v1", "deployments"));
-      // 첫 miss의 targeted refresh 이후에는 스냅샷 히트 → 그룹 재조회 없음
-      verifyBuildCallCount("/apis/qa-collision.ten1010.io", 1);
-      verifyBuildCallCount("/apis/qa-collision.ten1010.io/v1", 1);
-      verifyBuildCallCount("/apis/qa-collision.ten1010.io/v2", 1);
+      // 첫 miss의 CRD 단건 조회 이후에는 스냅샷 히트 → 재조회 없음. 그룹 디스커버리는 사용하지 않음.
+      verifyBuildCallCount(crdPath, 1);
+      verifyBuildCallCount("/apis/qa-collision.ten1010.io", 0);
+      verifyBuildCallCount("/apis/qa-collision.ten1010.io/v1", 0);
     }
 
-    // (b) API 서버에도 없는 그룹 → miss + 그룹 negative cache. TTL 내 동일 그룹 재조회 없음.
+    // (b) CRD가 존재하지 않는 조합 → miss + 조합 단위 negative cache. TTL 내 재조회 없음.
+    // RBAC 룰의 그룹×리소스 크로스곱처럼 없는 조합이 연달아 들어와도 조합당 단건 GET 1회가 전부.
     @Test
-    void missingGroup_negativeCached_noRepeatedApiCalls() throws Exception {
-      mockApiCallNotFound("/apis/ghost.example.io");
+    void missingCrd_negativeCached_noRepeatedApiCalls() throws Exception {
+      String thingsCrdPath = "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/"
+          + "things.ghost.example.io";
+      String othersCrdPath = "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/"
+          + "others.ghost.example.io";
+      mockApiCallNotFound(thingsCrdPath);
+      mockApiCallNotFound(othersCrdPath);
 
       assertThat(discovery.isExist("ghost.example.io/things")).isFalse();
-      // TTL 내 동일 그룹의 어떤 리소스든 API 호출 없이 즉시 miss
+      // TTL 내 동일 조합은 API 호출 없이 즉시 miss
       assertThat(discovery.isExist("ghost.example.io/things")).isFalse();
-      assertThat(discovery.isExist("ghost.example.io/others")).isFalse();
       assertThatThrownBy(() -> discovery.isNamespaced("ghost.example.io/things"))
           .isInstanceOf(GroupResourceNotFoundException.class);
+      // 다른 조합은 자기 CRD만 단건 조회. 그룹 디스커버리는 사용하지 않음.
+      assertThat(discovery.isExist("ghost.example.io/others")).isFalse();
 
-      verifyBuildCallCount("/apis/ghost.example.io", 1);
+      verifyBuildCallCount(thingsCrdPath, 1);
+      verifyBuildCallCount(othersCrdPath, 1);
+      verifyBuildCallCount("/apis/ghost.example.io", 0);
     }
 
-    // (c) 동일 그룹 동시 미스 → in-flight refresh 하나를 공유, API 호출 1회
+    // (c) 동일 조합 동시 미스 → in-flight 조회 하나를 공유, API 호출 1회
     @Test
-    void concurrentMisses_shareSingleInFlightRefresh() throws Exception {
+    void concurrentMisses_shareSingleInFlightLookup() throws Exception {
+      String crdPath = "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/"
+          + "newthings.newgroup.example.io";
       CountDownLatch releaseLatch = new CountDownLatch(1);
-      Call groupCall = mock(Call.class);
-      when(groupCall.execute()).thenAnswer(invocation -> {
+      Call crdCall = mock(Call.class);
+      when(crdCall.execute()).thenAnswer(invocation -> {
         // 두 스레드 모두 in-flight future 대기에 진입할 때까지 응답을 지연
         releaseLatch.await(5, TimeUnit.SECONDS);
-        return buildJsonResponse("/apis/newgroup.example.io", 200, """
+        return buildJsonResponse(crdPath, 200, """
             {
-              "kind": "APIGroup",
-              "name": "newgroup.example.io",
-              "versions": [{"groupVersion": "newgroup.example.io/v1", "version": "v1"}]
+              "spec": {
+                "group": "newgroup.example.io",
+                "names": {"plural": "newthings", "kind": "NewThing"},
+                "scope": "Namespaced",
+                "versions": [{"name": "v1", "served": true, "storage": true}]
+              },
+              "status": {
+                "acceptedNames": {"plural": "newthings", "kind": "NewThing"},
+                "conditions": [{"type": "Established", "status": "True"}]
+              }
             }
             """);
       });
       when(mockApiClient.buildCall(
-          any(), eq("/apis/newgroup.example.io"), any(), any(), any(), any(), any(), any(), any(),
-          any(), any()))
-          .thenReturn(groupCall);
-      mockApiCallRepeatable("/apis/newgroup.example.io/v1", """
-          {
-            "resources": [
-              {"name": "newthings", "kind": "NewThing", "namespaced": true}
-            ]
-          }
-          """);
+          any(), eq(crdPath), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+          .thenReturn(crdCall);
 
       ExecutorService pool = Executors.newFixedThreadPool(2);
       try {
@@ -418,8 +432,7 @@ class ApiResourceDiscoveryTest {
         pool.shutdownNow();
       }
 
-      verifyBuildCallCount("/apis/newgroup.example.io", 1);
-      verifyBuildCallCount("/apis/newgroup.example.io/v1", 1);
+      verifyBuildCallCount(crdPath, 1);
     }
 
     // (d) 기존 히트 경로는 API 호출 없음
@@ -449,38 +462,32 @@ class ApiResourceDiscoveryTest {
       verifyNoBuildCall();
     }
 
-    // 그룹은 존재하지만 요청 리소스가 없음 → miss + 그룹 단위 쿨다운.
-    // 쿨다운 내에는 같은 그룹의 어떤 조합 미스도(처음 보는 조합 포함) 그룹 재조회를 다시 유발하지 않음.
-    // RBAC 룰의 그룹×리소스 크로스곱 조회가 없는 조합마다 그룹 재조회를 반복 트리거하던 문제의 검증.
+    // Established 전의 CRD는 miss로 판정하고 negative cache. TTL 내 재조회 없음.
     @Test
-    void existingGroup_missingResource_cooldownPreventsRepeatedGroupRefresh() throws Exception {
-      mockApiCallRepeatable("/apis/qa.example.io", """
+    void crdNotEstablished_judgedMissing() throws Exception {
+      String crdPath = "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/"
+          + "pendings.qa.example.io";
+      mockApiCallRepeatable(crdPath, """
           {
-            "kind": "APIGroup",
-            "name": "qa.example.io",
-            "versions": [{"groupVersion": "qa.example.io/v1", "version": "v1"}]
-          }
-          """);
-      mockApiCallRepeatable("/apis/qa.example.io/v1", """
-          {
-            "resources": [
-              {"name": "widgets", "kind": "Widget", "namespaced": true}
-            ]
+            "spec": {
+              "group": "qa.example.io",
+              "names": {"plural": "pendings", "kind": "Pending"},
+              "scope": "Namespaced",
+              "versions": [{"name": "v1", "served": true, "storage": true}]
+            },
+            "status": {
+              "acceptedNames": {},
+              "conditions": [{"type": "Established", "status": "False"}]
+            }
           }
           """);
 
-      assertThat(discovery.isExist("qa.example.io/gadgets")).isFalse();
-      assertThat(discovery.isExist("qa.example.io/gadgets")).isFalse();
-      // 처음 보는 다른 조합의 미스도 쿨다운 내에는 재조회 없이 즉시 miss
-      assertThat(discovery.isExist("qa.example.io/whatsits")).isFalse();
-      assertThat(discovery.isExist("qa.example.io/doohickeys")).isFalse();
-      assertThatThrownBy(() -> discovery.isNamespaced("qa.example.io/whatsits"))
+      assertThat(discovery.isExist("qa.example.io/pendings")).isFalse();
+      assertThat(discovery.isExist("qa.example.io/pendings")).isFalse();
+      assertThatThrownBy(() -> discovery.isNamespaced("qa.example.io/pendings"))
           .isInstanceOf(GroupResourceNotFoundException.class);
-      // targeted refresh로 병합된 같은 그룹의 실제 리소스는 히트
-      assertThat(discovery.isExist("qa.example.io/widgets")).isTrue();
 
-      verifyBuildCallCount("/apis/qa.example.io", 1);
-      verifyBuildCallCount("/apis/qa.example.io/v1", 1);
+      verifyBuildCallCount(crdPath, 1);
     }
 
     private void mockApiCallRepeatable(String path, String responseBody) throws Exception {


### PR DESCRIPTION
## Summary
Follow-up to #95. In production, a single UserAuthorityReview request fired dozens of identical targeted group refreshes back to back:

```
16:47:21,917 Refreshing API resource discovery for missed group: group=qa.ten1010.io
16:47:21,921 Group refreshed but resource not found, negative-cached: groupResource=qa.ten1010.io/serviceexposures
16:47:21,921 Refreshing API resource discovery for missed group: group=qa.ten1010.io
16:47:21,925 Group refreshed but resource not found, negative-cached: groupResource=qa.ten1010.io/vmalerts
...
```

The RBAC authority computation probes the `apiGroups × resources` cross product of every rule via `isExist()`, and most combinations do not exist. With #95's design, every first-seen nonexistent combination re-triggered a live re-discovery of the whole group.

## Changes
On a snapshot miss, instead of re-discovering the entire group (`GET /apis/<group>` + every version), the controller now fetches **only the missed resource** with a single-object GET of the CRD named `<plural>.<group>`:

```
GET /apis/apiextensions.k8s.io/v1/customresourcedefinitions/<resource>.<group>
```

- Each miss costs at most one cheap single-object lookup, scoped to exactly the requested group/resource — the RBAC cross product cannot amplify into repeated group discovery.
- Combination-level negative caching (15s TTL) is now precise: a miss suppresses only lookups of that same combination, and each nonexistent combination is probed at most once per TTL.
- A CRD is merged into the snapshot only when `Established`, using `status.acceptedNames` and its served versions (multi-version CRDs supported). Not-yet-established CRDs are judged missing and negative-cached.
- In-flight sharing is now keyed per combination; the 2s bounded wait, copy-on-write snapshot merge, and clearing of caches on the periodic full refresh are unchanged.
- Expected 404s from CRD lookups are logged at DEBUG, not ERROR.
- Trade-off: non-CRD (aggregated API) resources are not discoverable through this path; they converge via the periodic 5-minute full refresh, same as before their initial discovery. The controller's ClusterRole (`*/*/*`) already permits CRD reads — no RBAC change.

## Test plan
- [x] `./gradlew build` passes
- [x] `./gradlew test` passes (111 tests, 0 failures)
- [x] Miss → single CRD GET → hit, multi-version merge, no group discovery calls
- [x] Nonexistent combinations: one GET each, negative-cached within TTL, no group discovery
- [x] Concurrent misses on the same combination share one in-flight lookup (1 API call)
- [x] Not-yet-established CRD is judged missing and negative-cached
- [x] Hit path and core/malformed inputs make no API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)