### PR TITLE
fix: exclude events from user-label webhook interception

### DIFF
--- a/kubernetes/controller/project-controller/templates/mutating-webhook-user-v2.yaml
+++ b/kubernetes/controller/project-controller/templates/mutating-webhook-user-v2.yaml
@@ -38,14 +38,16 @@ webhooks:
     reinvocationPolicy: IfNeeded
     # 소유권 대상 타입(OwnershipPolicy.OWNED_TARGETS)의 CREATE 를 인터셉트해 소유자 레이블을 찍는다.
     # 멤버가 직접 만든 오브젝트가 레이블 없이 남으면 본인도 수정/삭제할 수 없게 되므로
-    # 멤버 Role 이 create 를 허용하는 타입(events/endpoints 포함)은 모두 인터셉트한다.
+    # 멤버 Role 이 create 를 허용하는 타입은 인터셉트한다. 단 events 는 시스템 컴포넌트가
+    # 고빈도로 생성하므로 제외한다(모든 이벤트 생성이 웹훅을 경유하는 부하·fail-closed 리스크 회피).
     # 시스템 컴포넌트가 만드는 오브젝트는 비멤버라 무변경 통과된다.
-    # OwnershipPolicy 목록을 바꿀 때는 이 rules 도 함께 확인할 것.
+    # OwnershipPolicy 목록을 바꿀 때는 이 rules 와 aipub-installer 의 helm 차트
+    # (mutating-webhook.yaml)도 함께 갱신할 것.
     rules:
       - apiGroups: [ "" ]
         apiVersions: [ "*" ]
         operations: [ "CREATE" ]
-        resources: [ "pods", "replicationcontrollers", "services", "configmaps", "secrets", "persistentvolumeclaims", "serviceaccounts", "limitranges", "endpoints", "events" ]
+        resources: [ "pods", "replicationcontrollers", "services", "configmaps", "secrets", "persistentvolumeclaims", "serviceaccounts", "limitranges", "endpoints" ]
         scope: "Namespaced"
       - apiGroups: [ "networking.k8s.io" ]
         apiVersions: [ "*" ]

--- a/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/OwnershipPolicy.java
+++ b/src/main/java/io/ten1010/aipub/projectcontroller/domain/k8s/OwnershipPolicy.java
@@ -25,11 +25,13 @@ public final class OwnershipPolicy {
   /**
    * 소유권 추적 대상 네이티브 네임스페이스 리소스 16종 (고정 목록).
    * 소유자 레이블(aipub.ten1010.io/username)이 있는 오브젝트만 추적되며,
-   * 레이블은 낙인 웹훅(mutating-webhook-user-v2.yaml 의 rules)이 16종 전부의 CREATE 를
-   * 인터셉트해 찍는다 — 멤버가 만든 오브젝트가 레이블 없이 남으면 본인도 수정/삭제할 수
-   * 없게 되기 때문이다. 목록을 바꿀 때는 웹훅 rules 도 함께 갱신할 것.
-   * 시스템 컴포넌트가 만드는 오브젝트(events/endpoints 대부분)는 비멤버 생성이라
-   * 레이블 없이 통과되며 소유권 추적 대상이 아니다.
+   * 레이블은 낙인 웹훅(mutating-webhook-user-v2.yaml 의 rules)이 CREATE 를 인터셉트해
+   * 찍는다 — 멤버가 만든 오브젝트가 레이블 없이 남으면 본인도 수정/삭제할 수 없게
+   * 되기 때문이다. 목록을 바꿀 때는 웹훅 rules(이 저장소 + aipub-installer helm 차트)도
+   * 함께 갱신할 것.
+   * 예외: events 는 시스템 컴포넌트가 고빈도로 생성하므로 웹훅이 인터셉트하지 않는다
+   * — 수동으로 레이블이 부여된 경우에만 소유로 취급된다. 시스템 컴포넌트가 만드는
+   * 오브젝트는 비멤버 생성이라 레이블 없이 통과되며 소유권 추적 대상이 아니다.
    */
   public static final List<ResourceTarget> OWNED_TARGETS = List.of(
       new ResourceTarget("", "v1", "pods"),


### PR DESCRIPTION
## Summary

events 를 낙인 웹훅 인터셉트 대상에서 제외합니다 (installer 동일 결정: ten1010-io/aipub-installer#191).

- 이벤트는 시스템 컴포넌트가 파드 lifecycle 마다 고빈도 생성 → 전량 웹훅 경유는 부하·fail-closed 리스크만 증가
- 멤버가 이벤트를 직접 생성하는 실사용이 없어 낙인 실익 없음
- `OwnershipPolicy.OWNED_TARGETS` 에는 유지 — 수동 레이블 부여 시 소유권은 여전히 동작
- 결과: 멤버 생성 이벤트에 레이블이 안 붙는 것은 의도된 동작 (이벤트의 소유자 표시가 필요하면 UI 가 `involvedObject` 를 따라가 대상 워크로드의 소유자를 표시)

## 검증

- 유닛 105개 통과
- 웹훅 rules: 이 저장소 매니페스트와 installer helm 차트 동일 상태로 정렬 (core 9종 + apps 4 + networking/autoscaling/policy, events 제외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 16종 커버리지 (기계 대조 검증됨)

| # | 타입 | Role 부여 (OWNED_TARGETS) | 웹훅 낙인 (rules) |
|---|---|---|---|
| 1 | pods | ✅ | ✅ |
| 2 | configmaps | ✅ | ✅ |
| 3 | secrets | ✅ | ✅ |
| 4 | services | ✅ | ✅ |
| 5 | endpoints | ✅ | ✅ |
| 6 | serviceaccounts | ✅ | ✅ |
| 7 | **events** | ✅ (수동 레이블 시) | **❌ 명시적 제외** |
| 8 | persistentvolumeclaims | ✅ | ✅ |
| 9 | limitranges | ✅ | ✅ |
| 10 | deployments | ✅ | ✅ (apps/*) |
| 11 | replicasets | ✅ | ✅ (apps/*) |
| 12 | statefulsets | ✅ | ✅ (apps/*) |
| 13 | daemonsets | ✅ | ✅ (apps/*) |
| 14 | horizontalpodautoscalers | ✅ | ✅ |
| 15 | poddisruptionbudgets | ✅ | ✅ |
| 16 | ingresses | ✅ | ✅ |

**events 만 유일하게 웹훅 인터셉트에서 명시적으로 제외**되었습니다 — 시스템 컴포넌트가 파드 lifecycle 마다 고빈도로 생성하는 리소스라 전량 웹훅 경유는 부하·fail-closed 리스크만 키우고, 멤버가 직접 생성하는 실사용이 없기 때문입니다. 그 결과 이벤트에는 소유자 레이블이 자동으로 붙지 않으며(의도된 동작), Role 부여 대상(OWNED_TARGETS)에는 유지되므로 수동으로 레이블을 부여한 이벤트는 여전히 소유권이 동작합니다.

이 표는 project-controller 매니페스트와 aipub-installer helm 차트 양쪽에서 스크립트로 대조 검증되었으며, 두 원본의 rules 는 동일합니다.
