### PR TITLE
fix: intercept events created through the events.k8s.io API group

### DIFF
--- a/kubernetes/controller/project-controller/templates/mutating-webhook-user-v2.yaml
+++ b/kubernetes/controller/project-controller/templates/mutating-webhook-user-v2.yaml
@@ -47,6 +47,12 @@ webhooks:
         operations: [ "CREATE" ]
         resources: [ "pods", "replicationcontrollers", "services", "configmaps", "secrets", "persistentvolumeclaims", "serviceaccounts", "limitranges", "endpoints", "events" ]
         scope: "Namespaced"
+      # Event 는 core("") 와 events.k8s.io 두 API 로 생성될 수 있으므로 둘 다 인터셉트한다
+      - apiGroups: [ "events.k8s.io" ]
+        apiVersions: [ "*" ]
+        operations: [ "CREATE" ]
+        resources: [ "events" ]
+        scope: "Namespaced"
       - apiGroups: [ "networking.k8s.io" ]
         apiVersions: [ "*" ]
         operations: [ "CREATE" ]


### PR DESCRIPTION
## Summary

Event 는 core(`v1`)와 `events.k8s.io/v1` 두 API 로 생성될 수 있는데 낙인 웹훅 rules 가 core 그룹만 매칭하고 있어, `events.k8s.io` 경로로 생성된 멤버 이벤트에 소유자 레이블이 찍히지 않았습니다. `events.k8s.io` rule 을 추가합니다. installer 쪽 동일 변경: ten1010-io/aipub-installer#191

## 검증

- 웹훅 핸들러는 AdmissionReview 직접 호출로 Event 낙인(ownerReference + username/userid) 정상 확인
- 16종 전수 E2E (kind): 개인 Role 16/16 반영, 소유자 update/patch/delete 전부 yes, 비소유자 전부 no

🤖 Generated with [Claude Code](https://claude.com/claude-code)